### PR TITLE
Add Opus 4.6, Opus 4.5, Sonnet 4.6, Haiku 4.5, remove Haiku3.5

### DIFF
--- a/configs/base.yml
+++ b/configs/base.yml
@@ -290,7 +290,7 @@ providers:
       "claude-opus-4-5":
         enabled: true
         aliases: [
-          "claude-opus-4.5-20251101",
+          "claude-opus-4-5-20251101",
           "claude-opus-4.5",
         ]
         limits:
@@ -409,10 +409,9 @@ providers:
         pricing:
           input: 3.00
           output: 15.00
-      "claude-4-5-haiku":
+      "claude-haiku-4-5":
         enabled: true
         aliases: [
-            "claude-4.5-haiku",
             "claude-haiku-4.5",
             "claude-haiku-4-5-20251001"
           ]

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -274,6 +274,35 @@ providers:
       burst_requests: 100
 
     models:
+      "claude-opus-4-6":
+        enabled: true
+        aliases: ["claude-opus-4.6"]
+        limits:
+          tokens_per_minute: 40_000
+          requests_per_minute: 1_000
+          tokens_per_day: 960_000
+          requests_per_day: 1_440_000
+          burst_tokens: 4_000
+          burst_requests: 100
+        pricing:
+          input: 5.00
+          output: 25.00
+      "claude-opus-4-5":
+        enabled: true
+        aliases: [
+          "claude-opus-4.5-20251101",
+          "claude-opus-4.5",
+        ]
+        limits:
+          tokens_per_minute: 40_000
+          requests_per_minute: 1_000
+          tokens_per_day: 960_000
+          requests_per_day: 1_440_000
+          burst_tokens: 4_000
+          burst_requests: 100
+        pricing:
+          input: 5.00
+          output: 25.00
       "claude-opus-4-0":
         enabled: true
         aliases: ["claude-opus-4", "claude-opus-4-20250514"]
@@ -301,6 +330,19 @@ providers:
           input: 3.00
           output: 15.00
 
+      "claude-sonnet-4-6":
+        enabled: true
+        aliases: ["claude-sonnet-4.6"]
+        limits:
+          tokens_per_minute: 80_000
+          requests_per_minute: 1_000
+          tokens_per_day: 1_920_000
+          requests_per_day: 1_440_000
+          burst_tokens: 8_000
+          burst_requests: 100
+        pricing:
+          input: 3.00
+          output: 15.00
       "claude-sonnet-4-5":
         enabled: true
         aliases: ["claude-sonnet-4-5-20250929", "claude-sonnet-4.5"]
@@ -367,14 +409,12 @@ providers:
         pricing:
           input: 3.00
           output: 15.00
-      "claude-3-5-haiku":
+      "claude-4-5-haiku":
         enabled: true
-        aliases:
-          [
-            "claude-3-5-haiku-latest",
-            "claude-3.5-haiku",
-            "claude-haiku-3.5",
-            "claude-3-5-haiku-20241022",
+        aliases: [
+            "claude-4.5-haiku",
+            "claude-haiku-4.5",
+            "claude-haiku-4-5-20251001"
           ]
         limits:
           tokens_per_minute: 100_000
@@ -384,8 +424,8 @@ providers:
           burst_tokens: 10_000
           burst_requests: 100
         pricing:
-          input: 0.80
-          output: 4.00
+          input: 1.00
+          output: 5.00
       "claude-3-haiku-20240307":
         enabled: true
         aliases: ["claude-3-haiku", "claude-haiku"]

--- a/internal/providers/anthropic_integration_test.go
+++ b/internal/providers/anthropic_integration_test.go
@@ -26,14 +26,20 @@ type anthropicTestModel struct {
 // Test models to use in parameterized tests
 var anthropicTestModels = []anthropicTestModel{
 	{
-		name:       "Claude-3.5-Haiku",
-		modelID:    "claude-3-5-haiku-latest",
+		name:       "Claude-4.6-Opus",
+		modelID:    "claude-opus-4-6",
 		maxTokens:  50,
 		testPrompt: "What is 2+2?",
 	},
 	{
-		name:       "Claude-3.5-Sonnet",
-		modelID:    "claude-3-5-sonnet-latest",
+		name:       "Claude-4.5-Haiku",
+		modelID:    "claude-haiku-4-5",
+		maxTokens:  50,
+		testPrompt: "What is 2+2?",
+	},
+	{
+		name:       "Claude-Sonnet-4-6",
+		modelID:    "claude-sonnet-4-6",
 		maxTokens:  100,
 		testPrompt: "Hello! Can you tell me a short joke?",
 	},
@@ -51,8 +57,6 @@ func TestAnthropicIntegration_Models(t *testing.T) {
 
 	// Run model tests in parallel
 	for _, model := range anthropicTestModels {
-		model := model // capture range variable
-
 		t.Run(model.name, func(t *testing.T) {
 			// Test both streaming and non-streaming in parallel
 			t.Run("NonStreaming", func(t *testing.T) {

--- a/internal/providers/anthropic_integration_test.go
+++ b/internal/providers/anthropic_integration_test.go
@@ -26,19 +26,19 @@ type anthropicTestModel struct {
 // Test models to use in parameterized tests
 var anthropicTestModels = []anthropicTestModel{
 	{
-		name:       "Claude-4.6-Opus",
+		name:       "Claude-Opus-4.6",
 		modelID:    "claude-opus-4-6",
 		maxTokens:  50,
 		testPrompt: "What is 2+2?",
 	},
 	{
-		name:       "Claude-4.5-Haiku",
+		name:       "Claude-Haiku-4.5",
 		modelID:    "claude-haiku-4-5",
 		maxTokens:  50,
 		testPrompt: "What is 2+2?",
 	},
 	{
-		name:       "Claude-Sonnet-4-6",
+		name:       "Claude-Sonnet-4.6",
 		modelID:    "claude-sonnet-4-6",
 		maxTokens:  100,
 		testPrompt: "Hello! Can you tell me a short joke?",


### PR DESCRIPTION
This fixes `make test-anthropic`, which was failing due to haiku 3.5 retirement.

Decided to add opus to the integration test too for better coverage. It's 3x cheaper now since this test was created, I think we can afford to run it :) rather that than failures going unnoticed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 4-6, Claude Opus 4-5, and Claude Sonnet 4-6 models with complete configuration including usage limits and pricing.

* **Updates**
  * Replaced Claude 3.5 Haiku with Claude Haiku 4-5, featuring updated pricing and new model aliases for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->