### PR TITLE
feat(circuit): provider circuit breaker with degraded signal for client-side fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A simple, Go-based alternative to the `litellm` proxy, without all the extra stu
 - **Health Check**: Detailed health status for all providers
 - **Configurable Port**: Environment variable configuration (default: 9002)
 - **Rate Limiting (experimental)**: Optional request/token-based limits per user/API key/model/provider
+- **Circuit Breaker**: Opt-in provider health tracking that classifies upstream failures, retries transient / rate-limit errors, and emits a dedicated degraded-signal response so clients can fall back to another provider during an outage
 
 ## Quick Start
 
@@ -150,11 +151,82 @@ features:
 - Non-text modalities (images/videos) are not supported for estimation at this time and will fall back to credit-based only behavior essentially via `max_sample_bytes`.
 - Optimistic first request: to avoid estimation blocking initial traffic, the first token-bearing request in a window (when current token count is zero) is allowed even if token limits would otherwise apply. Subsequent requests are enforced normally.
 
+### Circuit Breaker & Provider Degradation
+
+Disabled by default. Enable it when you want the proxy to detect provider outages (as opposed to individual request failures) and broadcast that state to clients so they can switch to a fallback provider instead of retry-storming a dead upstream.
+
+#### What it does
+
+- **Classifies every upstream failure** as one of: local rate-limit, global rate-limit, or provider-degraded. Provider-specific rules — e.g. Anthropic `529 Overloaded` → degraded, Gemini `429 RESOURCE_EXHAUSTED` → local rate-limit, OpenAI 429 with both `x-ratelimit-remaining-requests` and `x-ratelimit-remaining-tokens` at zero → global rate-limit.
+- **Retries transient failures** with jittered exponential backoff (configurable attempts). Rate-limit retries honour `Retry-After`. Sustained global rate limits escalate to degraded after a configurable window.
+- **Opens the circuit** once a provider accumulates enough terminal failures inside a sliding window. While open, every request is fast-failed locally without touching the network. After a cooldown the proxy issues one half-open probe; success closes the circuit, failure re-opens it for another cooldown.
+- **Surfaces state** on `GET /health` per provider: `circuit_state` (`closed` / `open` / `half_open`), `circuit_failures`, `circuit_cooldown_until`.
+
+#### The degraded signal
+
+When a provider is degraded (terminal retry exhaustion, open-circuit fast-fail, or half-open probe failure), the proxy returns a synthetic response:
+
+- **HTTP 503** status
+- **`X-Llm-Proxy-Error-Class: provider_degraded`** response header
+- **JSON body** containing a configurable marker substring — `[LLM_PROXY_PROVIDER_DEGRADED]` by default:
+
+  ```json
+  {"error":{"message":"[LLM_PROXY_PROVIDER_DEGRADED] Provider openai is currently degraded or unavailable. Please try again later.","type":"provider_degraded","code":"provider_degraded"}}
+  ```
+
+Clients detect the degraded condition by looking for that substring anywhere in `str(exception)` (or the response body) and can then fall back to a different provider / model.
+
+#### Why a body marker and not just a status code?
+
+The 503 status and `X-Llm-Proxy-Error-Class` header are always set, but on their own they are not enough:
+
+1. **5xx is ambiguous.** The proxy streams real provider 5xx responses straight through (Anthropic 529, OpenAI 500/502/503/504, Gemini 500/503, …). A client that only looks at status code cannot tell a passthrough upstream 503 from a proxy-synthesised "circuit open" 503 — they have very different retry / fallback semantics.
+2. **4xx is wrong.** The caller did nothing wrong; the upstream is degraded. 4xx would break SDK retry logic that (correctly) refuses to retry 4xx.
+3. **A novel status code (e.g. 599) is hostile.** Many reverse proxies, CDNs, and HTTP clients coerce unknown codes to 500 or strip them entirely. The OpenAI / Anthropic / Google SDKs all map any ≥500 response into a generic `APIError` / `ServerError` class, so a custom code buys you nothing downstream.
+4. **Custom headers get stripped by SDK exception wrappers.** By the time an HTTPS error propagates up through e.g. the OpenAI Python SDK or LangChain, the caller typically only sees `str(exception)` (the body). Response headers are usually only accessible if the caller catches a specific, provider-native exception type *before* any framework wraps it. A body substring survives every wrapping layer.
+
+So the contract is **503 + header + body marker, and clients can key off any of them**. The body marker is the most reliable because exception message text is the lowest common denominator across every SDK stack.
+
+#### Configuration
+
+Config lives under `features.circuit_breaker` in YAML. All values shown below are defaults:
+
+```yaml
+features:
+  circuit_breaker:
+    enabled: true                       # gate the whole feature
+    backend: "memory"                   # "memory" (single instance) or "redis" (multi-instance)
+    failure_threshold: 5                # terminal failures in the window that trip the circuit
+    window_seconds: 120                 # sliding-window TTL for the failure counter
+    cooldown_seconds: 300               # how long the circuit stays open before a probe
+    max_transient_retries: 2            # retries for degraded-class failures
+    max_rate_limit_retries: 2           # retries for rate-limit failures
+    retry_contribution_mode: "log"      # "off" | "log" | "on" — whether retried failures count
+    global_rate_limit_escalation_window: 60  # seconds of sustained global 429s → degraded
+    degraded_signal: ""                 # override the body marker; empty → "[LLM_PROXY_PROVIDER_DEGRADED]"
+    test_mode_enabled: false            # prod: leave off.  Enables X-LLM-Proxy-Test-Mode header.
+    # redis:                            # required when backend == "redis"
+    #   address: "localhost:6379"
+    #   password: ""
+    #   db: 0
+```
+
+The `degraded_signal` field lets you embed a project- or company-specific tag in the response body (e.g. `"[MY_COMPANY_UPSTREAM_DOWN]"`). Clients then pattern-match on that tag instead of the default. Leaving it empty keeps the default, which is the right choice for most deployments.
+
+#### Testing the circuit breaker without touching real providers
+
+When `test_mode_enabled: true`, the proxy honours an `X-LLM-Proxy-Test-Mode` request header (or `llm_proxy_test_mode` query parameter, for SDKs like the Google Gemini client that don't let you pass custom headers):
+
+- `force_degraded` — return the synthesised 503 / degraded body immediately, as if the circuit were open.
+- `force_transient_recover` — fail the first attempt with a degraded error and succeed on the retry, so you can exercise the retry loop without the circuit tripping.
+
+This is intended strictly for integration tests — leave `test_mode_enabled` off in production.
+
 ## API Endpoints
 
 ### General
 
-- `GET /health` - Health check endpoint for all providers
+- `GET /health` - Health check endpoint for all providers. When the circuit breaker is enabled the response also includes `circuit_state`, `circuit_failures`, and `circuit_cooldown_until` per provider.
 
 ### OpenAI
 

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -364,6 +364,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 func circuitConfigFromYAML(cb config.CircuitBreakerConfig) circuit.Config {
 	cfg := circuit.Config{
 		Enabled:                         cb.Enabled,
+		Mode:                            cb.Mode,
 		Backend:                         cb.Backend,
 		FailureThreshold:                cb.FailureThreshold,
 		WindowSeconds:                   cb.WindowSeconds,
@@ -375,14 +376,31 @@ func circuitConfigFromYAML(cb config.CircuitBreakerConfig) circuit.Config {
 		DegradedSignal:                  cb.DegradedSignal,
 	}
 	if cb.Redis != nil {
-		cfg.RedisAddress = cb.Redis.Address
-		cfg.RedisPassword = cb.Redis.Password
+		// Expand ${VAR} / $VAR tokens from the process environment so we
+		// can thread secrets (e.g. Finch's ML_CACHE_URL SSM parameter
+		// rendered into REDIS_URL by ECS) through without baking them
+		// into the YAML or requiring a separate secrets flavour.  Values
+		// without any `$` pass through unchanged.
+		cfg.RedisURL = os.ExpandEnv(cb.Redis.URL)
+		cfg.RedisAddress = os.ExpandEnv(cb.Redis.Address)
+		cfg.RedisPassword = os.ExpandEnv(cb.Redis.Password)
 		cfg.RedisDB = cb.Redis.DB
 	}
 	return cfg.Defaults()
 }
 
 // initializeCircuitStore creates the circuit breaker state store from config.
+//
+// Redis failures are intentionally non-fatal:
+//   - If NewRedisStore itself errors (e.g. malformed URL), we log and fall
+//     back to a MemoryStore so the proxy still comes up.
+//   - If NewRedisStore succeeds but the cluster is unreachable at boot, the
+//     short-timeout PING warns the operator but we keep the Redis-backed
+//     store anyway — steady-state Store operations already fail-open to
+//     StateClosed on Redis errors, so transient outages self-heal.
+//
+// Net effect: a Redis outage degrades the circuit breaker to "per-instance
+// best effort" without ever taking the sidecar down.
 func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 	cb := yamlConfig.Features.CircuitBreaker
 	if !cb.Enabled {
@@ -394,12 +412,32 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 
 	store, err := circuit.Factory(cfg)
 	if err != nil {
-		logger.Error("⚡ Circuit Breaker: failed to create store", "error", err)
-		return nil
+		if cfg.Backend == "redis" {
+			logger.Error("⚡ Circuit Breaker: Redis store construction failed — falling back to memory store",
+				"error", err,
+			)
+			store = circuit.NewMemoryStore(cfg)
+		} else {
+			logger.Error("⚡ Circuit Breaker: failed to create store", "error", err)
+			return nil
+		}
+	}
+
+	if rs, ok := store.(*circuit.RedisStore); ok {
+		pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if pingErr := rs.Ping(pingCtx); pingErr != nil {
+			logger.Warn("⚡ Circuit Breaker: Redis PING failed at startup — proxy will continue (store fails open on Redis errors)",
+				"error", pingErr,
+			)
+		} else {
+			logger.Info("⚡ Circuit Breaker: Redis reachable")
+		}
+		cancel()
 	}
 
 	logger.Info("⚡ Circuit Breaker: initialized",
 		"backend", cfg.Backend,
+		"mode", cfg.Mode,
 		"failure_threshold", cfg.FailureThreshold,
 		"window_seconds", cfg.WindowSeconds,
 		"cooldown_seconds", cfg.CooldownSeconds,

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -372,6 +372,7 @@ func circuitConfigFromYAML(cb config.CircuitBreakerConfig) circuit.Config {
 		MaxRateLimitRetries:             cb.MaxRateLimitRetries,
 		RetryContributionMode:           cb.RetryContributionMode,
 		GlobalRateLimitEscalationWindow: cb.GlobalRateLimitEscalationWindow,
+		DegradedSignal:                  cb.DegradedSignal,
 	}
 	if cb.Redis != nil {
 		cfg.RedisAddress = cb.Redis.Address
@@ -405,6 +406,7 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 		"max_transient_retries", cfg.MaxTransientRetries,
 		"max_rate_limit_retries", cfg.MaxRateLimitRetries,
 		"retry_contribution_mode", cfg.RetryContributionMode,
+		"degraded_signal", cfg.DegradedSignal,
 	)
 	return store
 }
@@ -634,7 +636,8 @@ func runServer(yamlConfig *config.YAMLConfig) {
 
 	// Add test-mode middleware when enabled (integration tests only).
 	if yamlConfig.Features.CircuitBreaker.TestModeEnabled {
-		r.Use(middleware.TestModeMiddleware)
+		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker)
+		r.Use(middleware.NewTestModeMiddleware(cbCfg.DegradedSignal))
 		logger.Info("⚡ Circuit Breaker: test-mode middleware ENABLED (not for production)")
 	}
 

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -442,12 +442,10 @@ func circuitConfigFromYAML(cb config.CircuitBreakerConfig, testModeAllowed bool)
 // initializeCircuitStore creates the circuit breaker state store from config.
 //
 // Redis failures are intentionally non-fatal:
-//   - If NewRedisStore itself errors (e.g. malformed URL), we log and fall
-//     back to a MemoryStore so the proxy still comes up.
-//   - If NewRedisStore succeeds but the cluster is unreachable at boot, the
-//     short-timeout PING warns the operator but we keep the Redis-backed
-//     store anyway — steady-state Store operations already fail-open to
-//     StateClosed on Redis errors, so transient outages self-heal.
+//   - If NewRedisStore itself errors (e.g. malformed URL or failed PING), we
+//     log and fall back to a MemoryStore so the proxy still comes up.
+//   - If the Redis-backed store later encounters Redis errors, steady-state
+//     Store operations fail-open to StateClosed so transient outages self-heal.
 //
 // Net effect: a Redis outage degrades the circuit breaker to "per-instance
 // best effort" without ever taking the sidecar down.
@@ -460,22 +458,18 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 
 	cfg := circuitConfigFromYAML(cb, isTestModeAllowed(yamlConfig))
 	if err := cfg.Validate(); err != nil {
-		logger.Error("⚡ Circuit Breaker: invalid configuration — feature disabled", "error", err)
-		return nil
+		logger.Error("⚡ Circuit Breaker: invalid configuration — falling back to memory store", "error", err)
+		cfg.Backend = "memory"
 	}
 
 	store, err := circuit.Factory(cfg)
 	if err != nil {
-		if cfg.Backend == "redis" {
-			logger.Error("⚡ Circuit Breaker: Redis store construction failed — falling back to memory store",
-				"error", err,
-			)
-			store = circuit.NewMemoryStore(cfg)
-			globalCircuitRedisFallback = true
-		} else {
-			logger.Error("⚡ Circuit Breaker: failed to create store", "error", err)
-			return nil
-		}
+		logger.Error("⚡ Circuit Breaker: store construction failed — falling back to memory store",
+			"backend", cfg.Backend,
+			"error", err,
+		)
+		store = circuit.NewMemoryStore(cfg)
+		globalCircuitRedisFallback = true
 	}
 
 	if rs, ok := store.(*circuit.RedisStore); ok {

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -95,6 +95,27 @@ var globalRateLimiter ratelimit.RateLimiter
 // Global circuit breaker store instance
 var globalCircuitStore circuit.Store
 
+// Resolved circuit-breaker config after Defaults() is applied.  Captured at
+// startup so /health can surface the effective mode / backend / thresholds
+// without re-reading YAML.
+var globalCircuitConfig circuit.Config
+
+// Set to true when the configured backend was "redis" but the Redis store
+// could not be constructed and we transparently fell back to MemoryStore.
+// Surfaced in /health so operators can tell at a glance that the circuit
+// breaker is running without distributed coordination.
+var globalCircuitRedisFallback bool
+
+// Known provider names the circuit breaker tracks.  Kept as a single source
+// of truth so the wiring code, /health handler, and any future diagnostics
+// agree on the list.
+var circuitBreakerProviders = []string{"openai", "anthropic", "gemini"}
+
+// redisPingTimeout bounds the blocking startup PING to Redis.  Long enough
+// to succeed on a warm connection across regions, short enough that a dead
+// Redis never holds up proxy startup past its health-check window.
+const redisPingTimeout = 2 * time.Second
+
 func init() {
 	logLevel := os.Getenv("LOG_LEVEL")
 	var level slog.Level
@@ -358,10 +379,37 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 	return costTracker
 }
 
+// isTestModeAllowed evaluates the three-condition gate that controls
+// whether the proxy honours X-LLM-Proxy-Test-Mode / llm_proxy_test_mode.
+// ALL THREE conditions must be satisfied:
+//  1. The circuit breaker feature is enabled (otherwise there is
+//     nothing for the test-mode flag to exercise, and any honouring
+//     of the header is pure attack surface).
+//  2. TestModeEnabled is true in YAML (explicit opt-in).
+//  3. LLM_PROXY_ALLOW_TEST_MODE=1 is set in the process environment
+//     (belt-and-suspenders guard against a misconfigured YAML in
+//     production).
+//
+// The result of this gate is plumbed into circuit.Config.TestModeEnabled
+// so the transport layer refuses to honour the test-mode signals when
+// any guard fails — without this, a client could smuggle synthetic
+// degraded responses past the middleware by sending a request that
+// hits the transport directly.
+func isTestModeAllowed(yc *config.YAMLConfig) bool {
+	return yc.Features.CircuitBreaker.Enabled &&
+		yc.Features.CircuitBreaker.TestModeEnabled &&
+		os.Getenv("LLM_PROXY_ALLOW_TEST_MODE") == "1"
+}
+
 // circuitConfigFromYAML converts the YAML circuit breaker config into the
 // internal circuit.Config (with defaults applied). Centralised so we don't
 // drift between the store-initialisation and transport-wrapping call sites.
-func circuitConfigFromYAML(cb config.CircuitBreakerConfig) circuit.Config {
+//
+// testModeAllowed must be the result of isTestModeAllowed for the same
+// yamlConfig.  It is threaded in rather than re-derived so every call
+// site sees an identical value (there is no scenario where one layer
+// should honour test-mode and another should not).
+func circuitConfigFromYAML(cb config.CircuitBreakerConfig, testModeAllowed bool) circuit.Config {
 	cfg := circuit.Config{
 		Enabled:                         cb.Enabled,
 		Mode:                            cb.Mode,
@@ -374,6 +422,7 @@ func circuitConfigFromYAML(cb config.CircuitBreakerConfig) circuit.Config {
 		RetryContributionMode:           cb.RetryContributionMode,
 		GlobalRateLimitEscalationWindow: cb.GlobalRateLimitEscalationWindow,
 		DegradedSignal:                  cb.DegradedSignal,
+		TestModeEnabled:                 testModeAllowed,
 	}
 	if cb.Redis != nil {
 		// Expand ${VAR} / $VAR tokens from the process environment so we
@@ -385,6 +434,7 @@ func circuitConfigFromYAML(cb config.CircuitBreakerConfig) circuit.Config {
 		cfg.RedisAddress = os.ExpandEnv(cb.Redis.Address)
 		cfg.RedisPassword = os.ExpandEnv(cb.Redis.Password)
 		cfg.RedisDB = cb.Redis.DB
+		cfg.RedisDBSet = cb.Redis.DBSet
 	}
 	return cfg.Defaults()
 }
@@ -408,7 +458,11 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 		return nil
 	}
 
-	cfg := circuitConfigFromYAML(cb)
+	cfg := circuitConfigFromYAML(cb, isTestModeAllowed(yamlConfig))
+	if err := cfg.Validate(); err != nil {
+		logger.Error("⚡ Circuit Breaker: invalid configuration — feature disabled", "error", err)
+		return nil
+	}
 
 	store, err := circuit.Factory(cfg)
 	if err != nil {
@@ -417,6 +471,7 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 				"error", err,
 			)
 			store = circuit.NewMemoryStore(cfg)
+			globalCircuitRedisFallback = true
 		} else {
 			logger.Error("⚡ Circuit Breaker: failed to create store", "error", err)
 			return nil
@@ -424,7 +479,7 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 	}
 
 	if rs, ok := store.(*circuit.RedisStore); ok {
-		pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		pingCtx, cancel := context.WithTimeout(context.Background(), redisPingTimeout)
 		if pingErr := rs.Ping(pingCtx); pingErr != nil {
 			logger.Warn("⚡ Circuit Breaker: Redis PING failed at startup — proxy will continue (store fails open on Redis errors)",
 				"error", pingErr,
@@ -435,8 +490,13 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 		cancel()
 	}
 
+	// Capture the resolved config so /health can report it without
+	// re-applying Defaults() on every request.
+	globalCircuitConfig = cfg.Defaults()
+
 	logger.Info("⚡ Circuit Breaker: initialized",
 		"backend", cfg.Backend,
+		"redis_fallback", globalCircuitRedisFallback,
 		"mode", cfg.Mode,
 		"failure_threshold", cfg.FailureThreshold,
 		"window_seconds", cfg.WindowSeconds,
@@ -498,17 +558,49 @@ func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore 
 	return store
 }
 
-// healthHandler provides a simple health check endpoint
+// healthHandler provides a simple health check endpoint.
+//
+// When the circuit breaker is enabled, the response includes a
+// `circuit_breaker` block describing the effective mode, backend, whether
+// we fell back from Redis to in-memory, and per-provider state/failure
+// counts.  This is the canonical signal operators should key dashboards
+// and alerts off of.
 func healthHandler(w http.ResponseWriter, r *http.Request) {
 	providerHealth := globalProviderManager.GetHealthStatus()
 
-	// Augment with circuit breaker stats when available.
+	var circuitBlock map[string]interface{}
 	if globalCircuitStore != nil {
-		for _, name := range []string{"openai", "anthropic", "gemini"} {
+		perProvider := make(map[string]interface{}, len(circuitBreakerProviders))
+		for _, name := range circuitBreakerProviders {
 			stats, err := globalCircuitStore.GetStats(r.Context(), name)
 			if err != nil {
+				// /health is unauthenticated, so we MUST NOT leak the
+				// raw error string (it can contain Redis URLs, host
+				// names, port numbers, or other infrastructure detail
+				// that helps an attacker enumerate the deployment).
+				// Operators get the full detail via the structured
+				// logger below.
+				logger.Warn("⚡ Circuit Breaker: GetStats error on /health",
+					"provider", name,
+					"error", err,
+				)
+				perProvider[name] = map[string]interface{}{
+					"error": "stats_unavailable",
+				}
 				continue
 			}
+			entry := map[string]interface{}{
+				"state":    stats.State.String(),
+				"failures": stats.Failures,
+			}
+			if stats.CooldownUntil != nil {
+				entry["cooldown_until"] = stats.CooldownUntil.Unix()
+			}
+			perProvider[name] = entry
+
+			// Keep the legacy provider-level fields populated so any
+			// existing consumers that read providers[X].circuit_state
+			// don't break.
 			ph, _ := providerHealth[name].(map[string]interface{})
 			if ph == nil {
 				ph = make(map[string]interface{})
@@ -519,6 +611,14 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 				ph["circuit_cooldown_until"] = stats.CooldownUntil.Unix()
 			}
 			providerHealth[name] = ph
+		}
+		circuitBlock = map[string]interface{}{
+			"enabled":         true,
+			"mode":            globalCircuitConfig.Mode,
+			"backend":         globalCircuitConfig.Backend,
+			"redis_fallback":  globalCircuitRedisFallback,
+			"providers":       perProvider,
+			"degraded_signal": globalCircuitConfig.DegradedSignal,
 		}
 	}
 
@@ -531,8 +631,11 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 			"circuit_breaker": globalCircuitStore != nil,
 		},
 	}
+	if circuitBlock != nil {
+		health["circuit_breaker"] = circuitBlock
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(health)
+	json.NewEncoder(w).Encode(health) //nolint:errcheck
 }
 
 // handleConfigValidation handles the --validate-config flag functionality
@@ -657,11 +760,24 @@ func runServer(yamlConfig *config.YAMLConfig) {
 
 	// Inject circuit-breaking transports when the feature is enabled.
 	if globalCircuitStore != nil {
-		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker)
-		wrapProviderWithCircuitBreaker(openAIProvider, globalCircuitStore, cbCfg, "openai")
-		wrapProviderWithCircuitBreaker(anthropicProvider, globalCircuitStore, cbCfg, "anthropic")
-		wrapProviderWithCircuitBreaker(geminiProvider, globalCircuitStore, cbCfg, "gemini")
-		logger.Info("⚡ Circuit Breaker: transports wrapped for all providers")
+		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker, isTestModeAllowed(yamlConfig))
+		// Pair each provider with its canonical name so the wiring loop
+		// iterates the same set of names that /health queries.
+		type namedProvider struct {
+			name string
+			p    interface {
+				WrapTransport(func(http.RoundTripper) http.RoundTripper)
+			}
+		}
+		for _, np := range []namedProvider{
+			{"openai", openAIProvider},
+			{"anthropic", anthropicProvider},
+			{"gemini", geminiProvider},
+		} {
+			wrapProviderWithCircuitBreaker(np.p, globalCircuitStore, cbCfg, np.name)
+		}
+		logger.Info("⚡ Circuit Breaker: transports wrapped for all providers",
+			"providers", circuitBreakerProviders)
 	}
 
 	// Add middleware (order matters for streaming)
@@ -673,10 +789,28 @@ func runServer(yamlConfig *config.YAMLConfig) {
 	}
 
 	// Add test-mode middleware when enabled (integration tests only).
-	if yamlConfig.Features.CircuitBreaker.TestModeEnabled {
-		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker)
+	//
+	// We require THREE conditions before enabling this middleware, any one
+	// of which is sufficient to disable it:
+	//   1. The circuit breaker feature itself is Enabled.  Without it, the
+	//      test-mode header has nothing to toggle and only adds attack
+	//      surface.
+	//   2. TestModeEnabled is true in YAML.  This is the explicit opt-in
+	//      used by integration test configs.
+	//   3. LLM_PROXY_ALLOW_TEST_MODE=1 in the environment.  This belt-and-
+	//      suspenders guard ensures a production binary cannot accidentally
+	//      honour a test-mode header even if a misconfigured YAML slips
+	//      through review.
+	testModeAllowed := isTestModeAllowed(yamlConfig)
+	if testModeAllowed {
+		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker, testModeAllowed)
 		r.Use(middleware.NewTestModeMiddleware(cbCfg.DegradedSignal))
-		logger.Info("⚡ Circuit Breaker: test-mode middleware ENABLED (not for production)")
+		logger.Warn("⚡ Circuit Breaker: test-mode middleware ENABLED (not for production)")
+	} else if yamlConfig.Features.CircuitBreaker.TestModeEnabled {
+		logger.Warn("⚡ Circuit Breaker: test-mode requested in YAML but one or more guards not satisfied; middleware NOT installed",
+			"circuit_breaker_enabled", yamlConfig.Features.CircuitBreaker.Enabled,
+			"allow_env_set", os.Getenv("LLM_PROXY_ALLOW_TEST_MODE") == "1",
+		)
 	}
 
 	r.Use(middleware.LoggingMiddleware(globalProviderManager))
@@ -802,6 +936,17 @@ func runServer(yamlConfig *config.YAMLConfig) {
 		logger.Info("🔄 Stopping cost tracking workers and flushing queue...")
 		globalCostTracker.StopAsyncWorkers()
 		logger.Info("✅ Cost tracking workers stopped and queue flushed")
+	}
+
+	// Release circuit-breaker Redis connections so the pool drains cleanly.
+	// Best effort only: any error here is logged, not fatal, because at
+	// this point the HTTP server is already stopped.
+	if rs, ok := globalCircuitStore.(*circuit.RedisStore); ok {
+		if err := rs.Close(); err != nil {
+			logger.Warn("Circuit Breaker: Redis close failed", "error", err)
+		} else {
+			logger.Info("✅ Circuit Breaker: Redis client closed")
+		}
 	}
 
 	logger.Info("👋 Server shutdown complete")

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/circuit"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/cost"
 	"github.com/Instawork/llm-proxy/internal/middleware"
@@ -90,6 +91,9 @@ var globalAPIKeyStore providers.APIKeyStore
 
 // Global rate limiter instance
 var globalRateLimiter ratelimit.RateLimiter
+
+// Global circuit breaker store instance
+var globalCircuitStore circuit.Store
 
 func init() {
 	logLevel := os.Getenv("LOG_LEVEL")
@@ -354,6 +358,72 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 	return costTracker
 }
 
+// circuitConfigFromYAML converts the YAML circuit breaker config into the
+// internal circuit.Config (with defaults applied). Centralised so we don't
+// drift between the store-initialisation and transport-wrapping call sites.
+func circuitConfigFromYAML(cb config.CircuitBreakerConfig) circuit.Config {
+	cfg := circuit.Config{
+		Enabled:                         cb.Enabled,
+		Backend:                         cb.Backend,
+		FailureThreshold:                cb.FailureThreshold,
+		WindowSeconds:                   cb.WindowSeconds,
+		CooldownSeconds:                 cb.CooldownSeconds,
+		MaxTransientRetries:             cb.MaxTransientRetries,
+		MaxRateLimitRetries:             cb.MaxRateLimitRetries,
+		RetryContributionMode:           cb.RetryContributionMode,
+		GlobalRateLimitEscalationWindow: cb.GlobalRateLimitEscalationWindow,
+	}
+	if cb.Redis != nil {
+		cfg.RedisAddress = cb.Redis.Address
+		cfg.RedisPassword = cb.Redis.Password
+		cfg.RedisDB = cb.Redis.DB
+	}
+	return cfg.Defaults()
+}
+
+// initializeCircuitStore creates the circuit breaker state store from config.
+func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
+	cb := yamlConfig.Features.CircuitBreaker
+	if !cb.Enabled {
+		logger.Info("⚡ Circuit Breaker: disabled in config")
+		return nil
+	}
+
+	cfg := circuitConfigFromYAML(cb)
+
+	store, err := circuit.Factory(cfg)
+	if err != nil {
+		logger.Error("⚡ Circuit Breaker: failed to create store", "error", err)
+		return nil
+	}
+
+	logger.Info("⚡ Circuit Breaker: initialized",
+		"backend", cfg.Backend,
+		"failure_threshold", cfg.FailureThreshold,
+		"window_seconds", cfg.WindowSeconds,
+		"cooldown_seconds", cfg.CooldownSeconds,
+		"max_transient_retries", cfg.MaxTransientRetries,
+		"max_rate_limit_retries", cfg.MaxRateLimitRetries,
+		"retry_contribution_mode", cfg.RetryContributionMode,
+	)
+	return store
+}
+
+// wrapProviderWithCircuitBreaker injects a circuit-breaking transport into the
+// provider, keyed by providerName.
+func wrapProviderWithCircuitBreaker(
+	p interface {
+		WrapTransport(func(http.RoundTripper) http.RoundTripper)
+	},
+	store circuit.Store,
+	cfg circuit.Config,
+	providerName string,
+) {
+	p.WrapTransport(func(inner http.RoundTripper) http.RoundTripper {
+		return circuit.NewTransport(inner, store, cfg, providerName, logger)
+	})
+}
+
 // initializeAPIKeyStore creates and configures the API key store from config
 func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore {
 	// Check if API key management is enabled
@@ -390,12 +460,35 @@ func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore 
 
 // healthHandler provides a simple health check endpoint
 func healthHandler(w http.ResponseWriter, r *http.Request) {
+	providerHealth := globalProviderManager.GetHealthStatus()
+
+	// Augment with circuit breaker stats when available.
+	if globalCircuitStore != nil {
+		for _, name := range []string{"openai", "anthropic", "gemini"} {
+			stats, err := globalCircuitStore.GetStats(r.Context(), name)
+			if err != nil {
+				continue
+			}
+			ph, _ := providerHealth[name].(map[string]interface{})
+			if ph == nil {
+				ph = make(map[string]interface{})
+			}
+			ph["circuit_state"] = stats.State.String()
+			ph["circuit_failures"] = stats.Failures
+			if stats.CooldownUntil != nil {
+				ph["circuit_cooldown_until"] = stats.CooldownUntil.Unix()
+			}
+			providerHealth[name] = ph
+		}
+	}
+
 	health := map[string]interface{}{
 		"status":    "healthy",
 		"timestamp": time.Now().Unix(),
-		"providers": globalProviderManager.GetHealthStatus(),
+		"providers": providerHealth,
 		"features": map[string]bool{
-			"cost_tracking": globalCostTracker != nil,
+			"cost_tracking":   globalCostTracker != nil,
+			"circuit_breaker": globalCircuitStore != nil,
 		},
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -509,6 +602,9 @@ func runServer(yamlConfig *config.YAMLConfig) {
 		}
 	}
 
+	// Initialize circuit breaker
+	globalCircuitStore = initializeCircuitStore(yamlConfig)
+
 	// Register providers
 	openAIProvider := providers.NewOpenAIProxy()
 	globalProviderManager.RegisterProvider(openAIProvider)
@@ -519,12 +615,27 @@ func runServer(yamlConfig *config.YAMLConfig) {
 	geminiProvider := providers.NewGeminiProxy()
 	globalProviderManager.RegisterProvider(geminiProvider)
 
+	// Inject circuit-breaking transports when the feature is enabled.
+	if globalCircuitStore != nil {
+		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker)
+		wrapProviderWithCircuitBreaker(openAIProvider, globalCircuitStore, cbCfg, "openai")
+		wrapProviderWithCircuitBreaker(anthropicProvider, globalCircuitStore, cbCfg, "anthropic")
+		wrapProviderWithCircuitBreaker(geminiProvider, globalCircuitStore, cbCfg, "gemini")
+		logger.Info("⚡ Circuit Breaker: transports wrapped for all providers")
+	}
+
 	// Add middleware (order matters for streaming)
 	r.Use(middleware.MetaURLRewritingMiddleware(globalProviderManager)) // URL rewriting must happen first
 
 	// Add API key validation middleware if API key management is enabled
 	if globalAPIKeyStore != nil {
 		r.Use(middleware.APIKeyValidationMiddleware(globalProviderManager, globalAPIKeyStore))
+	}
+
+	// Add test-mode middleware when enabled (integration tests only).
+	if yamlConfig.Features.CircuitBreaker.TestModeEnabled {
+		r.Use(middleware.TestModeMiddleware)
+		logger.Info("⚡ Circuit Breaker: test-mode middleware ENABLED (not for production)")
 	}
 
 	r.Use(middleware.LoggingMiddleware(globalProviderManager))
@@ -587,6 +698,9 @@ func runServer(yamlConfig *config.YAMLConfig) {
 	}
 	if globalRateLimiter != nil {
 		features = append(features, "Rate limiting")
+	}
+	if globalCircuitStore != nil {
+		features = append(features, "Circuit breaker")
 	}
 	logger.Info("Features enabled", "features", strings.Join(features, ", "))
 

--- a/cmd/llm-proxy/main_test.go
+++ b/cmd/llm-proxy/main_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+// TestCircuitConfigFromYAML_ExpandsRedisURLEnvVar nails down the env-var
+// expansion contract for the circuit-breaker Redis URL: the raw YAML value
+// `${REDIS_URL}` must be replaced by whatever the process env holds at
+// boot, so the ECS-injected secret reaches the Redis client.
+func TestCircuitConfigFromYAML_ExpandsRedisURLEnvVar(t *testing.T) {
+	const want = "redis://:pw@cache.example.com:6379/5"
+	t.Setenv("REDIS_URL", want)
+
+	cbYAML := config.CircuitBreakerConfig{
+		Enabled: true,
+		Mode:    "log",
+		Backend: "redis",
+		Redis: &config.RedisConfig{
+			URL: "${REDIS_URL}",
+			DB:  5,
+		},
+	}
+
+	cfg := circuitConfigFromYAML(cbYAML)
+
+	if cfg.RedisURL != want {
+		t.Fatalf("RedisURL want %q, got %q (os.ExpandEnv didn't fire)", want, cfg.RedisURL)
+	}
+	if cfg.RedisDB != 5 {
+		t.Fatalf("RedisDB overlay lost: want 5, got %d", cfg.RedisDB)
+	}
+}
+
+// TestCircuitConfigFromYAML_ExpandsShellStyleVar verifies the `$VAR` form
+// (no braces) is also honoured — os.ExpandEnv accepts both.
+func TestCircuitConfigFromYAML_ExpandsShellStyleVar(t *testing.T) {
+	t.Setenv("MY_REDIS", "redis://cache.example.com:6379/1")
+
+	cfg := circuitConfigFromYAML(config.CircuitBreakerConfig{
+		Enabled: true,
+		Backend: "redis",
+		Redis:   &config.RedisConfig{URL: "$MY_REDIS"},
+	})
+
+	if cfg.RedisURL != "redis://cache.example.com:6379/1" {
+		t.Fatalf("shell-style var not expanded; got %q", cfg.RedisURL)
+	}
+}
+
+// TestCircuitConfigFromYAML_UnsetVarBecomesEmpty documents the fail-safe
+// behaviour: an unset env var collapses to "" (os.ExpandEnv semantics),
+// which then triggers `NewRedisStore`'s "address or url is required"
+// error, which `initializeCircuitStore` catches and falls back to the
+// memory store.  This path is what keeps a misconfigured sidecar from
+// refusing to boot.
+func TestCircuitConfigFromYAML_UnsetVarBecomesEmpty(t *testing.T) {
+	// Guarantee the env var isn't set by an earlier test or the CI runner.
+	t.Setenv("DEFINITELY_NOT_SET_ANYWHERE_12345", "")
+
+	cfg := circuitConfigFromYAML(config.CircuitBreakerConfig{
+		Enabled: true,
+		Backend: "redis",
+		Redis:   &config.RedisConfig{URL: "${DEFINITELY_NOT_SET_ANYWHERE_12345}"},
+	})
+
+	if cfg.RedisURL != "" {
+		t.Fatalf("unset env var should expand to empty string; got %q", cfg.RedisURL)
+	}
+}
+
+// TestCircuitConfigFromYAML_LiteralURLPassesThrough confirms that a YAML
+// value without any `$` tokens is returned unchanged — no false positives
+// from the expansion pass.
+func TestCircuitConfigFromYAML_LiteralURLPassesThrough(t *testing.T) {
+	const literal = "redis://cache.example.com:6379/5"
+
+	cfg := circuitConfigFromYAML(config.CircuitBreakerConfig{
+		Enabled: true,
+		Backend: "redis",
+		Redis:   &config.RedisConfig{URL: literal},
+	})
+
+	if cfg.RedisURL != literal {
+		t.Fatalf("literal URL mutated by ExpandEnv: want %q, got %q", literal, cfg.RedisURL)
+	}
+}
+
+// TestCircuitConfigFromYAML_ProductionYAMLExpandsEndToEnd is the full
+// integration slice: load the real production.yml (merged over base.yml),
+// set REDIS_URL in the environment, feed the parsed CircuitBreakerConfig
+// through circuitConfigFromYAML, and confirm the expanded URL reaches
+// circuit.Config.  If this test ever fails you have a real bug in the
+// path from ECS → binary → Redis.
+func TestCircuitConfigFromYAML_ProductionYAMLExpandsEndToEnd(t *testing.T) {
+	const want = "redis://:prodpw@finch-cache.internal:6379/6"
+	t.Setenv("REDIS_URL", want)
+
+	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
+	if err != nil {
+		t.Fatalf("resolve configs dir: %v", err)
+	}
+	merged, err := config.LoadAndMergeConfigs([]string{
+		filepath.Join(configsDir, "base.yml"),
+		filepath.Join(configsDir, "production.yml"),
+	})
+	if err != nil {
+		t.Fatalf("load prod configs: %v", err)
+	}
+
+	cfg := circuitConfigFromYAML(merged.Features.CircuitBreaker)
+
+	if cfg.RedisURL != want {
+		t.Fatalf("production.yml REDIS_URL expansion broken: want %q, got %q", want, cfg.RedisURL)
+	}
+	if cfg.Mode != "log" {
+		t.Fatalf("production.yml cb.mode should be 'log' until explicitly flipped, got %q", cfg.Mode)
+	}
+	if cfg.Backend != "redis" {
+		t.Fatalf("production.yml cb.backend should be 'redis', got %q", cfg.Backend)
+	}
+	if cfg.RedisDB != 5 {
+		t.Fatalf("production.yml cb.redis.db should pin 5 (isolated from Finch's DB), got %d", cfg.RedisDB)
+	}
+}

--- a/cmd/llm-proxy/main_test.go
+++ b/cmd/llm-proxy/main_test.go
@@ -20,18 +20,22 @@ func TestCircuitConfigFromYAML_ExpandsRedisURLEnvVar(t *testing.T) {
 		Mode:    "log",
 		Backend: "redis",
 		Redis: &config.RedisConfig{
-			URL: "${REDIS_URL}",
-			DB:  5,
+			URL:   "${REDIS_URL}",
+			DB:    5,
+			DBSet: true,
 		},
 	}
 
-	cfg := circuitConfigFromYAML(cbYAML)
+	cfg := circuitConfigFromYAML(cbYAML, false)
 
 	if cfg.RedisURL != want {
 		t.Fatalf("RedisURL want %q, got %q (os.ExpandEnv didn't fire)", want, cfg.RedisURL)
 	}
 	if cfg.RedisDB != 5 {
 		t.Fatalf("RedisDB overlay lost: want 5, got %d", cfg.RedisDB)
+	}
+	if !cfg.RedisDBSet {
+		t.Fatal("RedisDBSet overlay lost")
 	}
 }
 
@@ -44,7 +48,7 @@ func TestCircuitConfigFromYAML_ExpandsShellStyleVar(t *testing.T) {
 		Enabled: true,
 		Backend: "redis",
 		Redis:   &config.RedisConfig{URL: "$MY_REDIS"},
-	})
+	}, false)
 
 	if cfg.RedisURL != "redis://cache.example.com:6379/1" {
 		t.Fatalf("shell-style var not expanded; got %q", cfg.RedisURL)
@@ -65,7 +69,7 @@ func TestCircuitConfigFromYAML_UnsetVarBecomesEmpty(t *testing.T) {
 		Enabled: true,
 		Backend: "redis",
 		Redis:   &config.RedisConfig{URL: "${DEFINITELY_NOT_SET_ANYWHERE_12345}"},
-	})
+	}, false)
 
 	if cfg.RedisURL != "" {
 		t.Fatalf("unset env var should expand to empty string; got %q", cfg.RedisURL)
@@ -82,7 +86,7 @@ func TestCircuitConfigFromYAML_LiteralURLPassesThrough(t *testing.T) {
 		Enabled: true,
 		Backend: "redis",
 		Redis:   &config.RedisConfig{URL: literal},
-	})
+	}, false)
 
 	if cfg.RedisURL != literal {
 		t.Fatalf("literal URL mutated by ExpandEnv: want %q, got %q", literal, cfg.RedisURL)
@@ -111,7 +115,7 @@ func TestCircuitConfigFromYAML_ProductionYAMLExpandsEndToEnd(t *testing.T) {
 		t.Fatalf("load prod configs: %v", err)
 	}
 
-	cfg := circuitConfigFromYAML(merged.Features.CircuitBreaker)
+	cfg := circuitConfigFromYAML(merged.Features.CircuitBreaker, false)
 
 	if cfg.RedisURL != want {
 		t.Fatalf("production.yml REDIS_URL expansion broken: want %q, got %q", want, cfg.RedisURL)
@@ -124,5 +128,8 @@ func TestCircuitConfigFromYAML_ProductionYAMLExpandsEndToEnd(t *testing.T) {
 	}
 	if cfg.RedisDB != 5 {
 		t.Fatalf("production.yml cb.redis.db should pin 5 (isolated from Finch's DB), got %d", cfg.RedisDB)
+	}
+	if !cfg.RedisDBSet {
+		t.Fatal("production.yml cb.redis.db should be recorded as explicitly set")
 	}
 }

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -28,6 +28,16 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys-dev"
     region: "us-west-2"
+  circuit_breaker:
+    enabled: true
+    backend: "memory"
+    failure_threshold: 5
+    window_seconds: 120
+    cooldown_seconds: 300
+    max_transient_retries: 2
+    max_rate_limit_retries: 2
+    retry_contribution_mode: "log"
+    test_mode_enabled: true
   rate_limiting:
     enabled: true
     backend: "memory"

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -36,6 +36,7 @@ features:
     cooldown_seconds: 300
     max_transient_retries: 2
     max_rate_limit_retries: 2
+    global_rate_limit_escalation_window: 300
     retry_contribution_mode: "log"
     test_mode_enabled: true
   rate_limiting:

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -31,5 +31,28 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys"
     region: "us-west-2"
+  # Circuit breaker: shadow/observe-only rollout against the Finch-owned
+  # Redis cluster.  The sidecar records counterfactual state + failure
+  # counts in Redis (under the `llm:cb:` prefix, DB 5) but never retries
+  # traffic, fast-fails, or synthesises 503s — operators can flip
+  # `mode: enforce` once the would-trip rates look sane.
+  #
+  # ${REDIS_URL} is populated from the ML_CACHE_URL SSM secret in the
+  # ECS task definition; any transient Redis outage degrades the breaker
+  # to per-instance best-effort (fail-open) rather than tripping the
+  # proxy itself.
+  circuit_breaker:
+    enabled: true
+    mode: "log"
+    backend: "redis"
+    redis:
+      url: "${REDIS_URL}"
+      db: 5
+    failure_threshold: 5
+    window_seconds: 120
+    cooldown_seconds: 300
+    max_transient_retries: 2
+    max_rate_limit_retries: 2
+    retry_contribution_mode: "log"
   rate_limiting:
     enabled: false

--- a/configs/staging.yml
+++ b/configs/staging.yml
@@ -18,5 +18,23 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys-staging"
     region: "us-west-2"
+  # Circuit breaker: shadow/observe-only rollout in staging, matching
+  # production config so we can validate Redis connectivity and
+  # would-trip rates before flipping prod to `mode: enforce`.  DB 5 is
+  # pinned so `llm:cb:*` keys stay isolated from Finch's ML cache (DB 6
+  # in staging2).
+  circuit_breaker:
+    enabled: true
+    mode: "log"
+    backend: "redis"
+    redis:
+      url: "${REDIS_URL}"
+      db: 5
+    failure_threshold: 5
+    window_seconds: 120
+    cooldown_seconds: 300
+    max_transient_retries: 2
+    max_rate_limit_retries: 2
+    retry_contribution_mode: "log"
   rate_limiting:
     enabled: false

--- a/internal/circuit/classifier.go
+++ b/internal/circuit/classifier.go
@@ -1,6 +1,7 @@
 package circuit
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -162,13 +163,21 @@ func classifyNetworkError(err error) FailureClass {
 		return FailureClassNone
 	}
 
+	// Client-initiated cancellation is not a provider failure and must never
+	// count toward the circuit's failure window. We still treat a deadline
+	// exceeded at the request level as a degradation signal below, since that
+	// usually indicates the provider is too slow.
+	if errors.Is(err, context.Canceled) {
+		return FailureClassNone
+	}
+
 	// Unexpected EOF or closed connection.
 	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
 		return FailureClassDegraded
 	}
 
 	// context deadline / timeout.
-	if errors.Is(err, http.ErrHandlerTimeout) {
+	if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 		return FailureClassDegraded
 	}
 

--- a/internal/circuit/classifier.go
+++ b/internal/circuit/classifier.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // ClassifyResponse examines an HTTP response and the optional transport-level
@@ -207,13 +209,23 @@ func classifyNetworkError(err error) FailureClass {
 	return FailureClassDegraded // unknown transport errors → degraded
 }
 
-// parseRetryAfterSeconds returns the numeric seconds from a Retry-After header
-// value.  Returns 0 if unparseable.
+// parseRetryAfterSeconds returns seconds from a Retry-After header value.
+// Supports both delta-seconds and HTTP-date forms. Returns 0 if unparseable
+// or if the parsed date is in the past.
 func parseRetryAfterSeconds(s string) int {
 	s = strings.TrimSpace(s)
 	var n int
 	if _, err := fmt.Sscanf(s, "%d", &n); err == nil {
 		return n
 	}
-	return 0
+
+	t, err := http.ParseTime(s)
+	if err != nil {
+		return 0
+	}
+	seconds := t.Sub(time.Now()).Seconds()
+	if seconds <= 0 {
+		return 0
+	}
+	return int(math.Ceil(seconds))
 }

--- a/internal/circuit/classifier.go
+++ b/internal/circuit/classifier.go
@@ -1,0 +1,210 @@
+package circuit
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ClassifyResponse examines an HTTP response and the optional transport-level
+// error to determine what kind of failure it represents.
+//
+// provider must be one of "openai", "anthropic", or "gemini".  When the
+// response is nil (transport error) the network-level error is classified
+// directly.
+//
+// Returns FailureClassNone for successful responses and for client errors that
+// are not provider-side issues (4xx other than specific overload codes).
+func ClassifyResponse(provider string, resp *http.Response, err error) FailureClass {
+	// 1. Network-level errors: the provider never sent a clean HTTP response.
+	if err != nil {
+		return classifyNetworkError(err)
+	}
+	if resp == nil {
+		return FailureClassDegraded
+	}
+
+	status := resp.StatusCode
+
+	// 2. Success or informational — nothing to classify.
+	if status < 400 {
+		return FailureClassNone
+	}
+
+	// 3. Provider-specific classification.
+	switch provider {
+	case "anthropic":
+		return classifyAnthropic(status, resp)
+	case "openai":
+		return classifyOpenAI(status, resp)
+	case "gemini":
+		return classifyGemini(status, resp)
+	default:
+		return classifyGeneric(status)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider-specific classifiers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func classifyAnthropic(status int, resp *http.Response) FailureClass {
+	switch status {
+	case 529: // Anthropic "Overloaded" — capacity constraint, not a client error
+		return FailureClassDegraded
+	case 500, 502, 503, 504:
+		return FailureClassDegraded
+	case 429:
+		return classifyRateLimitScope(
+			resp.Header.Get("anthropic-ratelimit-requests-remaining"),
+			resp.Header.Get("anthropic-ratelimit-tokens-remaining"),
+			resp.Header.Get("retry-after"),
+		)
+	case 401, 403:
+		// Auth errors are almost always client config issues, not provider
+		// incidents.  Mark as unclassifiable (will surface as-is).
+		return FailureClassNone
+	default:
+		if status >= 500 {
+			return FailureClassDegraded
+		}
+		return FailureClassNone
+	}
+}
+
+func classifyOpenAI(status int, resp *http.Response) FailureClass {
+	switch status {
+	case 500, 502, 503, 504:
+		return FailureClassDegraded
+	case 429:
+		return classifyRateLimitScope(
+			resp.Header.Get("x-ratelimit-remaining-requests"),
+			resp.Header.Get("x-ratelimit-remaining-tokens"),
+			resp.Header.Get("retry-after"),
+		)
+	case 401, 403:
+		return FailureClassNone
+	default:
+		if status >= 500 {
+			return FailureClassDegraded
+		}
+		return FailureClassNone
+	}
+}
+
+func classifyGemini(status int, resp *http.Response) FailureClass {
+	switch status {
+	case 500, 503:
+		return FailureClassDegraded
+	case 504: // DEADLINE_EXCEEDED
+		return FailureClassDegraded
+	case 429: // RESOURCE_EXHAUSTED
+		// Gemini does not expose granular rate-limit headers the way OpenAI
+		// and Anthropic do, so we treat all 429s as localized for now and let
+		// the escalation window promote them to global/degraded if needed.
+		return FailureClassLocalRateLimit
+	case 401, 403:
+		return FailureClassNone
+	default:
+		if status >= 500 {
+			return FailureClassDegraded
+		}
+		return FailureClassNone
+	}
+}
+
+func classifyGeneric(status int) FailureClass {
+	if status >= 500 {
+		return FailureClassDegraded
+	}
+	return FailureClassNone
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// classifyRateLimitScope decides between LocalRateLimit and GlobalRateLimit
+// based on remaining capacity headers.  When remaining capacity is 0 across
+// the board (requests AND tokens both exhausted) we treat it as global.
+func classifyRateLimitScope(remainingRequests, remainingTokens, retryAfter string) FailureClass {
+	rr := strings.TrimSpace(remainingRequests)
+	rt := strings.TrimSpace(remainingTokens)
+
+	requestsExhausted := rr == "0"
+	tokensExhausted := rt == "0"
+
+	// If the provider says both bucket types are at zero, it's a global
+	// account-wide exhaustion rather than a single model/tier limit.
+	if requestsExhausted && tokensExhausted {
+		return FailureClassGlobalRateLimit
+	}
+
+	// A long Retry-After is also a signal of a broader throttle.
+	if retryAfter != "" {
+		secs := parseRetryAfterSeconds(retryAfter)
+		if secs >= 60 {
+			return FailureClassGlobalRateLimit
+		}
+	}
+
+	return FailureClassLocalRateLimit
+}
+
+// classifyNetworkError maps Go transport errors to FailureClassDegraded.
+// These indicate the provider never returned a response, which is always a
+// provider-side (or network-side) issue that we must track.
+func classifyNetworkError(err error) FailureClass {
+	if err == nil {
+		return FailureClassNone
+	}
+
+	// Unexpected EOF or closed connection.
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return FailureClassDegraded
+	}
+
+	// context deadline / timeout.
+	if errors.Is(err, http.ErrHandlerTimeout) {
+		return FailureClassDegraded
+	}
+
+	// net.Error covers dial timeout, connection refused, etc.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return FailureClassDegraded
+	}
+
+	// String-based heuristic for TLS / connection resets that don't always
+	// surface as net.Error.
+	msg := err.Error()
+	for _, pattern := range []string{
+		"connection reset",
+		"connection refused",
+		"tls handshake",
+		"no such host",
+		"i/o timeout",
+		"context deadline exceeded",
+		"EOF",
+	} {
+		if strings.Contains(strings.ToLower(msg), strings.ToLower(pattern)) {
+			return FailureClassDegraded
+		}
+	}
+
+	return FailureClassDegraded // unknown transport errors → degraded
+}
+
+// parseRetryAfterSeconds returns the numeric seconds from a Retry-After header
+// value.  Returns 0 if unparseable.
+func parseRetryAfterSeconds(s string) int {
+	s = strings.TrimSpace(s)
+	var n int
+	if _, err := fmt.Sscanf(s, "%d", &n); err == nil {
+		return n
+	}
+	return 0
+}

--- a/internal/circuit/classifier_test.go
+++ b/internal/circuit/classifier_test.go
@@ -1,0 +1,209 @@
+package circuit
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func resp(status int, headers map[string]string) *http.Response {
+	h := make(http.Header)
+	for k, v := range headers {
+		h.Set(k, v)
+	}
+	return &http.Response{StatusCode: status, Header: h}
+}
+
+func TestClassifyResponse_Success(t *testing.T) {
+	fc := ClassifyResponse("openai", resp(200, nil), nil)
+	if fc != FailureClassNone {
+		t.Fatalf("200 should be FailureClassNone, got %s", fc)
+	}
+}
+
+// ─── Anthropic ─────────────────────────────────────────────────────────────
+
+func TestClassify_Anthropic_529(t *testing.T) {
+	fc := ClassifyResponse("anthropic", resp(529, nil), nil)
+	if fc != FailureClassDegraded {
+		t.Fatalf("Anthropic 529 should be Degraded, got %s", fc)
+	}
+}
+
+func TestClassify_Anthropic_5xx(t *testing.T) {
+	for _, code := range []int{500, 502, 503, 504} {
+		fc := ClassifyResponse("anthropic", resp(code, nil), nil)
+		if fc != FailureClassDegraded {
+			t.Fatalf("Anthropic %d should be Degraded, got %s", code, fc)
+		}
+	}
+}
+
+func TestClassify_Anthropic_429_LocalRateLimit(t *testing.T) {
+	// One bucket still has capacity.
+	fc := ClassifyResponse("anthropic", resp(429, map[string]string{
+		"anthropic-ratelimit-requests-remaining": "10",
+		"anthropic-ratelimit-tokens-remaining":   "0",
+	}), nil)
+	if fc != FailureClassLocalRateLimit {
+		t.Fatalf("want LocalRateLimit, got %s", fc)
+	}
+}
+
+func TestClassify_Anthropic_429_GlobalRateLimit(t *testing.T) {
+	// Both buckets exhausted.
+	fc := ClassifyResponse("anthropic", resp(429, map[string]string{
+		"anthropic-ratelimit-requests-remaining": "0",
+		"anthropic-ratelimit-tokens-remaining":   "0",
+	}), nil)
+	if fc != FailureClassGlobalRateLimit {
+		t.Fatalf("want GlobalRateLimit, got %s", fc)
+	}
+}
+
+func TestClassify_Anthropic_401(t *testing.T) {
+	fc := ClassifyResponse("anthropic", resp(401, nil), nil)
+	if fc != FailureClassNone {
+		t.Fatalf("Anthropic 401 should be FailureClassNone, got %s", fc)
+	}
+}
+
+// ─── OpenAI ────────────────────────────────────────────────────────────────
+
+func TestClassify_OpenAI_5xx(t *testing.T) {
+	for _, code := range []int{500, 502, 503, 504} {
+		fc := ClassifyResponse("openai", resp(code, nil), nil)
+		if fc != FailureClassDegraded {
+			t.Fatalf("OpenAI %d should be Degraded, got %s", code, fc)
+		}
+	}
+}
+
+func TestClassify_OpenAI_429_Global(t *testing.T) {
+	fc := ClassifyResponse("openai", resp(429, map[string]string{
+		"x-ratelimit-remaining-requests": "0",
+		"x-ratelimit-remaining-tokens":   "0",
+	}), nil)
+	if fc != FailureClassGlobalRateLimit {
+		t.Fatalf("want GlobalRateLimit, got %s", fc)
+	}
+}
+
+func TestClassify_OpenAI_429_LongRetryAfter(t *testing.T) {
+	// Long Retry-After → global rate limit.
+	fc := ClassifyResponse("openai", resp(429, map[string]string{
+		"retry-after": "120",
+	}), nil)
+	if fc != FailureClassGlobalRateLimit {
+		t.Fatalf("want GlobalRateLimit, got %s", fc)
+	}
+}
+
+// ─── Gemini ────────────────────────────────────────────────────────────────
+
+func TestClassify_Gemini_503(t *testing.T) {
+	fc := ClassifyResponse("gemini", resp(503, nil), nil)
+	if fc != FailureClassDegraded {
+		t.Fatalf("Gemini 503 should be Degraded, got %s", fc)
+	}
+}
+
+func TestClassify_Gemini_504_DeadlineExceeded(t *testing.T) {
+	fc := ClassifyResponse("gemini", resp(504, nil), nil)
+	if fc != FailureClassDegraded {
+		t.Fatalf("Gemini 504 should be Degraded, got %s", fc)
+	}
+}
+
+func TestClassify_Gemini_429_LocalRateLimit(t *testing.T) {
+	fc := ClassifyResponse("gemini", resp(429, nil), nil)
+	if fc != FailureClassLocalRateLimit {
+		t.Fatalf("Gemini 429 should be LocalRateLimit, got %s", fc)
+	}
+}
+
+// ─── Network errors ────────────────────────────────────────────────────────
+
+func TestClassify_NetworkError_UnexpectedEOF(t *testing.T) {
+	fc := ClassifyResponse("openai", nil, io.ErrUnexpectedEOF)
+	if fc != FailureClassDegraded {
+		t.Fatalf("unexpected EOF should be Degraded, got %s", fc)
+	}
+}
+
+func TestClassify_NetworkError_Timeout(t *testing.T) {
+	fc := ClassifyResponse("anthropic", nil, &net.OpError{
+		Op:  "dial",
+		Err: errors.New("i/o timeout"),
+	})
+	if fc != FailureClassDegraded {
+		t.Fatalf("dial timeout should be Degraded, got %s", fc)
+	}
+}
+
+func TestClassify_NetworkError_NilResponse(t *testing.T) {
+	fc := ClassifyResponse("gemini", nil, errors.New("connection reset by peer"))
+	if fc != FailureClassDegraded {
+		t.Fatalf("nil response with error should be Degraded, got %s", fc)
+	}
+}
+
+func TestClassify_NilResponse_NilError(t *testing.T) {
+	fc := ClassifyResponse("openai", nil, nil)
+	if fc != FailureClassDegraded {
+		t.Fatalf("nil response + nil error should be Degraded, got %s", fc)
+	}
+}
+
+func TestClassify_UnknownProvider_5xx(t *testing.T) {
+	fc := ClassifyResponse("mistral", resp(503, nil), nil)
+	if fc != FailureClassDegraded {
+		t.Fatalf("unknown provider 503 should be Degraded via classifyGeneric, got %s", fc)
+	}
+}
+
+func TestClassify_UnknownProvider_400(t *testing.T) {
+	fc := ClassifyResponse("mistral", resp(400, nil), nil)
+	if fc != FailureClassNone {
+		t.Fatalf("unknown provider 400 should be None via classifyGeneric, got %s", fc)
+	}
+}
+
+func TestClassify_OpenAI_401(t *testing.T) {
+	fc := ClassifyResponse("openai", resp(401, nil), nil)
+	if fc != FailureClassNone {
+		t.Fatalf("OpenAI 401 should be FailureClassNone, got %s", fc)
+	}
+}
+
+func TestClassify_OpenAI_403(t *testing.T) {
+	fc := ClassifyResponse("openai", resp(403, nil), nil)
+	if fc != FailureClassNone {
+		t.Fatalf("OpenAI 403 should be FailureClassNone, got %s", fc)
+	}
+}
+
+func TestClassify_Gemini_401(t *testing.T) {
+	fc := ClassifyResponse("gemini", resp(401, nil), nil)
+	if fc != FailureClassNone {
+		t.Fatalf("Gemini 401 should be FailureClassNone, got %s", fc)
+	}
+}
+
+func TestClassify_OpenAI_429_ShortRetryAfter_Local(t *testing.T) {
+	fc := ClassifyResponse("openai", resp(429, map[string]string{
+		"retry-after": "5",
+	}), nil)
+	if fc != FailureClassLocalRateLimit {
+		t.Fatalf("OpenAI 429 with short Retry-After should be LocalRateLimit, got %s", fc)
+	}
+}
+
+func TestClassify_Anthropic_429_NoHeaders_Local(t *testing.T) {
+	fc := ClassifyResponse("anthropic", resp(429, nil), nil)
+	if fc != FailureClassLocalRateLimit {
+		t.Fatalf("Anthropic 429 with no remaining headers should be LocalRateLimit, got %s", fc)
+	}
+}

--- a/internal/circuit/classifier_test.go
+++ b/internal/circuit/classifier_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func resp(status int, headers map[string]string) *http.Response {
@@ -13,7 +14,7 @@ func resp(status int, headers map[string]string) *http.Response {
 	for k, v := range headers {
 		h.Set(k, v)
 	}
-	return &http.Response{StatusCode: status, Header: h}
+	return &http.Response{StatusCode: status, Header: h, Body: http.NoBody}
 }
 
 func TestClassifyResponse_Success(t *testing.T) {
@@ -98,6 +99,23 @@ func TestClassify_OpenAI_429_LongRetryAfter(t *testing.T) {
 	}), nil)
 	if fc != FailureClassGlobalRateLimit {
 		t.Fatalf("want GlobalRateLimit, got %s", fc)
+	}
+}
+
+func TestClassify_OpenAI_429_HTTPDateRetryAfter(t *testing.T) {
+	retryAt := time.Now().Add(2 * time.Minute).UTC().Format(http.TimeFormat)
+	fc := ClassifyResponse("openai", resp(429, map[string]string{
+		"retry-after": retryAt,
+	}), nil)
+	if fc != FailureClassGlobalRateLimit {
+		t.Fatalf("want GlobalRateLimit for future HTTP-date Retry-After, got %s", fc)
+	}
+}
+
+func TestParseRetryAfterSeconds_PastHTTPDate(t *testing.T) {
+	retryAt := time.Now().Add(-1 * time.Minute).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfterSeconds(retryAt); got != 0 {
+		t.Fatalf("past HTTP-date Retry-After should return 0, got %d", got)
 	}
 }
 

--- a/internal/circuit/log_mode_test.go
+++ b/internal/circuit/log_mode_test.go
@@ -1,0 +1,131 @@
+package circuit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestTransport_LogMode_PassThroughOnSuccess verifies that ModeLog performs
+// exactly one upstream call on a 200 and returns the real response
+// unmodified — no synthetic wrapping, no extra headers.
+func TestTransport_LogMode_PassThroughOnSuccess(t *testing.T) {
+	calls := 0
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return makeResp(200), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeLog,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 2, // would retry in enforce mode — must NOT here
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200 pass-through, got %d", resp.StatusCode)
+	}
+	if calls != 1 {
+		t.Fatalf("ModeLog must issue exactly 1 upstream call, got %d", calls)
+	}
+}
+
+// TestTransport_LogMode_RecordsFailuresButPassesThrough verifies that ModeLog
+// records terminal failures in the Store (so cross-instance counters stay
+// accurate during a shadow rollout) yet returns the raw upstream 503 — never
+// a synthetic DefaultDegradedSignal body.
+func TestTransport_LogMode_RecordsFailuresButPassesThrough(t *testing.T) {
+	calls := 0
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeLog,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 2, // would retry in enforce — must NOT here
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("ModeLog must return the real upstream 503, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("ModeLog must NOT inject DefaultDegradedSignal; body=%q", b)
+	}
+	if calls != 1 {
+		t.Fatalf("ModeLog must issue exactly 1 upstream call even on failure, got %d", calls)
+	}
+
+	// Counterfactual state advanced from Closed → Open in the Store so
+	// operators can measure would-trip rate during shadow rollout.
+	if state, _ := store.GetState(context.Background(), "openai"); state != StateOpen {
+		t.Fatalf("ModeLog should have recorded the failure and flipped would-be-state to Open, got %s", state)
+	}
+}
+
+// TestTransport_LogMode_DoesNotFastFailOnOpenCircuit verifies that even when
+// the circuit is already Open, ModeLog still performs the real upstream
+// round trip and returns its response (the whole point of shadow mode).
+func TestTransport_LogMode_DoesNotFastFailOnOpenCircuit(t *testing.T) {
+	calls := 0
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return makeResp(200), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeLog,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 0,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	store.RecordTerminalFailure(context.Background(), "openai") //nolint:errcheck
+
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("ModeLog must let traffic through even when circuit is open; got %d", resp.StatusCode)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 upstream call, got %d", calls)
+	}
+}
+
+// TestConfig_Defaults_ModeIsLog verifies that an unset Mode defaults to
+// ModeLog (observe-only) — the safe default for rollouts.
+func TestConfig_Defaults_ModeIsLog(t *testing.T) {
+	if got := (Config{}).Defaults().Mode; got != ModeLog {
+		t.Fatalf("empty Mode should default to ModeLog, got %q", got)
+	}
+	if got := (Config{Mode: "bogus"}).Defaults().Mode; got != ModeLog {
+		t.Fatalf("unknown Mode should default to ModeLog, got %q", got)
+	}
+	if got := (Config{Mode: ModeEnforce}).Defaults().Mode; got != ModeEnforce {
+		t.Fatalf("explicit ModeEnforce must be preserved, got %q", got)
+	}
+}

--- a/internal/circuit/memory.go
+++ b/internal/circuit/memory.go
@@ -81,6 +81,24 @@ func (s *MemoryStore) stateUnlocked(e *memoryEntry) State {
 	return e.state
 }
 
+// pruneFailuresLocked removes failures outside the sliding window and applies
+// the hard entry cap. Must be called with e.mu held.
+func (s *MemoryStore) pruneFailuresLocked(e *memoryEntry, now time.Time) {
+	window := time.Duration(s.cfg.WindowSeconds) * time.Second
+	cutoff := now.Add(-window)
+
+	pruned := e.failures[:0]
+	for _, t := range e.failures {
+		if t.After(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	if len(pruned) > maxFailureWindowEntries {
+		pruned = pruned[len(pruned)-maxFailureWindowEntries:]
+	}
+	e.failures = pruned
+}
+
 // RecordTerminalFailure adds a failure timestamp to the sliding window and
 // opens the circuit if the threshold is exceeded.
 func (s *MemoryStore) RecordTerminalFailure(_ context.Context, provider string) (State, error) {
@@ -89,26 +107,10 @@ func (s *MemoryStore) RecordTerminalFailure(_ context.Context, provider string) 
 	defer e.mu.Unlock()
 
 	now := time.Now()
-	window := time.Duration(s.cfg.WindowSeconds) * time.Second
-	cutoff := now.Add(-window)
 
 	// Append and prune the sliding window.
 	e.failures = append(e.failures, now)
-	pruned := e.failures[:0]
-	for _, t := range e.failures {
-		if t.After(cutoff) {
-			pruned = append(pruned, t)
-		}
-	}
-	// Apply a hard count-based cap as a belt-and-braces defence against a
-	// sustained failure flood outpacing WindowSeconds pruning.  We drop
-	// the oldest entries rather than the newest so that when the failures
-	// eventually subside the most recent ones accurately reflect the
-	// freshest state.
-	if len(pruned) > maxFailureWindowEntries {
-		pruned = pruned[len(pruned)-maxFailureWindowEntries:]
-	}
-	e.failures = pruned
+	s.pruneFailuresLocked(e, now)
 
 	// Open the circuit if we've crossed the threshold.
 	if len(e.failures) >= s.cfg.FailureThreshold && e.state == StateClosed {
@@ -165,6 +167,7 @@ func (s *MemoryStore) GetStats(_ context.Context, provider string) (*ProviderSta
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	s.pruneFailuresLocked(e, time.Now())
 	state := s.stateUnlocked(e)
 	stats := &ProviderStats{
 		State:    state,
@@ -195,6 +198,9 @@ func (s *MemoryStore) TryStartProbe(_ context.Context, provider string) bool {
 	e := s.entry(provider)
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if s.stateUnlocked(e) != StateHalfOpen {
+		return false
+	}
 	now := time.Now()
 	if e.probeInFlight {
 		if e.probeStartAt.IsZero() || now.Sub(e.probeStartAt) < probeWatchdogTTL {

--- a/internal/circuit/memory.go
+++ b/internal/circuit/memory.go
@@ -1,0 +1,148 @@
+package circuit
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// memoryEntry holds per-provider circuit state for the in-memory store.
+type memoryEntry struct {
+	mu            sync.Mutex
+	state         State
+	failures      []time.Time // sliding window: timestamps of terminal failures
+	cooldownUntil time.Time
+	probeInFlight bool // prevents multiple concurrent probes in half-open
+}
+
+// MemoryStore is a single-process, mutex-backed circuit breaker store.
+// It is the default backend for local development.
+type MemoryStore struct {
+	cfg     Config
+	mu      sync.Mutex
+	entries map[string]*memoryEntry
+}
+
+// NewMemoryStore constructs a MemoryStore with cfg defaults applied.
+func NewMemoryStore(cfg Config) *MemoryStore {
+	return &MemoryStore{
+		cfg:     cfg.Defaults(),
+		entries: make(map[string]*memoryEntry),
+	}
+}
+
+func (s *MemoryStore) entry(provider string) *memoryEntry {
+	s.mu.Lock()
+	e, ok := s.entries[provider]
+	if !ok {
+		e = &memoryEntry{}
+		s.entries[provider] = e
+	}
+	s.mu.Unlock()
+	return e
+}
+
+// GetState returns the current circuit state, advancing from Open → HalfOpen
+// when the cooldown period has elapsed.
+func (s *MemoryStore) GetState(_ context.Context, provider string) (State, error) {
+	e := s.entry(provider)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return s.stateUnlocked(e), nil
+}
+
+// stateUnlocked evaluates the current state, transitioning Open → HalfOpen when
+// the cooldown expires.  Must be called with e.mu held.
+func (s *MemoryStore) stateUnlocked(e *memoryEntry) State {
+	if e.state == StateOpen && !e.cooldownUntil.IsZero() && time.Now().After(e.cooldownUntil) {
+		e.state = StateHalfOpen
+		e.cooldownUntil = time.Time{}
+	}
+	return e.state
+}
+
+// RecordTerminalFailure adds a failure timestamp to the sliding window and
+// opens the circuit if the threshold is exceeded.
+func (s *MemoryStore) RecordTerminalFailure(_ context.Context, provider string) (State, error) {
+	e := s.entry(provider)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	now := time.Now()
+	window := time.Duration(s.cfg.WindowSeconds) * time.Second
+	cutoff := now.Add(-window)
+
+	// Append and prune the sliding window.
+	e.failures = append(e.failures, now)
+	pruned := e.failures[:0]
+	for _, t := range e.failures {
+		if t.After(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	e.failures = pruned
+
+	// Open the circuit if we've crossed the threshold.
+	if len(e.failures) >= s.cfg.FailureThreshold && e.state == StateClosed {
+		e.state = StateOpen
+		e.cooldownUntil = now.Add(time.Duration(s.cfg.CooldownSeconds) * time.Second)
+		e.probeInFlight = false
+	}
+
+	return s.stateUnlocked(e), nil
+}
+
+// RecordSuccess closes the circuit after a successful half-open probe.
+func (s *MemoryStore) RecordSuccess(_ context.Context, provider string) error {
+	e := s.entry(provider)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.state = StateClosed
+	e.failures = e.failures[:0]
+	e.cooldownUntil = time.Time{}
+	e.probeInFlight = false
+	return nil
+}
+
+// RecordProbeFailed re-opens the circuit after a failed half-open probe.
+func (s *MemoryStore) RecordProbeFailed(_ context.Context, provider string) error {
+	e := s.entry(provider)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.state = StateOpen
+	e.cooldownUntil = time.Now().Add(time.Duration(s.cfg.CooldownSeconds) * time.Second)
+	e.probeInFlight = false
+	return nil
+}
+
+// GetStats returns a snapshot of the provider's circuit stats.
+func (s *MemoryStore) GetStats(_ context.Context, provider string) (*ProviderStats, error) {
+	e := s.entry(provider)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	state := s.stateUnlocked(e)
+	stats := &ProviderStats{
+		State:    state,
+		Failures: len(e.failures),
+	}
+	if !e.cooldownUntil.IsZero() {
+		t := e.cooldownUntil
+		stats.CooldownUntil = &t
+	}
+	return stats, nil
+}
+
+// TryStartProbe attempts to acquire the probe slot in half-open state.
+// Returns true if this goroutine should send the probe, false if another
+// goroutine already claimed it (fast-fail the request instead).
+func (s *MemoryStore) TryStartProbe(provider string) bool {
+	e := s.entry(provider)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.probeInFlight {
+		return false
+	}
+	e.probeInFlight = true
+	return true
+}

--- a/internal/circuit/memory.go
+++ b/internal/circuit/memory.go
@@ -6,13 +6,33 @@ import (
 	"time"
 )
 
+// maxFailureWindowEntries caps the number of per-provider failure timestamps
+// the MemoryStore keeps in the sliding window.  Without a cap a sustained
+// failure burst can cause the slice to grow O(failures-in-window), which on
+// a long WindowSeconds setting is an unbounded-ish memory footprint per
+// provider.  Once the cap is reached we drop the oldest entries; since the
+// threshold check only cares about `len >= threshold`, this cap cannot
+// cause a false negative (if we already hit the cap we already tripped the
+// circuit several orders of magnitude ago).
+const maxFailureWindowEntries = 4096
+
+// probeWatchdogTTL bounds how long a probeInFlight=true flag can persist
+// without progress before TryStartProbe considers it stale and reclaims
+// the slot.  This defends against the degenerate case where a probe's
+// goroutine exits (panic, ctx cancellation, deferred cleanup skipped)
+// without clearing the flag, which would otherwise starve the circuit
+// permanently in this process.  Chosen generously so a healthy probe
+// (which typically completes in < 30 s) is never reclaimed prematurely.
+const probeWatchdogTTL = 5 * time.Minute
+
 // memoryEntry holds per-provider circuit state for the in-memory store.
 type memoryEntry struct {
 	mu            sync.Mutex
 	state         State
 	failures      []time.Time // sliding window: timestamps of terminal failures
 	cooldownUntil time.Time
-	probeInFlight bool // prevents multiple concurrent probes in half-open
+	probeInFlight bool      // prevents multiple concurrent probes in half-open
+	probeStartAt  time.Time // watchdog timestamp; see probeWatchdogTTL
 }
 
 // MemoryStore is a single-process, mutex-backed circuit breaker store.
@@ -80,6 +100,14 @@ func (s *MemoryStore) RecordTerminalFailure(_ context.Context, provider string) 
 			pruned = append(pruned, t)
 		}
 	}
+	// Apply a hard count-based cap as a belt-and-braces defence against a
+	// sustained failure flood outpacing WindowSeconds pruning.  We drop
+	// the oldest entries rather than the newest so that when the failures
+	// eventually subside the most recent ones accurately reflect the
+	// freshest state.
+	if len(pruned) > maxFailureWindowEntries {
+		pruned = pruned[len(pruned)-maxFailureWindowEntries:]
+	}
 	e.failures = pruned
 
 	// Open the circuit if we've crossed the threshold.
@@ -101,6 +129,7 @@ func (s *MemoryStore) RecordSuccess(_ context.Context, provider string) error {
 	e.failures = e.failures[:0]
 	e.cooldownUntil = time.Time{}
 	e.probeInFlight = false
+	e.probeStartAt = time.Time{}
 	return nil
 }
 
@@ -112,6 +141,21 @@ func (s *MemoryStore) RecordProbeFailed(_ context.Context, provider string) erro
 	e.state = StateOpen
 	e.cooldownUntil = time.Now().Add(time.Duration(s.cfg.CooldownSeconds) * time.Second)
 	e.probeInFlight = false
+	e.probeStartAt = time.Time{}
+	return nil
+}
+
+// ReleaseProbe releases the probe slot without changing the circuit state.
+// Used when the probe did not produce a signal we should credit — e.g.
+// the caller's request context was cancelled or its deadline expired, so
+// the "success or failure" of the upstream call does not reflect on the
+// provider's health.  Safe to call multiple times.
+func (s *MemoryStore) ReleaseProbe(_ context.Context, provider string) error {
+	e := s.entry(provider)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.probeInFlight = false
+	e.probeStartAt = time.Time{}
 	return nil
 }
 
@@ -136,13 +180,29 @@ func (s *MemoryStore) GetStats(_ context.Context, provider string) (*ProviderSta
 // TryStartProbe attempts to acquire the probe slot in half-open state.
 // Returns true if this goroutine should send the probe, false if another
 // goroutine already claimed it (fast-fail the request instead).
-func (s *MemoryStore) TryStartProbe(provider string) bool {
+//
+// The ctx argument is accepted for signature parity with RedisStore (the
+// distributed backend); in-memory coordination is synchronous and does not
+// consult it.
+//
+// A watchdog (see probeWatchdogTTL) forcibly reclaims a stale in-flight
+// flag whose probeStartAt is older than the TTL.  Without this, a probe
+// goroutine that exits before clearing probeInFlight (e.g. via a panic
+// in the HTTP transport, an early context cancellation that skips the
+// deferred cleanup, or a bug in caller wiring) would permanently starve
+// future probes on this instance.
+func (s *MemoryStore) TryStartProbe(_ context.Context, provider string) bool {
 	e := s.entry(provider)
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	now := time.Now()
 	if e.probeInFlight {
-		return false
+		if e.probeStartAt.IsZero() || now.Sub(e.probeStartAt) < probeWatchdogTTL {
+			return false
+		}
+		// Stale flag — reclaim it.
 	}
 	e.probeInFlight = true
+	e.probeStartAt = now
 	return true
 }

--- a/internal/circuit/memory_test.go
+++ b/internal/circuit/memory_test.go
@@ -172,10 +172,46 @@ func TestMemoryStore_GetStats(t *testing.T) {
 	}
 }
 
-func TestMemoryStore_TryStartProbe(t *testing.T) {
-	s := NewMemoryStore(defaultConfig())
+func TestMemoryStore_GetStatsPrunesExpiredFailures(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.WindowSeconds = 1
+	s := NewMemoryStore(cfg)
 	ctx := context.Background()
 
+	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	e := s.entry("openai")
+	e.mu.Lock()
+	e.failures[0] = time.Now().Add(-2 * time.Second)
+	e.mu.Unlock()
+
+	stats, err := s.GetStats(ctx, "openai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Failures != 0 {
+		t.Fatalf("want expired failures pruned from stats, got %d", stats.Failures)
+	}
+}
+
+func TestMemoryStore_TryStartProbe(t *testing.T) {
+	cfg := Config{
+		Enabled:          true,
+		Backend:          "memory",
+		FailureThreshold: 1,
+		WindowSeconds:    10,
+		CooldownSeconds:  1,
+	}.Defaults()
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	if s.TryStartProbe(ctx, "openai") {
+		t.Fatal("TryStartProbe should return false before half-open state")
+	}
+	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	time.Sleep(1100 * time.Millisecond)
+	if state, _ := s.GetState(ctx, "openai"); state != StateHalfOpen {
+		t.Fatalf("circuit should be half-open after cooldown, got %s", state)
+	}
 	// First attempt should succeed.
 	if !s.TryStartProbe(ctx, "openai") {
 		t.Fatal("first TryStartProbe should return true")

--- a/internal/circuit/memory_test.go
+++ b/internal/circuit/memory_test.go
@@ -121,22 +121,36 @@ func TestMemoryStore_SlidingWindowExpiry(t *testing.T) {
 	cfg := Config{
 		Enabled:          true,
 		FailureThreshold: 3,
-		WindowSeconds:    1, // 1 second window for test speed
+		WindowSeconds:    60,
 	}.Defaults()
 	s := NewMemoryStore(cfg)
 	ctx := context.Background()
 
-	// Record 2 failures.
+	// Record 2 failures at the current time.
 	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
 	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
 
-	// Wait for the window to expire.
-	time.Sleep(1100 * time.Millisecond)
+	// Rewind the recorded failure timestamps so they fall outside the
+	// sliding window — this is equivalent to waiting out the window but
+	// does not introduce a wall-clock sleep, which was previously the
+	// slowest test in the package and occasionally flaked on busy CI.
+	e := s.entry("openai")
+	e.mu.Lock()
+	rewound := time.Now().Add(-2 * time.Duration(cfg.WindowSeconds) * time.Second)
+	for i := range e.failures {
+		e.failures[i] = rewound
+	}
+	e.mu.Unlock()
 
-	// One more failure — the window is now clean, so we should still be closed.
+	// One more failure — the previous two are now outside the window so
+	// the count should be exactly 1 and the circuit should stay closed.
 	st, _ := s.RecordTerminalFailure(ctx, "openai")
 	if st != StateClosed {
 		t.Fatalf("want StateClosed after window expiry, got %s", st)
+	}
+	stats, _ := s.GetStats(ctx, "openai")
+	if stats.Failures != 1 {
+		t.Fatalf("want 1 failure after sliding-window prune, got %d", stats.Failures)
 	}
 }
 
@@ -160,13 +174,14 @@ func TestMemoryStore_GetStats(t *testing.T) {
 
 func TestMemoryStore_TryStartProbe(t *testing.T) {
 	s := NewMemoryStore(defaultConfig())
+	ctx := context.Background()
 
 	// First attempt should succeed.
-	if !s.TryStartProbe("openai") {
+	if !s.TryStartProbe(ctx, "openai") {
 		t.Fatal("first TryStartProbe should return true")
 	}
 	// Second attempt while probe is in flight should fail.
-	if s.TryStartProbe("openai") {
+	if s.TryStartProbe(ctx, "openai") {
 		t.Fatal("second TryStartProbe should return false")
 	}
 }

--- a/internal/circuit/memory_test.go
+++ b/internal/circuit/memory_test.go
@@ -1,0 +1,190 @@
+package circuit
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func defaultConfig() Config {
+	return Config{
+		Enabled:          true,
+		Backend:          "memory",
+		FailureThreshold: 3,
+		WindowSeconds:    10,
+		CooldownSeconds:  5,
+	}.Defaults()
+}
+
+func TestMemoryStore_InitialStateClosed(t *testing.T) {
+	s := NewMemoryStore(defaultConfig())
+	state, err := s.GetState(context.Background(), "openai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != StateClosed {
+		t.Fatalf("want StateClosed, got %s", state)
+	}
+}
+
+func TestMemoryStore_CircuitOpensAtThreshold(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.FailureThreshold = 3
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		st, err := s.RecordTerminalFailure(ctx, "openai")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if st != StateClosed {
+			t.Fatalf("expected StateClosed after %d failures, got %s", i+1, st)
+		}
+	}
+
+	st, err := s.RecordTerminalFailure(ctx, "openai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st != StateOpen {
+		t.Fatalf("expected StateOpen after 3 failures, got %s", st)
+	}
+}
+
+func TestMemoryStore_RecordSuccess_ClosesCircuit(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.FailureThreshold = 1
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	s.RecordTerminalFailure(ctx, "anthropic") //nolint:errcheck
+	s.RecordSuccess(ctx, "anthropic")         //nolint:errcheck
+
+	state, _ := s.GetState(ctx, "anthropic")
+	if state != StateClosed {
+		t.Fatalf("want StateClosed after success, got %s", state)
+	}
+}
+
+func TestMemoryStore_HalfOpenAfterCooldown(t *testing.T) {
+	cfg := Config{
+		Enabled:          true,
+		FailureThreshold: 1,
+		WindowSeconds:    60,
+		CooldownSeconds:  0, // will be set to 1ns via manipulation
+	}.Defaults()
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	// Trip the circuit.
+	s.RecordTerminalFailure(ctx, "gemini") //nolint:errcheck
+
+	// Manually set the cooldown to the past so half-open transition is tested.
+	e := s.entry("gemini")
+	e.mu.Lock()
+	e.cooldownUntil = time.Now().Add(-1 * time.Second) // expired
+	e.mu.Unlock()
+
+	state, _ := s.GetState(ctx, "gemini")
+	if state != StateHalfOpen {
+		t.Fatalf("want StateHalfOpen after cooldown expiry, got %s", state)
+	}
+}
+
+func TestMemoryStore_ProbeFailed_ReOpensCircuit(t *testing.T) {
+	cfg := Config{
+		Enabled:          true,
+		FailureThreshold: 1,
+		WindowSeconds:    60,
+		CooldownSeconds:  10,
+	}.Defaults()
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	// Manually expire cooldown.
+	e := s.entry("openai")
+	e.mu.Lock()
+	e.cooldownUntil = time.Now().Add(-1 * time.Second)
+	e.mu.Unlock()
+
+	// Probe fails → should re-open.
+	s.RecordProbeFailed(ctx, "openai") //nolint:errcheck
+	state, _ := s.GetState(ctx, "openai")
+	if state != StateOpen {
+		t.Fatalf("want StateOpen after probe failure, got %s", state)
+	}
+}
+
+func TestMemoryStore_SlidingWindowExpiry(t *testing.T) {
+	cfg := Config{
+		Enabled:          true,
+		FailureThreshold: 3,
+		WindowSeconds:    1, // 1 second window for test speed
+	}.Defaults()
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	// Record 2 failures.
+	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+
+	// Wait for the window to expire.
+	time.Sleep(1100 * time.Millisecond)
+
+	// One more failure — the window is now clean, so we should still be closed.
+	st, _ := s.RecordTerminalFailure(ctx, "openai")
+	if st != StateClosed {
+		t.Fatalf("want StateClosed after window expiry, got %s", st)
+	}
+}
+
+func TestMemoryStore_GetStats(t *testing.T) {
+	cfg := defaultConfig()
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	s.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	stats, err := s.GetStats(ctx, "openai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.State != StateClosed {
+		t.Fatalf("want StateClosed, got %s", stats.State)
+	}
+	if stats.Failures != 1 {
+		t.Fatalf("want 1 failure, got %d", stats.Failures)
+	}
+}
+
+func TestMemoryStore_TryStartProbe(t *testing.T) {
+	s := NewMemoryStore(defaultConfig())
+
+	// First attempt should succeed.
+	if !s.TryStartProbe("openai") {
+		t.Fatal("first TryStartProbe should return true")
+	}
+	// Second attempt while probe is in flight should fail.
+	if s.TryStartProbe("openai") {
+		t.Fatal("second TryStartProbe should return false")
+	}
+}
+
+func TestMemoryStore_MultipleProviders_Independent(t *testing.T) {
+	cfg := Config{Enabled: true, FailureThreshold: 1, WindowSeconds: 60, CooldownSeconds: 300}.Defaults()
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	s.RecordTerminalFailure(ctx, "anthropic") //nolint:errcheck
+
+	openAIState, _ := s.GetState(ctx, "openai")
+	if openAIState != StateClosed {
+		t.Fatalf("openai should be unaffected by anthropic failure, got %s", openAIState)
+	}
+
+	anthropicState, _ := s.GetState(ctx, "anthropic")
+	if anthropicState != StateOpen {
+		t.Fatalf("anthropic should be Open, got %s", anthropicState)
+	}
+}

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -1,0 +1,193 @@
+package circuit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+const (
+	// Redis key prefixes.
+	redisKeyFailures = "cb:failures:" // sorted set of failure timestamps
+	redisKeyState    = "cb:state:"    // string: "open" | "half_open" (absence = closed)
+	redisKeyProbe    = "cb:probe:"    // short-lived lock for half-open probe slot
+)
+
+// RedisStore is a distributed, Redis-backed circuit breaker store.  It uses a
+// sorted set per provider to implement the sliding-window failure counter, and
+// a keyed string for open/half-open state with a TTL-based cooldown.
+type RedisStore struct {
+	cfg Config
+	rdb *redis.Client
+}
+
+// NewRedisStore constructs a RedisStore connected to the address in cfg.
+func NewRedisStore(cfg Config) (*RedisStore, error) {
+	cfg = cfg.Defaults()
+	if cfg.RedisAddress == "" {
+		return nil, fmt.Errorf("circuit.RedisStore: redis address is required")
+	}
+	client := redis.NewClient(&redis.Options{
+		Addr:     cfg.RedisAddress,
+		Password: cfg.RedisPassword,
+		DB:       cfg.RedisDB,
+	})
+	return &RedisStore{cfg: cfg, rdb: client}, nil
+}
+
+// failuresKey returns the sorted-set key for a provider's failure timestamps.
+func (s *RedisStore) failuresKey(provider string) string {
+	return redisKeyFailures + provider
+}
+
+// stateKey returns the state string key for a provider.
+func (s *RedisStore) stateKey(provider string) string {
+	return redisKeyState + provider
+}
+
+// probeKey returns the probe-lock key for a provider.
+func (s *RedisStore) probeKey(provider string) string {
+	return redisKeyProbe + provider
+}
+
+// GetState returns the current circuit state, honouring the TTL-based
+// cooldown (Open state key expires → transitions to HalfOpen).
+func (s *RedisStore) GetState(ctx context.Context, provider string) (State, error) {
+	val, err := s.rdb.Get(ctx, s.stateKey(provider)).Result()
+	if err == redis.Nil {
+		return StateClosed, nil
+	}
+	if err != nil {
+		// On Redis errors, fail open (treat as closed) to avoid taking down the
+		// service because of a Redis blip.
+		return StateClosed, nil
+	}
+	switch val {
+	case "open":
+		return StateOpen, nil
+	case "half_open":
+		return StateHalfOpen, nil
+	default:
+		return StateClosed, nil
+	}
+}
+
+// luaRecordFailure atomically adds a failure timestamp, prunes old ones, and
+// opens the circuit if the threshold is crossed.
+//
+// KEYS[1] = failures sorted set
+// KEYS[2] = state string key
+// ARGV[1] = current unix timestamp (float, for ZADD score)
+// ARGV[2] = window cutoff unix timestamp (float, for ZREMRANGEBYSCORE)
+// ARGV[3] = threshold (int)
+// ARGV[4] = cooldown duration in seconds (int)
+//
+// Returns: new state string ("closed" | "open")
+var luaRecordFailure = redis.NewScript(`
+local fkey   = KEYS[1]
+local skey   = KEYS[2]
+local now    = tonumber(ARGV[1])
+local cutoff = tonumber(ARGV[2])
+local thresh = tonumber(ARGV[3])
+local cd     = tonumber(ARGV[4])
+
+-- Add the new failure and prune the window.
+redis.call('ZADD', fkey, now, tostring(now))
+redis.call('ZREMRANGEBYSCORE', fkey, '-inf', cutoff)
+redis.call('EXPIRE', fkey, math.ceil(tonumber(ARGV[4]) * 2))
+
+local count = redis.call('ZCARD', fkey)
+
+-- Check current state; only open if currently closed.
+local cur = redis.call('GET', skey)
+if cur == false then cur = 'closed' end
+
+if tonumber(count) >= thresh and cur == 'closed' then
+	redis.call('SET', skey, 'open', 'EX', cd)
+	return 'open'
+end
+
+return cur
+`)
+
+// RecordTerminalFailure records one failure and returns the new state.
+func (s *RedisStore) RecordTerminalFailure(ctx context.Context, provider string) (State, error) {
+	now := float64(time.Now().UnixNano()) / 1e9
+	cutoff := now - float64(s.cfg.WindowSeconds)
+
+	res, err := luaRecordFailure.Run(ctx, s.rdb,
+		[]string{s.failuresKey(provider), s.stateKey(provider)},
+		now, cutoff, s.cfg.FailureThreshold, s.cfg.CooldownSeconds,
+	).Text()
+	if err != nil {
+		// On Redis error fail safe: return closed so we don't block traffic.
+		return StateClosed, nil
+	}
+	switch res {
+	case "open":
+		return StateOpen, nil
+	case "half_open":
+		return StateHalfOpen, nil
+	default:
+		return StateClosed, nil
+	}
+}
+
+// RecordSuccess closes the circuit and removes all failure history.
+func (s *RedisStore) RecordSuccess(ctx context.Context, provider string) error {
+	pipe := s.rdb.Pipeline()
+	pipe.Del(ctx, s.stateKey(provider))
+	pipe.Del(ctx, s.failuresKey(provider))
+	pipe.Del(ctx, s.probeKey(provider))
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// RecordProbeFailed re-opens the circuit for another full cooldown.
+func (s *RedisStore) RecordProbeFailed(ctx context.Context, provider string) error {
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, s.stateKey(provider), "open",
+		time.Duration(s.cfg.CooldownSeconds)*time.Second)
+	pipe.Del(ctx, s.probeKey(provider))
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// GetStats returns a snapshot of circuit stats for the provider.
+func (s *RedisStore) GetStats(ctx context.Context, provider string) (*ProviderStats, error) {
+	state, err := s.GetState(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	stats := &ProviderStats{State: state}
+
+	// Count failures in the current window.
+	now := float64(time.Now().UnixNano()) / 1e9
+	cutoff := now - float64(s.cfg.WindowSeconds)
+	count, err := s.rdb.ZCount(ctx, s.failuresKey(provider),
+		fmt.Sprintf("%f", cutoff), "+inf").Result()
+	if err == nil {
+		stats.Failures = int(count)
+	}
+
+	// If open, try to surface the cooldown expiry from the key TTL.
+	if state == StateOpen {
+		dur, err := s.rdb.TTL(ctx, s.stateKey(provider)).Result()
+		if err == nil && dur > 0 {
+			t := time.Now().Add(dur)
+			stats.CooldownUntil = &t
+		}
+	}
+
+	return stats, nil
+}
+
+// TryStartProbe atomically acquires the half-open probe slot.  Returns true
+// only if this call won the race; other callers should fast-fail.
+func (s *RedisStore) TryStartProbe(ctx context.Context, provider string) bool {
+	set, err := s.rdb.SetNX(ctx, s.probeKey(provider), "1",
+		5*time.Second).Result()
+	return err == nil && set
+}

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -9,10 +9,14 @@ import (
 )
 
 const (
-	// Redis key prefixes.
-	redisKeyFailures = "cb:failures:" // sorted set of failure timestamps
-	redisKeyState    = "cb:state:"    // string: "open" | "half_open" (absence = closed)
-	redisKeyProbe    = "cb:probe:"    // short-lived lock for half-open probe slot
+	// Redis key prefixes.  We namespace under `llm:cb:` so the circuit
+	// breaker can safely share a Redis instance (and database) with other
+	// tenants — notably the Finch app, which also uses this cluster.
+	// Anything prefixed with `llm:cb:` is owned by the llm-proxy circuit
+	// breaker and may be wiped by operators at any time.
+	redisKeyFailures = "llm:cb:failures:" // sorted set of failure timestamps
+	redisKeyState    = "llm:cb:state:"    // string: "open" | "half_open" (absence = closed)
+	redisKeyProbe    = "llm:cb:probe:"    // short-lived lock for half-open probe slot
 )
 
 // RedisStore is a distributed, Redis-backed circuit breaker store.  It uses a
@@ -24,17 +28,59 @@ type RedisStore struct {
 }
 
 // NewRedisStore constructs a RedisStore connected to the address in cfg.
+//
+// Connection inputs are resolved in this order:
+//  1. If cfg.RedisURL is non-empty it is parsed via redis.ParseURL and its
+//     resulting Options form the baseline.
+//  2. Otherwise cfg.RedisAddress seeds the baseline Addr.
+//  3. The individual RedisPassword / RedisDB fields, when set, overlay
+//     whatever the URL parsed.  This lets us share Finch's Redis URL
+//     (from SSM) while pinning a dedicated DB to keep `llm:cb:*` keys
+//     isolated.
+//
+// Note: the Redis client is lazy — construction here does NOT require the
+// server to be reachable.  Connectivity is validated (soft-fail) by the
+// caller with a short-timeout PING; all steady-state ops on the Store
+// fail-open to StateClosed on Redis errors, so a Redis outage can never
+// cascade into a proxy outage.
 func NewRedisStore(cfg Config) (*RedisStore, error) {
 	cfg = cfg.Defaults()
-	if cfg.RedisAddress == "" {
-		return nil, fmt.Errorf("circuit.RedisStore: redis address is required")
+
+	var opts *redis.Options
+	if cfg.RedisURL != "" {
+		parsed, err := redis.ParseURL(cfg.RedisURL)
+		if err != nil {
+			return nil, fmt.Errorf("circuit.RedisStore: parse redis_url: %w", err)
+		}
+		opts = parsed
+	} else {
+		if cfg.RedisAddress == "" {
+			return nil, fmt.Errorf("circuit.RedisStore: redis address or url is required")
+		}
+		opts = &redis.Options{Addr: cfg.RedisAddress}
 	}
-	client := redis.NewClient(&redis.Options{
-		Addr:     cfg.RedisAddress,
-		Password: cfg.RedisPassword,
-		DB:       cfg.RedisDB,
-	})
+
+	// Per-field overlays.  We intentionally only overlay when the caller
+	// explicitly set a value — e.g. a password of "" means "don't
+	// override", not "force-clear", so operators can supply a URL with
+	// embedded credentials and leave RedisPassword unset.
+	if cfg.RedisPassword != "" {
+		opts.Password = cfg.RedisPassword
+	}
+	if cfg.RedisDB != 0 {
+		opts.DB = cfg.RedisDB
+	}
+
+	client := redis.NewClient(opts)
 	return &RedisStore{cfg: cfg, rdb: client}, nil
+}
+
+// Ping issues a bounded Redis PING to verify connectivity.  Intended for
+// one-shot startup health checks; callers should treat a non-nil error as
+// "Redis is currently unreachable" rather than fatal — the Store itself is
+// designed to fail-open on subsequent errors.
+func (s *RedisStore) Ping(ctx context.Context) error {
+	return s.rdb.Ping(ctx).Err()
 }
 
 // failuresKey returns the sorted-set key for a provider's failure timestamps.

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -3,6 +3,7 @@ package circuit
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -35,7 +36,10 @@ const (
 type RedisStore struct {
 	cfg Config
 	rdb *redis.Client
+	log *slog.Logger
 }
+
+const redisStorePingTimeout = 2 * time.Second
 
 // NewRedisStore constructs a RedisStore connected to the address in cfg.
 //
@@ -48,11 +52,9 @@ type RedisStore struct {
 //     (from SSM) while pinning a dedicated DB to keep `llm:cb:*` keys
 //     isolated.
 //
-// Note: the Redis client is lazy — construction here does NOT require the
-// server to be reachable.  Connectivity is validated (soft-fail) by the
-// caller with a short-timeout PING; all steady-state ops on the Store
-// fail-open to StateClosed on Redis errors, so a Redis outage can never
-// cascade into a proxy outage.
+// NewRedisStore validates connectivity with a short PING before returning.
+// Steady-state ops still fail-open to StateClosed on Redis errors, so a Redis
+// outage after startup can never cascade into a proxy outage.
 func NewRedisStore(cfg Config) (*RedisStore, error) {
 	cfg = cfg.Defaults()
 
@@ -82,7 +84,14 @@ func NewRedisStore(cfg Config) (*RedisStore, error) {
 	}
 
 	client := redis.NewClient(opts)
-	return &RedisStore{cfg: cfg, rdb: client}, nil
+	pingCtx, cancel := context.WithTimeout(context.Background(), redisStorePingTimeout)
+	err := client.Ping(pingCtx).Err()
+	cancel()
+	if err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("circuit.RedisStore: ping redis: %w", err)
+	}
+	return &RedisStore{cfg: cfg, rdb: client, log: slog.Default()}, nil
 }
 
 // Ping issues a bounded Redis PING to verify connectivity.  Intended for
@@ -136,6 +145,11 @@ func (s *RedisStore) GetState(ctx context.Context, provider string) (State, erro
 	if err != nil && err != redis.Nil {
 		// On Redis errors, fail open (treat as closed) to avoid taking down the
 		// service because of a Redis blip.
+		s.log.Warn("circuit.RedisStore: GetState failed open",
+			"provider", provider,
+			"error", err,
+			"ctx_err", ctx.Err(),
+		)
 		return StateClosed, nil
 	}
 	if err == nil {
@@ -219,6 +233,13 @@ func (s *RedisStore) RecordTerminalFailure(ctx context.Context, provider string)
 	).Text()
 	if err != nil {
 		// On Redis error fail safe: return closed so we don't block traffic.
+		s.log.Warn("circuit.RedisStore: luaRecordFailure failed open",
+			"provider", provider,
+			"script", "luaRecordFailure",
+			"redis_client", fmt.Sprintf("%p", s.rdb),
+			"error", err,
+			"ctx_err", ctx.Err(),
+		)
 		return StateClosed, nil
 	}
 	switch res {

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -3,6 +3,7 @@ package circuit
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
@@ -15,8 +16,17 @@ const (
 	// Anything prefixed with `llm:cb:` is owned by the llm-proxy circuit
 	// breaker and may be wiped by operators at any time.
 	redisKeyFailures = "llm:cb:failures:" // sorted set of failure timestamps
-	redisKeyState    = "llm:cb:state:"    // string: "open" | "half_open" (absence = closed)
+	redisKeyState    = "llm:cb:state:"    // string: "open" (TTL = cooldown); absence falls back to halfopen marker
+	redisKeyHalfOpen = "llm:cb:halfopen:" // marker: while present (and state is absent) the circuit is half-open
 	redisKeyProbe    = "llm:cb:probe:"    // short-lived lock for half-open probe slot
+
+	// halfOpenMarkerTTLMultiplier keeps the half-open marker alive long
+	// enough to outlive the open-state TTL expiry, so GetState can detect
+	// the Open → HalfOpen transition even if no traffic arrives for a
+	// while after the cooldown elapses.  If the marker eventually expires
+	// with no traffic, the circuit silently falls back to Closed — a safe
+	// default that matches MemoryStore's behaviour after a long idle.
+	halfOpenMarkerTTLMultiplier = 6
 )
 
 // RedisStore is a distributed, Redis-backed circuit breaker store.  It uses a
@@ -67,7 +77,7 @@ func NewRedisStore(cfg Config) (*RedisStore, error) {
 	if cfg.RedisPassword != "" {
 		opts.Password = cfg.RedisPassword
 	}
-	if cfg.RedisDB != 0 {
+	if cfg.RedisDBSet {
 		opts.DB = cfg.RedisDB
 	}
 
@@ -83,6 +93,15 @@ func (s *RedisStore) Ping(ctx context.Context) error {
 	return s.rdb.Ping(ctx).Err()
 }
 
+// Close releases the underlying Redis client's pooled connections.  Safe to
+// call multiple times; go-redis returns nil on subsequent calls.
+func (s *RedisStore) Close() error {
+	if s == nil || s.rdb == nil {
+		return nil
+	}
+	return s.rdb.Close()
+}
+
 // failuresKey returns the sorted-set key for a provider's failure timestamps.
 func (s *RedisStore) failuresKey(provider string) string {
 	return redisKeyFailures + provider
@@ -93,31 +112,48 @@ func (s *RedisStore) stateKey(provider string) string {
 	return redisKeyState + provider
 }
 
+// halfOpenKey returns the half-open marker key for a provider.
+func (s *RedisStore) halfOpenKey(provider string) string {
+	return redisKeyHalfOpen + provider
+}
+
 // probeKey returns the probe-lock key for a provider.
 func (s *RedisStore) probeKey(provider string) string {
 	return redisKeyProbe + provider
 }
 
-// GetState returns the current circuit state, honouring the TTL-based
-// cooldown (Open state key expires → transitions to HalfOpen).
+// GetState returns the current circuit state.
+//
+// The Open → HalfOpen transition is driven by TTL expiry: while the circuit
+// is open, stateKey holds "open" with a TTL equal to the cooldown, and a
+// companion halfOpenKey marker is set with a longer TTL.  When the stateKey
+// TTL elapses the marker is still present, so the next GetState returns
+// HalfOpen and the transport runs a probe.  If no traffic arrives before the
+// marker itself expires the circuit silently falls back to Closed — safe
+// default behaviour after a long idle.
 func (s *RedisStore) GetState(ctx context.Context, provider string) (State, error) {
 	val, err := s.rdb.Get(ctx, s.stateKey(provider)).Result()
-	if err == redis.Nil {
-		return StateClosed, nil
-	}
-	if err != nil {
+	if err != nil && err != redis.Nil {
 		// On Redis errors, fail open (treat as closed) to avoid taking down the
 		// service because of a Redis blip.
 		return StateClosed, nil
 	}
-	switch val {
-	case "open":
-		return StateOpen, nil
-	case "half_open":
-		return StateHalfOpen, nil
-	default:
-		return StateClosed, nil
+	if err == nil {
+		switch val {
+		case "open":
+			return StateOpen, nil
+		case "half_open":
+			return StateHalfOpen, nil
+		}
 	}
+
+	// stateKey is absent — consult the half-open marker to distinguish a
+	// fresh Closed circuit from one whose cooldown has just elapsed.
+	exists, hoErr := s.rdb.Exists(ctx, s.halfOpenKey(provider)).Result()
+	if hoErr == nil && exists == 1 {
+		return StateHalfOpen, nil
+	}
+	return StateClosed, nil
 }
 
 // luaRecordFailure atomically adds a failure timestamp, prunes old ones, and
@@ -125,33 +161,43 @@ func (s *RedisStore) GetState(ctx context.Context, provider string) (State, erro
 //
 // KEYS[1] = failures sorted set
 // KEYS[2] = state string key
+// KEYS[3] = half-open marker key
 // ARGV[1] = current unix timestamp (float, for ZADD score)
 // ARGV[2] = window cutoff unix timestamp (float, for ZREMRANGEBYSCORE)
 // ARGV[3] = threshold (int)
 // ARGV[4] = cooldown duration in seconds (int)
+// ARGV[5] = window duration in seconds (int)
+// ARGV[6] = half-open marker TTL in seconds (int)
 //
-// Returns: new state string ("closed" | "open")
+// Returns: new state string ("closed" | "open" | "half_open")
 var luaRecordFailure = redis.NewScript(`
 local fkey   = KEYS[1]
 local skey   = KEYS[2]
+local hkey   = KEYS[3]
 local now    = tonumber(ARGV[1])
 local cutoff = tonumber(ARGV[2])
 local thresh = tonumber(ARGV[3])
 local cd     = tonumber(ARGV[4])
+local win    = tonumber(ARGV[5])
+local hoTTL  = tonumber(ARGV[6])
 
--- Add the new failure and prune the window.
+-- Add the new failure and prune the window.  We keep the sorted set alive
+-- for at least one full window so the failure count survives even if no
+-- further failures arrive before the cooldown ends.
 redis.call('ZADD', fkey, now, tostring(now))
 redis.call('ZREMRANGEBYSCORE', fkey, '-inf', cutoff)
-redis.call('EXPIRE', fkey, math.ceil(tonumber(ARGV[4]) * 2))
+local fttl = cd * 2
+if win > fttl then fttl = win end
+redis.call('EXPIRE', fkey, math.ceil(fttl))
 
 local count = redis.call('ZCARD', fkey)
 
--- Check current state; only open if currently closed.
 local cur = redis.call('GET', skey)
 if cur == false then cur = 'closed' end
 
 if tonumber(count) >= thresh and cur == 'closed' then
 	redis.call('SET', skey, 'open', 'EX', cd)
+	redis.call('SET', hkey, '1', 'EX', hoTTL)
 	return 'open'
 end
 
@@ -164,8 +210,12 @@ func (s *RedisStore) RecordTerminalFailure(ctx context.Context, provider string)
 	cutoff := now - float64(s.cfg.WindowSeconds)
 
 	res, err := luaRecordFailure.Run(ctx, s.rdb,
-		[]string{s.failuresKey(provider), s.stateKey(provider)},
-		now, cutoff, s.cfg.FailureThreshold, s.cfg.CooldownSeconds,
+		[]string{s.failuresKey(provider), s.stateKey(provider), s.halfOpenKey(provider)},
+		now, cutoff,
+		s.cfg.FailureThreshold,
+		s.cfg.CooldownSeconds,
+		s.cfg.WindowSeconds,
+		s.cfg.CooldownSeconds*halfOpenMarkerTTLMultiplier,
 	).Text()
 	if err != nil {
 		// On Redis error fail safe: return closed so we don't block traffic.
@@ -185,6 +235,7 @@ func (s *RedisStore) RecordTerminalFailure(ctx context.Context, provider string)
 func (s *RedisStore) RecordSuccess(ctx context.Context, provider string) error {
 	pipe := s.rdb.Pipeline()
 	pipe.Del(ctx, s.stateKey(provider))
+	pipe.Del(ctx, s.halfOpenKey(provider))
 	pipe.Del(ctx, s.failuresKey(provider))
 	pipe.Del(ctx, s.probeKey(provider))
 	_, err := pipe.Exec(ctx)
@@ -193,9 +244,11 @@ func (s *RedisStore) RecordSuccess(ctx context.Context, provider string) error {
 
 // RecordProbeFailed re-opens the circuit for another full cooldown.
 func (s *RedisStore) RecordProbeFailed(ctx context.Context, provider string) error {
+	cd := time.Duration(s.cfg.CooldownSeconds) * time.Second
+	hoTTL := time.Duration(s.cfg.CooldownSeconds*halfOpenMarkerTTLMultiplier) * time.Second
 	pipe := s.rdb.Pipeline()
-	pipe.Set(ctx, s.stateKey(provider), "open",
-		time.Duration(s.cfg.CooldownSeconds)*time.Second)
+	pipe.Set(ctx, s.stateKey(provider), "open", cd)
+	pipe.Set(ctx, s.halfOpenKey(provider), "1", hoTTL)
 	pipe.Del(ctx, s.probeKey(provider))
 	_, err := pipe.Exec(ctx)
 	return err
@@ -230,10 +283,73 @@ func (s *RedisStore) GetStats(ctx context.Context, provider string) (*ProviderSt
 	return stats, nil
 }
 
+// probeLockTTL is how long a half-open probe slot stays reserved once a
+// caller wins the SetNX race.  A lease-refresher (see KeepProbeAlive)
+// periodically extends the TTL while the probe is in flight so we can
+// keep the initial TTL modest: short enough that a crashed caller never
+// starves the circuit for long, long enough that a slow-but-healthy
+// probe still fits inside one refresh interval.
+const probeLockTTL = 30 * time.Second
+
+// probeLockRefreshInterval is how often KeepProbeAlive extends the probe
+// lock's TTL while the probe is in flight.  Set to probeLockTTL/3 so a
+// single missed refresh tick (e.g. a brief Redis hiccup) still leaves a
+// full probeLockTTL/3 of headroom before the lock would actually expire.
+const probeLockRefreshInterval = probeLockTTL / 3
+
 // TryStartProbe atomically acquires the half-open probe slot.  Returns true
 // only if this call won the race; other callers should fast-fail.
 func (s *RedisStore) TryStartProbe(ctx context.Context, provider string) bool {
-	set, err := s.rdb.SetNX(ctx, s.probeKey(provider), "1",
-		5*time.Second).Result()
+	set, err := s.rdb.SetNX(ctx, s.probeKey(provider), "1", probeLockTTL).Result()
 	return err == nil && set
+}
+
+// ReleaseProbe drops the probe slot without changing the circuit state.
+// This is the right call when a probe did not produce a signal we want to
+// credit to the upstream (e.g. the caller's context was cancelled or its
+// deadline expired before the upstream responded), because in that case
+// the outcome tells us nothing about provider health.  Using SetNX + DEL
+// here matches the semantics of RecordSuccess / RecordProbeFailed, which
+// both also clear the probe key.
+func (s *RedisStore) ReleaseProbe(ctx context.Context, provider string) error {
+	return s.rdb.Del(ctx, s.probeKey(provider)).Err()
+}
+
+// KeepProbeAlive periodically extends the probe lock's TTL until the
+// returned stop function is called.  It is the Redis counterpart to the
+// MemoryStore's in-process probeInFlight flag: for the in-memory backend
+// there is no TTL so no refresh is required, but Redis imposes a TTL on
+// the SetNX lock so a slow-but-healthy probe (e.g. a legitimate long
+// LLM generation that exceeds probeLockTTL) could otherwise let a
+// second probe win the lock concurrently.
+//
+// The refresh goroutine uses context.Background() on purpose: if the
+// caller's request context is cancelled mid-probe, we do NOT want to
+// stop refreshing — the probe is still in flight at the HTTP layer
+// until RoundTrip returns, and a premature TTL expiry would allow a
+// parallel probe.  Callers must always invoke the returned stop
+// function (typically via defer) once the probe completes.
+func (s *RedisStore) KeepProbeAlive(provider string) (stop func()) {
+	done := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		ticker := time.NewTicker(probeLockRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				// Re-assert the TTL.  We use a bounded context rather
+				// than Background so the refresh op itself can't hang
+				// behind a Redis failure.
+				refreshCtx, cancel := context.WithTimeout(context.Background(), probeLockTTL)
+				_ = s.rdb.Expire(refreshCtx, s.probeKey(provider), probeLockTTL).Err()
+				cancel()
+			}
+		}
+	}()
+
+	return func() { once.Do(func() { close(done) }) }
 }

--- a/internal/circuit/redis_url_test.go
+++ b/internal/circuit/redis_url_test.go
@@ -33,16 +33,35 @@ func TestNewRedisStore_URLOnly(t *testing.T) {
 // cluster while pinning a dedicated circuit-breaker DB.
 func TestNewRedisStore_URLPlusDBOverlay(t *testing.T) {
 	s, err := NewRedisStore(Config{
-		Enabled:  true,
-		Backend:  "redis",
-		RedisURL: "redis://cache.example.com:6379/6", // Finch uses DB 6
-		RedisDB:  5,                                  // circuit breaker pinned to DB 5
+		Enabled:    true,
+		Backend:    "redis",
+		RedisURL:   "redis://cache.example.com:6379/6", // Finch uses DB 6
+		RedisDB:    5,                                  // circuit breaker pinned to DB 5
+		RedisDBSet: true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := s.rdb.Options().DB; got != 5 {
 		t.Fatalf("explicit RedisDB must override URL DB; got %d", got)
+	}
+}
+
+// TestNewRedisStore_URLPlusExplicitZeroDBOverlay confirms that an explicit
+// RedisDB=0 can override a DB encoded in the URL.
+func TestNewRedisStore_URLPlusExplicitZeroDBOverlay(t *testing.T) {
+	s, err := NewRedisStore(Config{
+		Enabled:    true,
+		Backend:    "redis",
+		RedisURL:   "redis://cache.example.com:6379/6",
+		RedisDB:    0,
+		RedisDBSet: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := s.rdb.Options().DB; got != 0 {
+		t.Fatalf("explicit RedisDB=0 must override URL DB; got %d", got)
 	}
 }
 
@@ -90,6 +109,7 @@ func TestNewRedisStore_AddressFallback(t *testing.T) {
 		RedisAddress:  "cache.example.com:6379",
 		RedisPassword: "pw",
 		RedisDB:       2,
+		RedisDBSet:    true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -122,5 +142,12 @@ func TestNewRedisStore_MalformedURL(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected parse error on malformed URL")
+	}
+	// We specifically want the factory error wrapper (parse redis_url),
+	// not some unrelated validation error — asserting on the wrapper
+	// prevents accidental changes where a future refactor would bypass
+	// redis.ParseURL and hide the underlying problem.
+	if !strings.Contains(err.Error(), "parse redis_url") {
+		t.Fatalf("error message should wrap the parse failure; got: %v", err)
 	}
 }

--- a/internal/circuit/redis_url_test.go
+++ b/internal/circuit/redis_url_test.go
@@ -1,0 +1,126 @@
+package circuit
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNewRedisStore_URLOnly verifies that a redis:// URL alone is sufficient
+// and the resulting client inherits host, DB, and password from the URL.
+func TestNewRedisStore_URLOnly(t *testing.T) {
+	s, err := NewRedisStore(Config{
+		Enabled:  true,
+		Backend:  "redis",
+		RedisURL: "redis://:supersecret@cache.example.com:6379/3",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	opts := s.rdb.Options()
+	if opts.Addr != "cache.example.com:6379" {
+		t.Fatalf("want Addr=cache.example.com:6379, got %q", opts.Addr)
+	}
+	if opts.Password != "supersecret" {
+		t.Fatalf("want Password=supersecret, got %q", opts.Password)
+	}
+	if opts.DB != 3 {
+		t.Fatalf("want DB=3, got %d", opts.DB)
+	}
+}
+
+// TestNewRedisStore_URLPlusDBOverlay confirms that an explicit RedisDB
+// overrides the DB encoded in the URL, so operators can share Finch's
+// cluster while pinning a dedicated circuit-breaker DB.
+func TestNewRedisStore_URLPlusDBOverlay(t *testing.T) {
+	s, err := NewRedisStore(Config{
+		Enabled:  true,
+		Backend:  "redis",
+		RedisURL: "redis://cache.example.com:6379/6", // Finch uses DB 6
+		RedisDB:  5,                                  // circuit breaker pinned to DB 5
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := s.rdb.Options().DB; got != 5 {
+		t.Fatalf("explicit RedisDB must override URL DB; got %d", got)
+	}
+}
+
+// TestNewRedisStore_URLPlusPasswordOverlay confirms the same for password.
+func TestNewRedisStore_URLPlusPasswordOverlay(t *testing.T) {
+	s, err := NewRedisStore(Config{
+		Enabled:       true,
+		Backend:       "redis",
+		RedisURL:      "redis://:urlpw@cache.example.com:6379/0",
+		RedisPassword: "overridepw",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := s.rdb.Options().Password; got != "overridepw" {
+		t.Fatalf("explicit RedisPassword must override URL password; got %q", got)
+	}
+}
+
+// TestNewRedisStore_EmptyPasswordLeavesURLAlone documents that an empty
+// RedisPassword is treated as "don't override" rather than "force blank".
+// This is the behaviour that lets operators pass a URL-with-credentials
+// while leaving the individual field unset.
+func TestNewRedisStore_EmptyPasswordLeavesURLAlone(t *testing.T) {
+	s, err := NewRedisStore(Config{
+		Enabled:       true,
+		Backend:       "redis",
+		RedisURL:      "redis://:fromurl@cache.example.com:6379/0",
+		RedisPassword: "",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := s.rdb.Options().Password; got != "fromurl" {
+		t.Fatalf("empty RedisPassword must NOT clear URL password; got %q", got)
+	}
+}
+
+// TestNewRedisStore_AddressFallback confirms that when no URL is provided
+// we still accept the legacy Address/Password/DB triple.
+func TestNewRedisStore_AddressFallback(t *testing.T) {
+	s, err := NewRedisStore(Config{
+		Enabled:       true,
+		Backend:       "redis",
+		RedisAddress:  "cache.example.com:6379",
+		RedisPassword: "pw",
+		RedisDB:       2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	opts := s.rdb.Options()
+	if opts.Addr != "cache.example.com:6379" || opts.Password != "pw" || opts.DB != 2 {
+		t.Fatalf("address-only fallback broken: %+v", opts)
+	}
+}
+
+// TestNewRedisStore_NeitherURLNorAddress is the "misconfigured" path —
+// must surface a clear error rather than build a zero-value client.
+func TestNewRedisStore_NeitherURLNorAddress(t *testing.T) {
+	_, err := NewRedisStore(Config{Enabled: true, Backend: "redis"})
+	if err == nil {
+		t.Fatalf("expected error when neither URL nor Address is set")
+	}
+	if !strings.Contains(err.Error(), "address or url") {
+		t.Fatalf("error message should mention missing URL/address; got: %v", err)
+	}
+}
+
+// TestNewRedisStore_MalformedURL surfaces parse errors rather than
+// silently producing a broken client.
+func TestNewRedisStore_MalformedURL(t *testing.T) {
+	_, err := NewRedisStore(Config{
+		Enabled:  true,
+		Backend:  "redis",
+		RedisURL: "not-a-url://garbage",
+	})
+	if err == nil {
+		t.Fatalf("expected parse error on malformed URL")
+	}
+}

--- a/internal/circuit/redis_url_test.go
+++ b/internal/circuit/redis_url_test.go
@@ -1,24 +1,104 @@
 package circuit
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
 	"strings"
 	"testing"
 )
 
+func newPingRedisServer(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen fake redis: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		for {
+			cmd, err := readRedisCommand(reader)
+			if err != nil || len(cmd) == 0 {
+				return
+			}
+			switch strings.ToUpper(cmd[0]) {
+			case "HELLO":
+				_, _ = conn.Write([]byte("%1\r\n+server\r\n+redis\r\n"))
+			case "PING":
+				_, _ = conn.Write([]byte("+PONG\r\n"))
+				return
+			default:
+				_, _ = conn.Write([]byte("+OK\r\n"))
+			}
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+func readRedisCommand(reader *bufio.Reader) ([]string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "*") {
+		return nil, fmt.Errorf("unexpected redis command prefix: %q", line)
+	}
+	count, err := strconv.Atoi(strings.TrimPrefix(line, "*"))
+	if err != nil {
+		return nil, err
+	}
+
+	parts := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		lenLine, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		lenLine = strings.TrimSpace(lenLine)
+		if !strings.HasPrefix(lenLine, "$") {
+			return nil, fmt.Errorf("unexpected redis bulk prefix: %q", lenLine)
+		}
+		n, err := strconv.Atoi(strings.TrimPrefix(lenLine, "$"))
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, n+2)
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return nil, err
+		}
+		parts = append(parts, string(buf[:n]))
+	}
+	return parts, nil
+}
+
 // TestNewRedisStore_URLOnly verifies that a redis:// URL alone is sufficient
 // and the resulting client inherits host, DB, and password from the URL.
 func TestNewRedisStore_URLOnly(t *testing.T) {
+	addr := newPingRedisServer(t)
 	s, err := NewRedisStore(Config{
 		Enabled:  true,
 		Backend:  "redis",
-		RedisURL: "redis://:supersecret@cache.example.com:6379/3",
+		RedisURL: "redis://:supersecret@" + addr + "/3",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	opts := s.rdb.Options()
-	if opts.Addr != "cache.example.com:6379" {
-		t.Fatalf("want Addr=cache.example.com:6379, got %q", opts.Addr)
+	if opts.Addr != addr {
+		t.Fatalf("want Addr=%s, got %q", addr, opts.Addr)
 	}
 	if opts.Password != "supersecret" {
 		t.Fatalf("want Password=supersecret, got %q", opts.Password)
@@ -32,11 +112,12 @@ func TestNewRedisStore_URLOnly(t *testing.T) {
 // overrides the DB encoded in the URL, so operators can share Finch's
 // cluster while pinning a dedicated circuit-breaker DB.
 func TestNewRedisStore_URLPlusDBOverlay(t *testing.T) {
+	addr := newPingRedisServer(t)
 	s, err := NewRedisStore(Config{
 		Enabled:    true,
 		Backend:    "redis",
-		RedisURL:   "redis://cache.example.com:6379/6", // Finch uses DB 6
-		RedisDB:    5,                                  // circuit breaker pinned to DB 5
+		RedisURL:   "redis://" + addr + "/6", // Finch uses DB 6
+		RedisDB:    5,                        // circuit breaker pinned to DB 5
 		RedisDBSet: true,
 	})
 	if err != nil {
@@ -50,10 +131,11 @@ func TestNewRedisStore_URLPlusDBOverlay(t *testing.T) {
 // TestNewRedisStore_URLPlusExplicitZeroDBOverlay confirms that an explicit
 // RedisDB=0 can override a DB encoded in the URL.
 func TestNewRedisStore_URLPlusExplicitZeroDBOverlay(t *testing.T) {
+	addr := newPingRedisServer(t)
 	s, err := NewRedisStore(Config{
 		Enabled:    true,
 		Backend:    "redis",
-		RedisURL:   "redis://cache.example.com:6379/6",
+		RedisURL:   "redis://" + addr + "/6",
 		RedisDB:    0,
 		RedisDBSet: true,
 	})
@@ -67,10 +149,11 @@ func TestNewRedisStore_URLPlusExplicitZeroDBOverlay(t *testing.T) {
 
 // TestNewRedisStore_URLPlusPasswordOverlay confirms the same for password.
 func TestNewRedisStore_URLPlusPasswordOverlay(t *testing.T) {
+	addr := newPingRedisServer(t)
 	s, err := NewRedisStore(Config{
 		Enabled:       true,
 		Backend:       "redis",
-		RedisURL:      "redis://:urlpw@cache.example.com:6379/0",
+		RedisURL:      "redis://:urlpw@" + addr + "/0",
 		RedisPassword: "overridepw",
 	})
 	if err != nil {
@@ -86,10 +169,11 @@ func TestNewRedisStore_URLPlusPasswordOverlay(t *testing.T) {
 // This is the behaviour that lets operators pass a URL-with-credentials
 // while leaving the individual field unset.
 func TestNewRedisStore_EmptyPasswordLeavesURLAlone(t *testing.T) {
+	addr := newPingRedisServer(t)
 	s, err := NewRedisStore(Config{
 		Enabled:       true,
 		Backend:       "redis",
-		RedisURL:      "redis://:fromurl@cache.example.com:6379/0",
+		RedisURL:      "redis://:fromurl@" + addr + "/0",
 		RedisPassword: "",
 	})
 	if err != nil {
@@ -103,10 +187,11 @@ func TestNewRedisStore_EmptyPasswordLeavesURLAlone(t *testing.T) {
 // TestNewRedisStore_AddressFallback confirms that when no URL is provided
 // we still accept the legacy Address/Password/DB triple.
 func TestNewRedisStore_AddressFallback(t *testing.T) {
+	addr := newPingRedisServer(t)
 	s, err := NewRedisStore(Config{
 		Enabled:       true,
 		Backend:       "redis",
-		RedisAddress:  "cache.example.com:6379",
+		RedisAddress:  addr,
 		RedisPassword: "pw",
 		RedisDB:       2,
 		RedisDBSet:    true,
@@ -115,7 +200,7 @@ func TestNewRedisStore_AddressFallback(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	opts := s.rdb.Options()
-	if opts.Addr != "cache.example.com:6379" || opts.Password != "pw" || opts.DB != 2 {
+	if opts.Addr != addr || opts.Password != "pw" || opts.DB != 2 {
 		t.Fatalf("address-only fallback broken: %+v", opts)
 	}
 }

--- a/internal/circuit/store.go
+++ b/internal/circuit/store.go
@@ -1,0 +1,35 @@
+package circuit
+
+import "context"
+
+// Store abstracts the shared state backend for the circuit breaker.  Both the
+// in-memory and Redis implementations satisfy this interface.
+type Store interface {
+	// GetState returns the current circuit state for the given provider.
+	GetState(ctx context.Context, provider string) (State, error)
+
+	// RecordTerminalFailure records one terminal degraded failure for provider.
+	// It returns the NEW state after recording, which may have just become Open
+	// if the failure pushed the count past the threshold.
+	RecordTerminalFailure(ctx context.Context, provider string) (State, error)
+
+	// RecordSuccess is called when a half-open probe succeeds.  It transitions
+	// the circuit to Closed and resets all failure counters.
+	RecordSuccess(ctx context.Context, provider string) error
+
+	// RecordProbeFailed is called when a half-open probe fails.  It
+	// transitions the circuit back to Open for another full cooldown period.
+	RecordProbeFailed(ctx context.Context, provider string) error
+
+	// GetStats returns health statistics for the provider (used in /health).
+	GetStats(ctx context.Context, provider string) (*ProviderStats, error)
+}
+
+// Factory returns the appropriate Store implementation based on the Backend
+// field of cfg.  "redis" → RedisStore, anything else → MemoryStore.
+func Factory(cfg Config) (Store, error) {
+	if cfg.Backend == "redis" {
+		return NewRedisStore(cfg)
+	}
+	return NewMemoryStore(cfg), nil
+}

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -26,8 +26,10 @@ type retryAttemptKey struct{}
 //   - records terminal failures in the Store and opens the circuit when the
 //     threshold is crossed;
 //   - performs a single probe request when the circuit is Half-Open;
-//   - injects MagicString into any degraded error response so Finch can detect
-//     it regardless of which SDK exception type surfaces the HTTP error.
+//   - injects Config.DegradedSignal into every synthesised degraded response
+//     body so downstream clients can reliably detect provider degradation
+//     even after SDK / framework exception wrapping hides headers and status
+//     codes (see DefaultDegradedSignal for the full rationale).
 type Transport struct {
 	inner    http.RoundTripper
 	store    Store
@@ -263,7 +265,7 @@ func (t *Transport) runProbe(req *http.Request) (*http.Response, error) {
 }
 
 // handleTerminalFailure records the failure, potentially opens the circuit,
-// and returns the appropriate response to Finch.
+// and returns the appropriate synthesised response to the caller.
 func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request) (*http.Response, error) {
 	newState, err := t.store.RecordTerminalFailure(ctx, t.provider)
 	if err != nil {
@@ -287,9 +289,10 @@ func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request
 // ─────────────────────────────────────────────────────────────────────────────
 
 // degradedResponse returns a synthetic HTTP 503 response whose JSON body
-// contains MagicString so Finch can detect provider degradation.
+// contains Config.DegradedSignal so downstream clients can detect
+// proxy-originated provider degradation (see DefaultDegradedSignal).
 func (t *Transport) degradedResponse(req *http.Request) *http.Response {
-	body := buildDegradedBody(t.provider)
+	body := buildDegradedBody(t.provider, t.cfg.DegradedSignal)
 	return &http.Response{
 		StatusCode: http.StatusServiceUnavailable,
 		Status:     "503 Service Unavailable",
@@ -306,7 +309,7 @@ func (t *Transport) degradedResponse(req *http.Request) *http.Response {
 	}
 }
 
-// rateLimitResponse returns a synthetic 429 without the MagicString — the
+// rateLimitResponse returns a synthetic 429 without the DegradedSignal — the
 // request is throttled but the provider is not considered degraded.
 func (t *Transport) rateLimitResponse() *http.Response {
 	body := []byte(`{"error":{"message":"Rate limit exceeded; please retry later.","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
@@ -325,10 +328,15 @@ func (t *Transport) rateLimitResponse() *http.Response {
 	}
 }
 
-// buildDegradedBody returns a JSON error body containing MagicString.
-func buildDegradedBody(provider string) []byte {
+// buildDegradedBody returns a JSON error body containing the configured
+// degraded signal.  An empty signal falls back to DefaultDegradedSignal so
+// the body is never unmarked.
+func buildDegradedBody(provider, signal string) []byte {
+	if signal == "" {
+		signal = DefaultDegradedSignal
+	}
 	msg := fmt.Sprintf("%s Provider %s is currently degraded or unavailable. Please try again later.",
-		MagicString, provider)
+		signal, provider)
 	body := map[string]interface{}{
 		"error": map[string]interface{}{
 			"message": msg,

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -1,0 +1,428 @@
+package circuit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// retryAttemptKey is the context key used to pass the current attempt index
+// down to the inner transport (used by the test-mode transport).
+type retryAttemptKey struct{}
+
+// Transport wraps an inner http.RoundTripper with circuit-breaker logic:
+//
+//   - checks the circuit state before every logical request;
+//   - retries transient (degraded-class) failures up to MaxTransientRetries;
+//   - retries rate-limit failures up to MaxRateLimitRetries with Retry-After
+//     backoff;
+//   - records terminal failures in the Store and opens the circuit when the
+//     threshold is crossed;
+//   - performs a single probe request when the circuit is Half-Open;
+//   - injects MagicString into any degraded error response so Finch can detect
+//     it regardless of which SDK exception type surfaces the HTTP error.
+type Transport struct {
+	inner    http.RoundTripper
+	store    Store
+	cfg      Config
+	provider string
+	log      *slog.Logger
+}
+
+// NewTransport wraps inner with circuit-breaker behaviour for provider.
+func NewTransport(inner http.RoundTripper, store Store, cfg Config, provider string, log *slog.Logger) *Transport {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Transport{
+		inner:    inner,
+		store:    store,
+		cfg:      cfg.Defaults(),
+		provider: provider,
+		log:      log,
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	// ── Test-mode: force_degraded fast path ───────────────────────────────
+	// force_transient_recover is handled inside runWithRetries so it can
+	// interact with the retry loop's attempt counter.
+	if testModeFromRequest(req) == TestModeForceDegraded {
+		t.log.Info("circuit: test-mode force_degraded", "provider", t.provider)
+		return t.degradedResponse(req), nil
+	}
+
+	// ── Circuit state check ───────────────────────────────────────────────
+	state, err := t.store.GetState(ctx, t.provider)
+	if err != nil {
+		t.log.Warn("circuit: GetState error, treating as closed", "provider", t.provider, "error", err)
+		state = StateClosed
+	}
+
+	switch state {
+	case StateOpen:
+		t.log.Info("circuit: fast-fail (circuit open)", "provider", t.provider)
+		return t.degradedResponse(req), nil
+
+	case StateHalfOpen:
+		return t.runProbe(req)
+
+	default: // StateClosed — normal path
+		return t.runWithRetries(req)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core retry loops
+// ─────────────────────────────────────────────────────────────────────────────
+
+// runWithRetries executes the request with the configured retry policies and
+// records terminal failures in the circuit store.
+func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	// Ensure the body can be re-read on retries.
+	if err := cacheBody(req); err != nil {
+		return nil, fmt.Errorf("circuit: cacheBody: %w", err)
+	}
+
+	var (
+		transientAttempts int
+		rateLimitAttempts int
+	)
+
+	// Track whether we've had any rate-limit failures for escalation logic.
+	var firstRateLimitAt time.Time
+
+	for {
+		attempt := transientAttempts + rateLimitAttempts
+		attemptReq := req.WithContext(context.WithValue(ctx, retryAttemptKey{}, attempt))
+		if attempt > 0 {
+			// Restore the body for the retry.
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return nil, fmt.Errorf("circuit: GetBody on retry: %w", err)
+				}
+				attemptReq.Body = body
+			}
+		}
+
+		// ── test-mode: force_transient_recover ────────────────────────────
+		// Fail on attempt 0, forward to the real inner transport on attempt 1+.
+		if testModeFromRequest(req) == TestModeForceTransientRecover {
+			if attempt == 0 {
+				t.log.Info("circuit: test-mode force_transient_recover (attempt 0 → fail)",
+					"provider", t.provider)
+				// Simulate a degraded failure and let the retry loop continue.
+				backoff := transientBackoff(transientAttempts)
+				t.sleep(ctx, backoff)
+				transientAttempts++
+				continue
+			}
+			// Strip the test mode header on retries so the real inner transport
+			// does not see it.
+			inner := attemptReq.Clone(ctx)
+			inner.Header.Del(TestModeHeader)
+			attemptReq = inner
+		}
+
+		resp, err := t.inner.RoundTrip(attemptReq)
+		fc := ClassifyResponse(t.provider, resp, err)
+
+		// ── Success ───────────────────────────────────────────────────────
+		if fc == FailureClassNone {
+			return resp, err
+		}
+
+		// ── Drain the response body before retrying so the connection is
+		//    returned to the pool cleanly.
+		if resp != nil {
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
+			resp.Body.Close()
+		}
+
+		retryAfterSec := retryAfterSeconds(resp)
+
+		// ── Rate-limit handling ───────────────────────────────────────────
+		if fc == FailureClassLocalRateLimit || fc == FailureClassGlobalRateLimit {
+			if rateLimitAttempts >= t.cfg.MaxRateLimitRetries {
+				t.log.Warn("circuit: rate-limit retries exhausted",
+					"provider", t.provider,
+					"attempts", rateLimitAttempts,
+					"class", fc,
+				)
+				// Escalate sustained global rate limits to degraded.
+				if fc == FailureClassGlobalRateLimit && !firstRateLimitAt.IsZero() {
+					elapsed := time.Since(firstRateLimitAt).Seconds()
+					if int(elapsed) >= t.cfg.GlobalRateLimitEscalationWindow {
+						t.log.Warn("circuit: global rate-limit escalated to provider_degraded",
+							"provider", t.provider,
+							"elapsed_seconds", elapsed,
+						)
+						return t.handleTerminalFailure(ctx, req)
+					}
+				}
+				// Return a synthetic rate-limit error (no magic string — not
+				// degraded, just throttled).
+				return t.rateLimitResponse(), nil
+			}
+			if fc == FailureClassGlobalRateLimit && firstRateLimitAt.IsZero() {
+				firstRateLimitAt = time.Now()
+			}
+			backoff := rateLimitBackoff(retryAfterSec, rateLimitAttempts)
+			t.log.Info("circuit: rate-limit backoff",
+				"provider", t.provider,
+				"class", fc,
+				"backoff_ms", backoff.Milliseconds(),
+				"attempt", rateLimitAttempts+1,
+			)
+			t.sleep(ctx, backoff)
+			rateLimitAttempts++
+			continue
+		}
+
+		// ── Degraded / transient handling ─────────────────────────────────
+		if fc == FailureClassDegraded {
+			if t.cfg.RetryContributionMode == "on" {
+				t.log.Info("circuit: retried failure contributing to degradation score",
+					"provider", t.provider, "attempt", transientAttempts)
+				t.store.RecordTerminalFailure(ctx, t.provider) //nolint:errcheck
+			} else if t.cfg.RetryContributionMode == "log" {
+				t.log.Info("circuit: retried failure would_have_contributed_to_degradation",
+					"provider", t.provider, "attempt", transientAttempts)
+			}
+
+			if transientAttempts >= t.cfg.MaxTransientRetries {
+				t.log.Warn("circuit: transient retries exhausted, recording terminal failure",
+					"provider", t.provider,
+					"attempts", transientAttempts,
+				)
+				return t.handleTerminalFailure(ctx, req)
+			}
+
+			backoff := transientBackoff(transientAttempts)
+			t.log.Info("circuit: transient backoff",
+				"provider", t.provider,
+				"backoff_ms", backoff.Milliseconds(),
+				"attempt", transientAttempts+1,
+			)
+			t.sleep(ctx, backoff)
+			transientAttempts++
+			continue
+		}
+
+		// ── Unknown / unclassifiable failure — pass through as-is ─────────
+		return resp, err
+	}
+}
+
+// runProbe executes a single half-open probe request (no retries).
+func (t *Transport) runProbe(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	// Only one goroutine/process should probe at a time.
+	type probeStarter interface {
+		TryStartProbe(provider string) bool
+	}
+	if ps, ok := t.store.(probeStarter); ok {
+		if !ps.TryStartProbe(t.provider) {
+			// Another probe is already in flight — fast-fail this request.
+			t.log.Info("circuit: half-open probe already in flight, fast-failing",
+				"provider", t.provider)
+			return t.degradedResponse(req), nil
+		}
+	}
+
+	resp, err := t.inner.RoundTrip(req)
+	fc := ClassifyResponse(t.provider, resp, err)
+
+	if fc == FailureClassNone {
+		t.log.Info("circuit: probe succeeded, closing circuit", "provider", t.provider)
+		t.store.RecordSuccess(ctx, t.provider) //nolint:errcheck
+		return resp, err
+	}
+
+	t.log.Warn("circuit: probe failed, re-opening circuit", "provider", t.provider)
+	if resp != nil {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		resp.Body.Close()
+	}
+	t.store.RecordProbeFailed(ctx, t.provider) //nolint:errcheck
+	return t.degradedResponse(req), nil
+}
+
+// handleTerminalFailure records the failure, potentially opens the circuit,
+// and returns the appropriate response to Finch.
+func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request) (*http.Response, error) {
+	newState, err := t.store.RecordTerminalFailure(ctx, t.provider)
+	if err != nil {
+		t.log.Error("circuit: RecordTerminalFailure error", "provider", t.provider, "error", err)
+	}
+
+	if newState == StateOpen {
+		t.log.Warn("circuit: threshold crossed — circuit opened",
+			"provider", t.provider)
+	}
+
+	t.log.Warn("circuit: terminal failure, returning degraded signal",
+		"provider", t.provider,
+		"new_state", newState.String(),
+	)
+	return t.degradedResponse(req), nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Synthetic response builders
+// ─────────────────────────────────────────────────────────────────────────────
+
+// degradedResponse returns a synthetic HTTP 503 response whose JSON body
+// contains MagicString so Finch can detect provider degradation.
+func (t *Transport) degradedResponse(req *http.Request) *http.Response {
+	body := buildDegradedBody(t.provider)
+	return &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     "503 Service Unavailable",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"Content-Type":            []string{"application/json"},
+			"X-Llm-Proxy-Error-Class": []string{string(FailureClassDegraded)},
+		},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}
+
+// rateLimitResponse returns a synthetic 429 without the MagicString — the
+// request is throttled but the provider is not considered degraded.
+func (t *Transport) rateLimitResponse() *http.Response {
+	body := []byte(`{"error":{"message":"Rate limit exceeded; please retry later.","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     "429 Too Many Requests",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"Content-Type":            []string{"application/json"},
+			"X-Llm-Proxy-Error-Class": []string{string(FailureClassLocalRateLimit)},
+		},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+// buildDegradedBody returns a JSON error body containing MagicString.
+func buildDegradedBody(provider string) []byte {
+	msg := fmt.Sprintf("%s Provider %s is currently degraded or unavailable. Please try again later.",
+		MagicString, provider)
+	body := map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": msg,
+			"type":    "provider_degraded",
+			"code":    "provider_degraded",
+		},
+	}
+	b, _ := json.Marshal(body)
+	return b
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backoff helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// transientBackoff returns a jittered backoff duration for transient failures.
+// attempt is 0-indexed (0 = first retry).
+func transientBackoff(attempt int) time.Duration {
+	base := 500 * time.Millisecond
+	exp := base * (1 << uint(attempt)) // 500ms, 1s, 2s, ...
+	jitter := time.Duration(rand.Int63n(int64(exp / 2)))
+	return exp + jitter
+}
+
+// rateLimitBackoff returns a backoff duration for rate-limit failures,
+// honouring a provider-supplied Retry-After value when available.
+func rateLimitBackoff(retryAfterSec, attempt int) time.Duration {
+	if retryAfterSec > 0 {
+		return time.Duration(retryAfterSec) * time.Second
+	}
+	base := 1 * time.Second
+	exp := base * (1 << uint(attempt)) // 1s, 2s, 4s, ...
+	jitter := time.Duration(rand.Int63n(int64(exp / 2)))
+	return exp + jitter
+}
+
+// retryAfterSeconds extracts the Retry-After header value as seconds.
+func retryAfterSeconds(resp *http.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return parseRetryAfterSeconds(resp.Header.Get("Retry-After"))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Misc helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// cacheBody reads req.Body into memory and replaces it with a NopCloser
+// backed by the bytes, setting GetBody so retries can re-read it.
+// A no-op if req.Body is nil or already has GetBody.
+func cacheBody(req *http.Request) error {
+	if req.Body == nil || req.GetBody != nil {
+		return nil
+	}
+	b, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		return err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(b))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(b)), nil
+	}
+	req.ContentLength = int64(len(b))
+	return nil
+}
+
+// sleep blocks for d, respecting context cancellation.
+func (t *Transport) sleep(ctx context.Context, d time.Duration) {
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+}
+
+// testModeFromRequest returns the test mode value from the header or, as a
+// fallback, the URL query parameter.
+func testModeFromRequest(req *http.Request) string {
+	if v := req.Header.Get(TestModeHeader); v != "" {
+		return v
+	}
+	if req.URL != nil {
+		return req.URL.Query().Get(TestModeQueryParam)
+	}
+	return ""
+}
+
+// ProviderFromPath derives the provider name from the URL path prefix
+// (e.g. "/openai/v1/chat/completions" → "openai").
+func ProviderFromPath(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	if idx := strings.Index(path, "/"); idx > 0 {
+		return path[:idx]
+	}
+	return path
+}

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -56,6 +56,17 @@ func NewTransport(inner http.RoundTripper, store Store, cfg Config, provider str
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
+	// ── Observe-only / log-mode fast path ─────────────────────────────────
+	// In ModeLog we intentionally skip the retry loop, fast-fail, and
+	// synthetic-response machinery entirely.  We just do one round trip,
+	// classify the result, record failures so /health and Redis counters
+	// are accurate, emit counterfactual logs, and hand the real response
+	// back to the caller.  This lets us roll out the feature to prod
+	// without any behavioural change to traffic.
+	if t.cfg.Mode == ModeLog {
+		return t.runObserveOnly(req)
+	}
+
 	// ── Test-mode: force_degraded fast path ───────────────────────────────
 	// force_transient_recover is handled inside runWithRetries so it can
 	// interact with the retry loop's attempt counter.
@@ -82,6 +93,51 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	default: // StateClosed — normal path
 		return t.runWithRetries(req)
 	}
+}
+
+// runObserveOnly performs a single pass-through RoundTrip, records observed
+// failures + emits counterfactual log lines, and returns the real upstream
+// response.  No retries, no synthetic responses, no fast-fail on open
+// circuit — this is the "shadow" rollout path (ModeLog).
+func (t *Transport) runObserveOnly(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	// Log what ModeEnforce *would* have done given the current state, but
+	// always let the real request through.
+	if state, err := t.store.GetState(ctx, t.provider); err == nil && state == StateOpen {
+		t.log.Info("circuit: log-mode would_have_fast_failed (circuit open, passing through)",
+			"provider", t.provider)
+	}
+
+	resp, err := t.inner.RoundTrip(req)
+	fc := ClassifyResponse(t.provider, resp, err)
+
+	switch fc {
+	case FailureClassDegraded:
+		// Record the failure so cross-instance counters and /health stats
+		// still reflect reality in shadow mode.  The Store is guaranteed
+		// to fail-open on Redis errors (returns StateClosed, no error),
+		// so this cannot cascade.
+		newState, recErr := t.store.RecordTerminalFailure(ctx, t.provider)
+		if recErr != nil {
+			t.log.Error("circuit: log-mode RecordTerminalFailure error",
+				"provider", t.provider, "error", recErr)
+		}
+		t.log.Info("circuit: log-mode terminal_failure_observed (no synthetic response, passing through)",
+			"provider", t.provider,
+			"would_be_new_state", newState.String(),
+		)
+
+	case FailureClassGlobalRateLimit:
+		t.log.Info("circuit: log-mode global_rate_limit_observed (passing through)",
+			"provider", t.provider)
+
+	case FailureClassLocalRateLimit:
+		t.log.Info("circuit: log-mode local_rate_limit_observed (passing through)",
+			"provider", t.provider)
+	}
+
+	return resp, err
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -244,7 +244,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 		//    returned to the pool cleanly.
 		if resp != nil {
 			io.Copy(io.Discard, resp.Body) //nolint:errcheck
-			resp.Body.Close()
+			resp.Body.Close()              //nolint:errcheck
 		}
 
 		retryAfterSec := retryAfterSeconds(resp)
@@ -291,11 +291,12 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 
 		// ── Degraded / transient handling ─────────────────────────────────
 		if fc == FailureClassDegraded {
-			if t.cfg.RetryContributionMode == "on" {
+			switch t.cfg.RetryContributionMode {
+			case "on":
 				t.log.Info("circuit: retried failure contributing to degradation score",
 					"provider", t.provider, "attempt", transientAttempts)
 				t.store.RecordTerminalFailure(ctx, t.provider) //nolint:errcheck
-			} else if t.cfg.RetryContributionMode == "log" {
+			case "log":
 				t.log.Info("circuit: retried failure would_have_contributed_to_degradation",
 					"provider", t.provider, "attempt", transientAttempts)
 			}
@@ -382,7 +383,7 @@ func (t *Transport) runProbe(req *http.Request) (*http.Response, error) {
 		)
 		if resp != nil {
 			io.Copy(io.Discard, resp.Body) //nolint:errcheck
-			resp.Body.Close()
+			resp.Body.Close()              //nolint:errcheck
 		}
 		type probeReleaser interface {
 			ReleaseProbe(ctx context.Context, provider string) error
@@ -408,7 +409,7 @@ func (t *Transport) runProbe(req *http.Request) (*http.Response, error) {
 	t.log.Warn("circuit: probe failed, re-opening circuit", "provider", t.provider)
 	if resp != nil {
 		io.Copy(io.Discard, resp.Body) //nolint:errcheck
-		resp.Body.Close()
+		resp.Body.Close()              //nolint:errcheck
 	}
 	t.store.RecordProbeFailed(ctx, t.provider) //nolint:errcheck
 	return t.degradedResponse(req), nil
@@ -570,7 +571,7 @@ func (t *Transport) cacheBody(req *http.Request) error {
 	limited := &io.LimitedReader{R: req.Body, N: cap + 1}
 	prefix, err := io.ReadAll(limited)
 	if err != nil {
-		req.Body.Close()
+		req.Body.Close() //nolint:errcheck
 		return err
 	}
 
@@ -589,7 +590,9 @@ func (t *Transport) cacheBody(req *http.Request) error {
 	}
 
 	// Fits in memory — buffer it and enable retries.
-	req.Body.Close()
+	if err := req.Body.Close(); err != nil {
+		return err
+	}
 	req.Body = io.NopCloser(bytes.NewReader(prefix))
 	req.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(prefix)), nil

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,6 +13,13 @@ import (
 	"strings"
 	"time"
 )
+
+// errRetryBodyTooLarge is an internal sentinel returned by cacheBody when
+// the incoming request body exceeds Config.MaxRetryableBodyBytes.  We
+// treat it as "body too large to buffer — fall through and disable
+// retries" rather than a hard error back to the caller, so oversize
+// requests still reach the upstream on a best-effort basis.
+var errRetryBodyTooLarge = errors.New("circuit: request body exceeds MaxRetryableBodyBytes")
 
 // retryAttemptKey is the context key used to pass the current attempt index
 // down to the inner transport (used by the test-mode transport).
@@ -70,7 +78,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// ── Test-mode: force_degraded fast path ───────────────────────────────
 	// force_transient_recover is handled inside runWithRetries so it can
 	// interact with the retry loop's attempt counter.
-	if testModeFromRequest(req) == TestModeForceDegraded {
+	//
+	// Test-mode honouring is gated on Config.TestModeEnabled so a prod
+	// deployment cannot be tricked into emitting synthetic degraded
+	// responses by a client setting X-LLM-Proxy-Test-Mode or
+	// llm_proxy_test_mode.  Plumbed from the CLI's three-condition
+	// security gate in cmd/llm-proxy/main.go.
+	if t.testModeFromRequest(req) == TestModeForceDegraded {
 		t.log.Info("circuit: test-mode force_degraded", "provider", t.provider)
 		return t.degradedResponse(req), nil
 	}
@@ -149,8 +163,20 @@ func (t *Transport) runObserveOnly(req *http.Request) (*http.Response, error) {
 func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
-	// Ensure the body can be re-read on retries.
-	if err := cacheBody(req); err != nil {
+	// Ensure the body can be re-read on retries.  When the body is too
+	// large to buffer in memory we gracefully disable retries and fall
+	// through to a single-pass RoundTrip so oversize requests (e.g. a
+	// multi-megabyte vision payload) still reach the upstream without
+	// giving a client an unbounded-memory DoS vector.
+	if err := t.cacheBody(req); err != nil {
+		if errors.Is(err, errRetryBodyTooLarge) {
+			t.log.Warn("circuit: request body exceeds MaxRetryableBodyBytes, retries disabled for this request",
+				"provider", t.provider,
+				"content_length", req.ContentLength,
+				"max_retryable_body_bytes", t.cfg.MaxRetryableBodyBytes,
+			)
+			return t.inner.RoundTrip(req)
+		}
 		return nil, fmt.Errorf("circuit: cacheBody: %w", err)
 	}
 
@@ -163,6 +189,13 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 	var firstRateLimitAt time.Time
 
 	for {
+		// Bail out early if the caller has gone away.  Without this check
+		// we would still consume retry budget and record terminal
+		// failures for requests whose downstream has already cancelled.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		attempt := transientAttempts + rateLimitAttempts
 		attemptReq := req.WithContext(context.WithValue(ctx, retryAttemptKey{}, attempt))
 		if attempt > 0 {
@@ -178,13 +211,17 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 
 		// ── test-mode: force_transient_recover ────────────────────────────
 		// Fail on attempt 0, forward to the real inner transport on attempt 1+.
-		if testModeFromRequest(req) == TestModeForceTransientRecover {
+		// Gated on Config.TestModeEnabled — see the header docstring on
+		// Transport.testModeFromRequest for why that gate exists.
+		if t.testModeFromRequest(req) == TestModeForceTransientRecover {
 			if attempt == 0 {
 				t.log.Info("circuit: test-mode force_transient_recover (attempt 0 → fail)",
 					"provider", t.provider)
 				// Simulate a degraded failure and let the retry loop continue.
 				backoff := transientBackoff(transientAttempts)
-				t.sleep(ctx, backoff)
+				if err := t.sleep(ctx, backoff); err != nil {
+					return nil, err
+				}
 				transientAttempts++
 				continue
 			}
@@ -233,7 +270,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 				}
 				// Return a synthetic rate-limit error (no magic string — not
 				// degraded, just throttled).
-				return t.rateLimitResponse(), nil
+				return t.rateLimitResponse(fc), nil
 			}
 			if fc == FailureClassGlobalRateLimit && firstRateLimitAt.IsZero() {
 				firstRateLimitAt = time.Now()
@@ -245,7 +282,9 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 				"backoff_ms", backoff.Milliseconds(),
 				"attempt", rateLimitAttempts+1,
 			)
-			t.sleep(ctx, backoff)
+			if err := t.sleep(ctx, backoff); err != nil {
+				return nil, err
+			}
 			rateLimitAttempts++
 			continue
 		}
@@ -275,7 +314,9 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 				"backoff_ms", backoff.Milliseconds(),
 				"attempt", transientAttempts+1,
 			)
-			t.sleep(ctx, backoff)
+			if err := t.sleep(ctx, backoff); err != nil {
+				return nil, err
+			}
 			transientAttempts++
 			continue
 		}
@@ -289,12 +330,15 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 func (t *Transport) runProbe(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
-	// Only one goroutine/process should probe at a time.
+	// Only one goroutine/process should probe at a time.  Both MemoryStore
+	// (single-process) and RedisStore (distributed) implement this via
+	// TryStartProbe, which takes a context so Redis ops are bounded by the
+	// request deadline.
 	type probeStarter interface {
-		TryStartProbe(provider string) bool
+		TryStartProbe(ctx context.Context, provider string) bool
 	}
 	if ps, ok := t.store.(probeStarter); ok {
-		if !ps.TryStartProbe(t.provider) {
+		if !ps.TryStartProbe(ctx, t.provider) {
 			// Another probe is already in flight — fast-fail this request.
 			t.log.Info("circuit: half-open probe already in flight, fast-failing",
 				"provider", t.provider)
@@ -302,7 +346,57 @@ func (t *Transport) runProbe(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	// For distributed stores the probe slot is held by a TTL-bounded
+	// Redis key; if the upstream round-trip exceeds that TTL a parallel
+	// probe could win the slot.  KeepProbeAlive starts a background
+	// lease-refresher that extends the TTL until we're done.  MemoryStore
+	// does not expose this and is a no-op here.
+	type probeLeaser interface {
+		KeepProbeAlive(provider string) func()
+	}
+	if pl, ok := t.store.(probeLeaser); ok {
+		stop := pl.KeepProbeAlive(t.provider)
+		defer stop()
+	}
+
 	resp, err := t.inner.RoundTrip(req)
+
+	// If the caller's context was cancelled or its deadline expired,
+	// we learned nothing about the provider's actual health.  Silently
+	// releasing the probe slot (without flipping state in either
+	// direction) is the correct outcome: a subsequent request will try
+	// the probe again, instead of either (a) prematurely closing the
+	// circuit because we saw FailureClassNone, or (b) re-opening for a
+	// full cooldown because we saw "some error".  We check ctx.Err()
+	// directly rather than errors.Is(err, context.Canceled) because
+	// http.RoundTrip wraps context errors inside *url.Error, and some
+	// transports surface the cancellation as an io.EOF when the body
+	// is drained mid-flight.
+	if ctxErr := ctx.Err(); ctxErr != nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		t.log.Info("circuit: probe aborted by caller context, releasing probe slot without state change",
+			"provider", t.provider,
+			"ctx_err", ctxErr,
+			"round_trip_err", err,
+		)
+		if resp != nil {
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
+			resp.Body.Close()
+		}
+		type probeReleaser interface {
+			ReleaseProbe(ctx context.Context, provider string) error
+		}
+		if pr, ok := t.store.(probeReleaser); ok {
+			// Use a detached, short-timeout context because the
+			// caller's context is already dead.
+			relCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			pr.ReleaseProbe(relCtx, t.provider) //nolint:errcheck
+			cancel()
+		}
+		return nil, err
+	}
+
 	fc := ClassifyResponse(t.provider, resp, err)
 
 	if fc == FailureClassNone {
@@ -367,7 +461,7 @@ func (t *Transport) degradedResponse(req *http.Request) *http.Response {
 
 // rateLimitResponse returns a synthetic 429 without the DegradedSignal — the
 // request is throttled but the provider is not considered degraded.
-func (t *Transport) rateLimitResponse() *http.Response {
+func (t *Transport) rateLimitResponse(fc FailureClass) *http.Response {
 	body := []byte(`{"error":{"message":"Rate limit exceeded; please retry later.","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
 	return &http.Response{
 		StatusCode: http.StatusTooManyRequests,
@@ -377,7 +471,7 @@ func (t *Transport) rateLimitResponse() *http.Response {
 		ProtoMinor: 1,
 		Header: http.Header{
 			"Content-Type":            []string{"application/json"},
-			"X-Llm-Proxy-Error-Class": []string{string(FailureClassLocalRateLimit)},
+			"X-Llm-Proxy-Error-Class": []string{string(fc)},
 		},
 		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
@@ -444,34 +538,92 @@ func retryAfterSeconds(resp *http.Response) int {
 // cacheBody reads req.Body into memory and replaces it with a NopCloser
 // backed by the bytes, setting GetBody so retries can re-read it.
 // A no-op if req.Body is nil or already has GetBody.
-func cacheBody(req *http.Request) error {
+//
+// Returns errRetryBodyTooLarge (a sentinel the caller is expected to
+// handle) when the body exceeds Config.MaxRetryableBodyBytes, rather
+// than either (a) allocating the full payload anyway — which gives a
+// client an easy memory-DoS primitive — or (b) returning a hard error
+// that fails otherwise-legitimate large requests.  On overflow we
+// leave req.Body as a streaming reader that still carries every byte
+// we observed (via MultiReader over the peeked prefix + the rest of
+// the original body), so the caller can still forward the request on
+// a best-effort, no-retry basis.
+func (t *Transport) cacheBody(req *http.Request) error {
 	if req.Body == nil || req.GetBody != nil {
 		return nil
 	}
-	b, err := io.ReadAll(req.Body)
-	req.Body.Close()
+	cap := t.cfg.MaxRetryableBodyBytes
+	if cap <= 0 {
+		cap = DefaultMaxRetryableBodyBytes
+	}
+
+	// Content-Length short-circuit: if the client explicitly tells us
+	// the body is too big we skip the read entirely and leave the body
+	// intact for a streaming pass-through.
+	if req.ContentLength > cap {
+		return errRetryBodyTooLarge
+	}
+
+	// Read at most cap+1 bytes so we can detect overflow even when
+	// Content-Length is unknown / chunked.  io.LimitReader is safe
+	// against a body that lies about its length.
+	limited := &io.LimitedReader{R: req.Body, N: cap + 1}
+	prefix, err := io.ReadAll(limited)
 	if err != nil {
+		req.Body.Close()
 		return err
 	}
-	req.Body = io.NopCloser(bytes.NewReader(b))
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(b)), nil
+
+	if int64(len(prefix)) > cap {
+		// Overflow: rewind what we read into the front of the body so a
+		// downstream streaming pass-through sees the full payload, and
+		// let the caller know retries are not possible for this req.
+		req.Body = struct {
+			io.Reader
+			io.Closer
+		}{
+			Reader: io.MultiReader(bytes.NewReader(prefix), req.Body),
+			Closer: req.Body,
+		}
+		return errRetryBodyTooLarge
 	}
-	req.ContentLength = int64(len(b))
+
+	// Fits in memory — buffer it and enable retries.
+	req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(prefix))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(prefix)), nil
+	}
+	req.ContentLength = int64(len(prefix))
 	return nil
 }
 
 // sleep blocks for d, respecting context cancellation.
-func (t *Transport) sleep(ctx context.Context, d time.Duration) {
+func (t *Transport) sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
 	select {
-	case <-time.After(d):
+	case <-timer.C:
+		return nil
 	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
 // testModeFromRequest returns the test mode value from the header or, as a
-// fallback, the URL query parameter.
-func testModeFromRequest(req *http.Request) string {
+// fallback, the URL query parameter.  When Config.TestModeEnabled is
+// false it unconditionally returns "" so a client cannot smuggle
+// X-LLM-Proxy-Test-Mode or llm_proxy_test_mode past a production
+// deployment to force synthetic degraded responses.
+//
+// This is a method on Transport (rather than a free function) precisely
+// so we always route through the config gate.  Callers inside this
+// package MUST NOT read those fields directly.
+func (t *Transport) testModeFromRequest(req *http.Request) string {
+	if !t.cfg.TestModeEnabled {
+		return ""
+	}
 	if v := req.Header.Get(TestModeHeader); v != "" {
 		return v
 	}

--- a/internal/circuit/transport_test.go
+++ b/internal/circuit/transport_test.go
@@ -96,10 +96,10 @@ func TestTransport_DegradedAfterTerminalFailures(t *testing.T) {
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("want 503 degraded response, got %d", resp.StatusCode)
 	}
-	// Body must contain MagicString.
+	// Body must contain DefaultDegradedSignal.
 	b, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(b), MagicString) {
-		t.Fatalf("MagicString not found in response body: %s", b)
+	if !strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found in response body: %s", b)
 	}
 }
 
@@ -151,8 +151,8 @@ func TestTransport_FastFailWhenCircuitOpen(t *testing.T) {
 		t.Fatalf("want 503 fast-fail, got %d", resp.StatusCode)
 	}
 	b, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(b), MagicString) {
-		t.Fatalf("MagicString not found in fast-fail body: %s", b)
+	if !strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found in fast-fail body: %s", b)
 	}
 }
 
@@ -174,8 +174,8 @@ func TestTransport_TestMode_ForceDegraded(t *testing.T) {
 		t.Fatalf("want 503, got %d", resp.StatusCode)
 	}
 	b, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(b), MagicString) {
-		t.Fatalf("MagicString not found in body: %s", b)
+	if !strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found in body: %s", b)
 	}
 }
 
@@ -231,8 +231,8 @@ func TestTransport_DegradedResponseBodyIsValidJSON(t *testing.T) {
 		t.Fatal("expected 'error' key in JSON body")
 	}
 	msg, _ := errObj["message"].(string)
-	if !strings.Contains(msg, MagicString) {
-		t.Fatalf("MagicString not in message: %s", msg)
+	if !strings.Contains(msg, DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not in message: %s", msg)
 	}
 	if errObj["type"] != "provider_degraded" {
 		t.Fatalf("expected type 'provider_degraded', got %v", errObj["type"])
@@ -241,7 +241,7 @@ func TestTransport_DegradedResponseBodyIsValidJSON(t *testing.T) {
 
 // TestTransport_DegradedResponse_SetsErrorClassHeader verifies the defense-in-
 // depth signal: even if the response body is ever rewritten by a downstream
-// transformer, Finch can still detect provider degradation via the
+// transformer, clients can still detect provider degradation via the
 // X-Llm-Proxy-Error-Class header.
 func TestTransport_DegradedResponse_SetsErrorClassHeader(t *testing.T) {
 	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
@@ -267,8 +267,9 @@ func TestTransport_DegradedResponse_SetsErrorClassHeader(t *testing.T) {
 }
 
 // TestTransport_RateLimitExhausted_SetsErrorClassHeader verifies the header
-// flags rate-limit exhaustion distinctly from degradation.  Finch uses the
-// magic string only for degradation; 429s must NOT be classified as degraded.
+// flags rate-limit exhaustion distinctly from degradation.  The degraded
+// signal is only emitted for true degradation; 429s must NOT be classified
+// as degraded.
 func TestTransport_RateLimitExhausted_SetsErrorClassHeader(t *testing.T) {
 	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		r := makeResp(429)
@@ -354,8 +355,8 @@ func TestTransport_ProbeFails_ReturnsDegraded(t *testing.T) {
 		t.Fatalf("want 503 degraded after probe failure, got %d", resp.StatusCode)
 	}
 	b, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(b), MagicString) {
-		t.Fatalf("MagicString not found in probe-failed body: %s", b)
+	if !strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found in probe-failed body: %s", b)
 	}
 	// Circuit should still be open (not closed).
 	state, _ := store.GetState(ctx, "openai")
@@ -403,8 +404,8 @@ func TestTransport_HalfOpen_ConcurrentRequestFastFails(t *testing.T) {
 		t.Fatalf("want 503 fast-fail while probe in flight, got %d", resp.StatusCode)
 	}
 	b, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(b), MagicString) {
-		t.Fatalf("MagicString not found: %s", b)
+	if !strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found: %s", b)
 	}
 }
 
@@ -435,8 +436,8 @@ func TestTransport_RateLimitRetriesExhausted_Returns429(t *testing.T) {
 		t.Fatalf("want 429 after rate-limit exhaustion, got %d", resp.StatusCode)
 	}
 	b, _ := io.ReadAll(resp.Body)
-	if strings.Contains(string(b), MagicString) {
-		t.Fatal("MagicString should NOT be in rate-limit response (not degraded)")
+	if strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatal("DefaultDegradedSignal should NOT be in rate-limit response (not degraded)")
 	}
 }
 
@@ -543,5 +544,41 @@ func TestTransport_ProbeSucceeds_ClosesCircuit(t *testing.T) {
 	state, _ := store.GetState(ctx, "openai")
 	if state != StateClosed {
 		t.Fatalf("circuit should be closed after successful probe, got %s", state)
+	}
+}
+
+// TestTransport_CustomDegradedSignal verifies that operators can override
+// the degraded-signal marker via Config.DegradedSignal and it shows up in
+// synthetic degraded responses instead of DefaultDegradedSignal.
+func TestTransport_CustomDegradedSignal(t *testing.T) {
+	const custom = "[MY_COMPANY_UPSTREAM_DOWN]"
+
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 0,
+		DegradedSignal:      custom,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), custom) {
+		t.Fatalf("custom degraded signal not found in body: %s", b)
+	}
+	if strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("default signal should NOT appear when custom one is set: %s", b)
 	}
 }

--- a/internal/circuit/transport_test.go
+++ b/internal/circuit/transport_test.go
@@ -480,7 +480,7 @@ func TestTransport_ProbeFails_ReturnsDegraded(t *testing.T) {
 		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
-		CooldownSeconds:     0,
+		CooldownSeconds:     1,
 		MaxTransientRetries: 0,
 	}.Defaults()
 	store := NewMemoryStore(cfg)
@@ -488,11 +488,10 @@ func TestTransport_ProbeFails_ReturnsDegraded(t *testing.T) {
 
 	// Open the circuit.
 	store.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
-	// Expire cooldown.
-	e := store.entry("openai")
-	e.mu.Lock()
-	e.cooldownUntil = time.Now().Add(-1 * time.Second)
-	e.mu.Unlock()
+	time.Sleep(1100 * time.Millisecond)
+	if state, _ := store.GetState(ctx, "openai"); state != StateHalfOpen {
+		t.Fatalf("circuit should be half-open after cooldown, got %s", state)
+	}
 
 	// Inner returns 503 — the probe fails.
 	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
@@ -524,7 +523,7 @@ func TestTransport_HalfOpen_ConcurrentRequestFastFails(t *testing.T) {
 		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
-		CooldownSeconds:     0,
+		CooldownSeconds:     1,
 		MaxTransientRetries: 0,
 	}.Defaults()
 	store := NewMemoryStore(cfg)
@@ -532,11 +531,10 @@ func TestTransport_HalfOpen_ConcurrentRequestFastFails(t *testing.T) {
 
 	// Open the circuit.
 	store.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
-	// Expire cooldown.
-	e := store.entry("openai")
-	e.mu.Lock()
-	e.cooldownUntil = time.Now().Add(-1 * time.Second)
-	e.mu.Unlock()
+	time.Sleep(1100 * time.Millisecond)
+	if state, _ := store.GetState(ctx, "openai"); state != StateHalfOpen {
+		t.Fatalf("circuit should be half-open after cooldown, got %s", state)
+	}
 
 	// Start a probe (simulating an in-flight probe).
 	if !store.TryStartProbe(ctx, "openai") {
@@ -672,7 +670,7 @@ func TestTransport_ProbeSucceeds_ClosesCircuit(t *testing.T) {
 		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
-		CooldownSeconds:     0,
+		CooldownSeconds:     1,
 		MaxTransientRetries: 0,
 	}.Defaults()
 	store := NewMemoryStore(cfg)
@@ -680,11 +678,10 @@ func TestTransport_ProbeSucceeds_ClosesCircuit(t *testing.T) {
 
 	// Open the circuit.
 	store.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
-	// Expire the cooldown by setting it to the past.
-	e := store.entry("openai")
-	e.mu.Lock()
-	e.cooldownUntil = time.Now().Add(-1 * time.Second)
-	e.mu.Unlock()
+	time.Sleep(1100 * time.Millisecond)
+	if state, _ := store.GetState(ctx, "openai"); state != StateHalfOpen {
+		t.Fatalf("circuit should be half-open after cooldown, got %s", state)
+	}
 
 	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		return makeResp(200), nil

--- a/internal/circuit/transport_test.go
+++ b/internal/circuit/transport_test.go
@@ -34,6 +34,7 @@ func makeResp(status int) *http.Response {
 func newTestTransport(inner http.RoundTripper) *Transport {
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    3,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -47,6 +48,7 @@ func newTestTransport(inner http.RoundTripper) *Transport {
 func newTestTransportWithStore(inner http.RoundTripper, store Store) *Transport {
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    3,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -133,6 +135,7 @@ func TestTransport_FastFailWhenCircuitOpen(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -211,6 +214,7 @@ func TestTransport_DegradedResponseBodyIsValidJSON(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -249,6 +253,7 @@ func TestTransport_DegradedResponse_SetsErrorClassHeader(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -279,6 +284,7 @@ func TestTransport_RateLimitExhausted_SetsErrorClassHeader(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    5,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -325,6 +331,7 @@ func TestTransport_RateLimitRetry(t *testing.T) {
 func TestTransport_ProbeFails_ReturnsDegraded(t *testing.T) {
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
 		CooldownSeconds:     0,
@@ -368,6 +375,7 @@ func TestTransport_ProbeFails_ReturnsDegraded(t *testing.T) {
 func TestTransport_HalfOpen_ConcurrentRequestFastFails(t *testing.T) {
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
 		CooldownSeconds:     0,
@@ -419,6 +427,7 @@ func TestTransport_RateLimitRetriesExhausted_Returns429(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    5,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -464,6 +473,7 @@ func TestTransport_RetryContributionMode_On(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:               true,
+		Mode:                  ModeEnforce,
 		FailureThreshold:      10,
 		WindowSeconds:         60,
 		CooldownSeconds:       300,
@@ -490,6 +500,7 @@ func TestTransport_RetryContributionMode_Off(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:               true,
+		Mode:                  ModeEnforce,
 		FailureThreshold:      10,
 		WindowSeconds:         60,
 		CooldownSeconds:       300,
@@ -512,6 +523,7 @@ func TestTransport_ProbeSucceeds_ClosesCircuit(t *testing.T) {
 	// Build a store where the circuit is already half-open.
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
 		CooldownSeconds:     0,
@@ -558,6 +570,7 @@ func TestTransport_CustomDegradedSignal(t *testing.T) {
 	})
 	cfg := Config{
 		Enabled:             true,
+		Mode:                ModeEnforce,
 		FailureThreshold:    1,
 		WindowSeconds:       60,
 		CooldownSeconds:     300,

--- a/internal/circuit/transport_test.go
+++ b/internal/circuit/transport_test.go
@@ -1,0 +1,547 @@
+package circuit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── Mock inner transport ─────────────────────────────────────────────────
+
+// roundTripFunc lets tests build a RoundTripper from a plain func.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// makeResp is a small helper to build an *http.Response.
+func makeResp(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader([]byte{})),
+	}
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+func newTestTransport(inner http.RoundTripper) *Transport {
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    3,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1, // small for tests
+		MaxRateLimitRetries: 1,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	return NewTransport(inner, store, cfg, "openai", nil)
+}
+
+func newTestTransportWithStore(inner http.RoundTripper, store Store) *Transport {
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    3,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1,
+		MaxRateLimitRetries: 1,
+	}.Defaults()
+	return NewTransport(inner, store, cfg, "openai", nil)
+}
+
+// dummyRequest creates a minimal POST request with a cacheable body.
+func dummyRequest() *http.Request {
+	body := `{"model":"gpt-4o","messages":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+func TestTransport_SuccessPassthrough(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(200), nil
+	})
+	tr := newTestTransport(inner)
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestTransport_DegradedAfterTerminalFailures(t *testing.T) {
+	// Always return 503.
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(503), nil
+	})
+	tr := newTestTransport(inner)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The transport retried once (MaxTransientRetries=1) then gave up.
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 degraded response, got %d", resp.StatusCode)
+	}
+	// Body must contain MagicString.
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), MagicString) {
+		t.Fatalf("MagicString not found in response body: %s", b)
+	}
+}
+
+func TestTransport_RetrySucceedsOnSecondAttempt(t *testing.T) {
+	attempt := 0
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		attempt++
+		if attempt == 1 {
+			return makeResp(503), nil
+		}
+		return makeResp(200), nil
+	})
+	tr := newTestTransport(inner)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200 on retry success, got %d", resp.StatusCode)
+	}
+	if attempt != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempt)
+	}
+}
+
+func TestTransport_FastFailWhenCircuitOpen(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Error("inner transport should NOT be called when circuit is open")
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 0, // no retries so circuit opens immediately
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	// Open the circuit manually.
+	store.RecordTerminalFailure(context.Background(), "openai") //nolint:errcheck
+
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 fast-fail, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), MagicString) {
+		t.Fatalf("MagicString not found in fast-fail body: %s", b)
+	}
+}
+
+func TestTransport_TestMode_ForceDegraded(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Error("inner transport should NOT be called in force_degraded test mode")
+		return makeResp(200), nil
+	})
+	tr := newTestTransport(inner)
+
+	req := dummyRequest()
+	req.Header.Set(TestModeHeader, TestModeForceDegraded)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), MagicString) {
+		t.Fatalf("MagicString not found in body: %s", b)
+	}
+}
+
+func TestTransport_TestMode_ForceTransientRecover(t *testing.T) {
+	attempts := 0
+	inner := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		attempts++
+		return makeResp(200), nil
+	})
+	tr := newTestTransport(inner)
+
+	req := dummyRequest()
+	req.Header.Set(TestModeHeader, TestModeForceTransientRecover)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Attempt 0 is intercepted by test mode (returns degraded), then the
+	// transport retries.  On attempt 1, force_transient_recover forwards to
+	// the real inner transport which returns 200.
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200 on second attempt, got %d", resp.StatusCode)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected inner transport called once (on retry), got %d", attempts)
+	}
+}
+
+func TestTransport_DegradedResponseBodyIsValidJSON(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 0,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "anthropic", nil)
+
+	resp, _ := tr.RoundTrip(dummyRequest())
+	b, _ := io.ReadAll(resp.Body)
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(b, &payload); err != nil {
+		t.Fatalf("degraded response body is not valid JSON: %v\nbody: %s", err, b)
+	}
+	errObj, _ := payload["error"].(map[string]interface{})
+	if errObj == nil {
+		t.Fatal("expected 'error' key in JSON body")
+	}
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, MagicString) {
+		t.Fatalf("MagicString not in message: %s", msg)
+	}
+	if errObj["type"] != "provider_degraded" {
+		t.Fatalf("expected type 'provider_degraded', got %v", errObj["type"])
+	}
+}
+
+// TestTransport_DegradedResponse_SetsErrorClassHeader verifies the defense-in-
+// depth signal: even if the response body is ever rewritten by a downstream
+// transformer, Finch can still detect provider degradation via the
+// X-Llm-Proxy-Error-Class header.
+func TestTransport_DegradedResponse_SetsErrorClassHeader(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 0,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := resp.Header.Get("X-Llm-Proxy-Error-Class"); got != string(FailureClassDegraded) {
+		t.Fatalf("want X-Llm-Proxy-Error-Class=%q, got %q", FailureClassDegraded, got)
+	}
+}
+
+// TestTransport_RateLimitExhausted_SetsErrorClassHeader verifies the header
+// flags rate-limit exhaustion distinctly from degradation.  Finch uses the
+// magic string only for degradation; 429s must NOT be classified as degraded.
+func TestTransport_RateLimitExhausted_SetsErrorClassHeader(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		r := makeResp(429)
+		r.Header.Set("Retry-After", "0")
+		r.Header.Set("x-ratelimit-remaining-requests", "5")
+		return r, nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    5,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1,
+		MaxRateLimitRetries: 1,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Llm-Proxy-Error-Class"); got != string(FailureClassLocalRateLimit) {
+		t.Fatalf("want X-Llm-Proxy-Error-Class=%q, got %q", FailureClassLocalRateLimit, got)
+	}
+}
+
+func TestTransport_RateLimitRetry(t *testing.T) {
+	attempts := 0
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			r := makeResp(429)
+			r.Header.Set("Retry-After", "0")
+			return r, nil
+		}
+		return makeResp(200), nil
+	})
+	tr := newTestTransport(inner)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200 after rate-limit retry, got %d", resp.StatusCode)
+	}
+}
+
+func TestTransport_ProbeFails_ReturnsDegraded(t *testing.T) {
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     0,
+		MaxTransientRetries: 0,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	// Open the circuit.
+	store.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	// Expire cooldown.
+	e := store.entry("openai")
+	e.mu.Lock()
+	e.cooldownUntil = time.Now().Add(-1 * time.Second)
+	e.mu.Unlock()
+
+	// Inner returns 503 — the probe fails.
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(503), nil
+	})
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 degraded after probe failure, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), MagicString) {
+		t.Fatalf("MagicString not found in probe-failed body: %s", b)
+	}
+	// Circuit should still be open (not closed).
+	state, _ := store.GetState(ctx, "openai")
+	if state == StateClosed {
+		t.Fatal("circuit should NOT be closed after failed probe")
+	}
+}
+
+func TestTransport_HalfOpen_ConcurrentRequestFastFails(t *testing.T) {
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     0,
+		MaxTransientRetries: 0,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	// Open the circuit.
+	store.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	// Expire cooldown.
+	e := store.entry("openai")
+	e.mu.Lock()
+	e.cooldownUntil = time.Now().Add(-1 * time.Second)
+	e.mu.Unlock()
+
+	// Start a probe (simulating an in-flight probe).
+	if !store.TryStartProbe("openai") {
+		t.Fatal("first TryStartProbe should succeed")
+	}
+
+	// Inner should NOT be called for the second request.
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Error("inner transport should NOT be called when probe is in flight")
+		return makeResp(200), nil
+	})
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 fast-fail while probe in flight, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), MagicString) {
+		t.Fatalf("MagicString not found: %s", b)
+	}
+}
+
+func TestTransport_RateLimitRetriesExhausted_Returns429(t *testing.T) {
+	// Always return 429 with local rate limit headers.
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		r := makeResp(429)
+		r.Header.Set("Retry-After", "0")
+		r.Header.Set("x-ratelimit-remaining-requests", "5")
+		return r, nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    5,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1,
+		MaxRateLimitRetries: 1,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("want 429 after rate-limit exhaustion, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(b), MagicString) {
+		t.Fatal("MagicString should NOT be in rate-limit response (not degraded)")
+	}
+}
+
+func TestTransport_NonRetryable400_Passthrough(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(400), nil
+	})
+	tr := newTestTransport(inner)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Fatalf("want 400 passthrough, got %d", resp.StatusCode)
+	}
+}
+
+func TestTransport_RetryContributionMode_On(t *testing.T) {
+	attempt := 0
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		attempt++
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:               true,
+		FailureThreshold:      10,
+		WindowSeconds:         60,
+		CooldownSeconds:       300,
+		MaxTransientRetries:   1,
+		RetryContributionMode: "on",
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	tr.RoundTrip(dummyRequest()) //nolint:errcheck
+
+	// With "on", each retry also records a terminal failure.
+	// Initial attempt + 1 retry = 2 attempts. The retry contributes 1 extra
+	// failure, plus the final terminal failure at exhaustion = 2 total.
+	stats, _ := store.GetStats(context.Background(), "openai")
+	if stats.Failures < 2 {
+		t.Fatalf("expected at least 2 recorded failures with contribution_mode=on, got %d", stats.Failures)
+	}
+}
+
+func TestTransport_RetryContributionMode_Off(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:               true,
+		FailureThreshold:      10,
+		WindowSeconds:         60,
+		CooldownSeconds:       300,
+		MaxTransientRetries:   1,
+		RetryContributionMode: "off",
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	tr.RoundTrip(dummyRequest()) //nolint:errcheck
+
+	// With "off", only the final terminal failure is recorded (1 total).
+	stats, _ := store.GetStats(context.Background(), "openai")
+	if stats.Failures != 1 {
+		t.Fatalf("expected exactly 1 recorded failure with contribution_mode=off, got %d", stats.Failures)
+	}
+}
+
+func TestTransport_ProbeSucceeds_ClosesCircuit(t *testing.T) {
+	// Build a store where the circuit is already half-open.
+	cfg := Config{
+		Enabled:             true,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     0,
+		MaxTransientRetries: 0,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	// Open the circuit.
+	store.RecordTerminalFailure(ctx, "openai") //nolint:errcheck
+	// Expire the cooldown by setting it to the past.
+	e := store.entry("openai")
+	e.mu.Lock()
+	e.cooldownUntil = time.Now().Add(-1 * time.Second)
+	e.mu.Unlock()
+
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResp(200), nil
+	})
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("probe should succeed, got %d", resp.StatusCode)
+	}
+
+	state, _ := store.GetState(ctx, "openai")
+	if state != StateClosed {
+		t.Fatalf("circuit should be closed after successful probe, got %s", state)
+	}
+}

--- a/internal/circuit/transport_test.go
+++ b/internal/circuit/transport_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,28 +41,20 @@ func newTestTransport(inner http.RoundTripper) *Transport {
 		CooldownSeconds:     300,
 		MaxTransientRetries: 1, // small for tests
 		MaxRateLimitRetries: 1,
+		// Tests that exercise the X-LLM-Proxy-Test-Mode plumbing need
+		// the gate open; tests that don't care are unaffected by the
+		// setting.  Production gating is covered separately by
+		// TestTransport_TestMode_DisabledByDefault_IgnoresHeader.
+		TestModeEnabled: true,
 	}.Defaults()
 	store := NewMemoryStore(cfg)
-	return NewTransport(inner, store, cfg, "openai", nil)
-}
-
-func newTestTransportWithStore(inner http.RoundTripper, store Store) *Transport {
-	cfg := Config{
-		Enabled:             true,
-		Mode:                ModeEnforce,
-		FailureThreshold:    3,
-		WindowSeconds:       60,
-		CooldownSeconds:     300,
-		MaxTransientRetries: 1,
-		MaxRateLimitRetries: 1,
-	}.Defaults()
 	return NewTransport(inner, store, cfg, "openai", nil)
 }
 
 // dummyRequest creates a minimal POST request with a cacheable body.
 func dummyRequest() *http.Request {
 	body := `{"model":"gpt-4o","messages":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions",
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/openai/v1/chat/completions",
 		strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	return req
@@ -182,6 +175,84 @@ func TestTransport_TestMode_ForceDegraded(t *testing.T) {
 	}
 }
 
+// TestTransport_TestMode_DisabledByDefault_IgnoresHeader pins down the
+// fix for the B1 security finding: with Config.TestModeEnabled left at
+// its zero-value (false), the transport MUST NOT honour the
+// X-LLM-Proxy-Test-Mode header.  If this regresses, a client could
+// smuggle synthetic degraded responses past a production deployment by
+// setting the header on any request.
+func TestTransport_TestMode_DisabledByDefault_IgnoresHeader(t *testing.T) {
+	innerCalled := false
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		innerCalled = true
+		return makeResp(200), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeEnforce,
+		FailureThreshold:    3,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 0,
+		// TestModeEnabled intentionally left false.
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	req := dummyRequest()
+	req.Header.Set(TestModeHeader, TestModeForceDegraded)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !innerCalled {
+		t.Fatal("inner transport should have been called — test-mode header must be ignored when TestModeEnabled is false")
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("want real 200 response, got %d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(b), DefaultDegradedSignal) {
+		t.Fatalf("synthetic DegradedSignal leaked into response body: %s", b)
+	}
+}
+
+// TestTransport_TestMode_DisabledByDefault_IgnoresQueryParam is the
+// query-param counterpart of the header regression test above.
+func TestTransport_TestMode_DisabledByDefault_IgnoresQueryParam(t *testing.T) {
+	innerCalled := false
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		innerCalled = true
+		return makeResp(200), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeEnforce,
+		FailureThreshold:    3,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 0,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/openai/v1/chat/completions?"+TestModeQueryParam+"="+TestModeForceDegraded,
+		strings.NewReader(`{}`))
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !innerCalled {
+		t.Fatal("inner transport should have been called — test-mode query param must be ignored when TestModeEnabled is false")
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("want real 200 response, got %d", resp.StatusCode)
+	}
+}
+
 func TestTransport_TestMode_ForceTransientRecover(t *testing.T) {
 	attempts := 0
 	inner := roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -223,8 +294,15 @@ func TestTransport_DegradedResponseBodyIsValidJSON(t *testing.T) {
 	store := NewMemoryStore(cfg)
 	tr := NewTransport(inner, store, cfg, "anthropic", nil)
 
-	resp, _ := tr.RoundTrip(dummyRequest())
-	b, _ := io.ReadAll(resp.Body)
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected RoundTrip error: %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
 
 	var payload map[string]interface{}
 	if err := json.Unmarshal(b, &payload); err != nil {
@@ -306,6 +384,38 @@ func TestTransport_RateLimitExhausted_SetsErrorClassHeader(t *testing.T) {
 	}
 }
 
+func TestTransport_GlobalRateLimitExhausted_SetsErrorClassHeader(t *testing.T) {
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		r := makeResp(429)
+		r.Header.Set("Retry-After", "0")
+		r.Header.Set("x-ratelimit-remaining-requests", "0")
+		r.Header.Set("x-ratelimit-remaining-tokens", "0")
+		return r, nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeEnforce,
+		FailureThreshold:    5,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1,
+		MaxRateLimitRetries: 1,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	resp, err := tr.RoundTrip(dummyRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Llm-Proxy-Error-Class"); got != string(FailureClassGlobalRateLimit) {
+		t.Fatalf("want X-Llm-Proxy-Error-Class=%q, got %q", FailureClassGlobalRateLimit, got)
+	}
+}
+
 func TestTransport_RateLimitRetry(t *testing.T) {
 	attempts := 0
 	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
@@ -325,6 +435,42 @@ func TestTransport_RateLimitRetry(t *testing.T) {
 	}
 	if resp.StatusCode != 200 {
 		t.Fatalf("want 200 after rate-limit retry, got %d", resp.StatusCode)
+	}
+}
+
+func TestTransport_BackoffSleepStopsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		attempts++
+		cancel()
+		return makeResp(503), nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeEnforce,
+		FailureThreshold:    5,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1,
+		MaxRateLimitRetries: 1,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(inner, store, cfg, "openai", nil)
+
+	req := dummyRequest().WithContext(ctx)
+	resp, err := tr.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on cancellation, got %d", resp.StatusCode)
+	}
+	if attempts != 1 {
+		t.Fatalf("sleep cancellation should abort before retry; attempts=%d", attempts)
 	}
 }
 
@@ -393,7 +539,7 @@ func TestTransport_HalfOpen_ConcurrentRequestFastFails(t *testing.T) {
 	e.mu.Unlock()
 
 	// Start a probe (simulating an in-flight probe).
-	if !store.TryStartProbe("openai") {
+	if !store.TryStartProbe(ctx, "openai") {
 		t.Fatal("first TryStartProbe should succeed")
 	}
 

--- a/internal/circuit/types.go
+++ b/internal/circuit/types.go
@@ -1,0 +1,175 @@
+package circuit
+
+import "time"
+
+// MagicString is injected into every degraded error response body so that
+// downstream callers (e.g. Finch Python SDKs) can detect provider degradation
+// by checking `"[FINCH_PROVIDER_DEGRADED]" in str(e)` regardless of which SDK
+// exception type wraps the HTTP error.
+const MagicString = "[FINCH_PROVIDER_DEGRADED]"
+
+// TestModeHeader is the HTTP request header used to force specific failure
+// scenarios in integration tests without hitting real providers.
+const TestModeHeader = "X-LLM-Proxy-Test-Mode"
+
+// TestModeQueryParam is the URL query parameter equivalent of TestModeHeader.
+// SDKs like the Google Gemini client that don't support custom HTTP headers can
+// embed the test mode value directly in the base URL instead:
+//
+//	base_url = "http://localhost:9002/gemini?llm_proxy_test_mode=force_degraded"
+const TestModeQueryParam = "llm_proxy_test_mode"
+
+// Test mode header values.
+const (
+	// TestModeForceDegraded bypasses the provider and returns a degraded error
+	// immediately, simulating an open circuit or terminal provider failure.
+	TestModeForceDegraded = "force_degraded"
+
+	// TestModeForceTransientRecover simulates a 503 on the first attempt that
+	// recovers on the proxy's internal retry, proving the retry loop works
+	// without opening the circuit.
+	TestModeForceTransientRecover = "force_transient_recover"
+)
+
+// State represents the current circuit breaker state for a provider.
+type State int8
+
+const (
+	// StateClosed is the healthy state: requests flow through normally and the
+	// proxy performs its standard transient retries.
+	StateClosed State = iota
+
+	// StateOpen is the degraded/cooldown state: the circuit has tripped.  The
+	// proxy fast-fails every request without hitting the network and returns
+	// the MagicString degraded error to Finch.
+	StateOpen
+
+	// StateHalfOpen is the probing state: the cooldown period has expired and
+	// exactly one request is allowed through as a probe.  No retries.  If it
+	// succeeds the circuit closes; if it fails the circuit re-opens for another
+	// cooldown period.
+	StateHalfOpen
+)
+
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half_open"
+	default:
+		return "unknown"
+	}
+}
+
+// FailureClass categorises an upstream failure so the transport can apply the
+// right retry policy and decide whether to credit the circuit breaker.
+type FailureClass string
+
+const (
+	// FailureClassLocalRateLimit is a model- or bucket-specific throttle (e.g.
+	// a 429 that applies only to one model tier).  The proxy backs off and
+	// retries but does NOT increment the provider degradation counter.
+	FailureClassLocalRateLimit FailureClass = "localized_rate_limit"
+
+	// FailureClassGlobalRateLimit is a provider-wide quota exhaustion (e.g. the
+	// account has hit its global RPM/TPM limit).  The proxy backs off and
+	// retries; if it persists beyond the escalation window it is promoted to
+	// FailureClassDegraded.
+	FailureClassGlobalRateLimit FailureClass = "global_rate_limit"
+
+	// FailureClassDegraded represents a true provider outage or capacity
+	// failure: 5xx responses (including Anthropic 529), network-level errors
+	// (timeouts, connection resets, unexpected EOFs), or sustained global rate
+	// limits.  Terminal failures of this class increment the circuit breaker
+	// counter and can open the circuit.
+	FailureClassDegraded FailureClass = "provider_degraded"
+
+	// FailureClassNone signals that the response was successful or that the
+	// failure type is unknown/not classifiable as transient.
+	FailureClassNone FailureClass = ""
+)
+
+// Config holds all circuit-breaker and retry tuning parameters.  Zero values
+// are replaced by the defaults documented on each field.
+type Config struct {
+	// Enabled gates the entire circuit-breaker feature.  When false the
+	// transport behaves as a simple pass-through with no retries.
+	Enabled bool
+
+	// Backend selects the state store: "memory" (default) or "redis".
+	Backend string
+
+	// FailureThreshold is the number of terminal failures within WindowSeconds
+	// required to open the circuit.  Default: 5.
+	FailureThreshold int
+
+	// WindowSeconds is the sliding-window TTL for failure counters.  Failures
+	// older than this are discarded and do not contribute to the threshold.
+	// Default: 120 (2 minutes).
+	WindowSeconds int
+
+	// CooldownSeconds is how long the circuit stays Open before transitioning
+	// to Half-Open for a probe.  Default: 300 (5 minutes).
+	CooldownSeconds int
+
+	// MaxTransientRetries is the maximum number of retries for degraded-class
+	// failures before declaring the request terminal.  Default: 2.
+	MaxTransientRetries int
+
+	// MaxRateLimitRetries is the maximum number of retries for rate-limit
+	// failures before surfacing the error.  Default: 2.
+	MaxRateLimitRetries int
+
+	// RetryContributionMode controls whether retried failures count toward the
+	// circuit-breaker threshold.
+	//   "off"  – retried failures never contribute
+	//   "log"  – retried failures are logged but do not contribute (default)
+	//   "on"   – retried failures contribute to the threshold
+	RetryContributionMode string
+
+	// GlobalRateLimitEscalationWindow is how many seconds of sustained global
+	// rate-limit failures must elapse before they escalate to provider_degraded.
+	// Default: 60.
+	GlobalRateLimitEscalationWindow int
+
+	// Redis connection settings, used when Backend == "redis".
+	RedisAddress  string
+	RedisPassword string
+	RedisDB       int
+}
+
+// Defaults returns a Config with all zero fields replaced by sensible defaults.
+func (c Config) Defaults() Config {
+	if c.FailureThreshold <= 0 {
+		c.FailureThreshold = 5
+	}
+	if c.WindowSeconds <= 0 {
+		c.WindowSeconds = 120
+	}
+	if c.CooldownSeconds <= 0 {
+		c.CooldownSeconds = 300
+	}
+	if c.MaxTransientRetries <= 0 {
+		c.MaxTransientRetries = 2
+	}
+	if c.MaxRateLimitRetries <= 0 {
+		c.MaxRateLimitRetries = 2
+	}
+	if c.RetryContributionMode == "" {
+		c.RetryContributionMode = "log"
+	}
+	if c.GlobalRateLimitEscalationWindow <= 0 {
+		c.GlobalRateLimitEscalationWindow = 60
+	}
+	return c
+}
+
+// ProviderStats is returned by the Store for health / observability endpoints.
+type ProviderStats struct {
+	State         State
+	Failures      int
+	CooldownUntil *time.Time
+}

--- a/internal/circuit/types.go
+++ b/internal/circuit/types.go
@@ -1,6 +1,22 @@
 package circuit
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+// MaxDegradedSignalLength bounds the DegradedSignal substring we embed in
+// synthetic degraded bodies so a misconfigured (or hostile) operator setting
+// cannot force arbitrary-sized strings into every error response, blow up log
+// volume, or complicate client-side substring detection.
+const MaxDegradedSignalLength = 256
+
+// DefaultMaxRetryableBodyBytes is the default hard cap cacheBody uses to
+// decide whether an incoming request body can be buffered in memory for
+// retry-replay.  Chosen to comfortably fit typical LLM requests (including
+// moderate base64 image payloads) while keeping per-request memory bounded
+// even when a client streams a pathologically large body.
+const DefaultMaxRetryableBodyBytes int64 = 10 * 1024 * 1024 // 10 MiB
 
 // DefaultDegradedSignal is the default marker embedded in synthetic degraded
 // error response bodies.  Callers can override it per-deployment via
@@ -218,12 +234,13 @@ type Config struct {
 	// If both are provided, RedisURL is parsed first and the individual
 	// fields overlay its result (so you can, for example, point the URL
 	// at Finch's cluster but explicitly pin DB to a dedicated circuit-
-	// breaker database).  A zero RedisDB is treated as "don't override"
-	// when a URL is also provided; set it explicitly to 0 via URL path.
+	// breaker database).  RedisDB overlays the URL DB only when
+	// RedisDBSet is true, which lets an explicit DB 0 override a URL path.
 	RedisURL      string
 	RedisAddress  string
 	RedisPassword string
 	RedisDB       int
+	RedisDBSet    bool
 
 	// DegradedSignal is the opaque substring embedded in every synthesised
 	// degraded error body so downstream clients can detect proxy-originated
@@ -234,6 +251,22 @@ type Config struct {
 	//
 	// Defaults to DefaultDegradedSignal when empty.
 	DegradedSignal string
+
+	// TestModeEnabled gates whether the transport will honour the
+	// X-LLM-Proxy-Test-Mode header and llm_proxy_test_mode query
+	// parameter.  When false (the default) the transport ignores those
+	// signals entirely so that a production deployment cannot be
+	// tricked by a client into returning synthetic degraded responses.
+	// Operators opt-in explicitly via the YAML config.
+	TestModeEnabled bool
+
+	// MaxRetryableBodyBytes caps how much of an incoming request body
+	// cacheBody is willing to buffer into memory to support retry
+	// replay.  Requests whose body exceeds this cap bypass the retry
+	// machinery and are forwarded once as a streaming pass-through so
+	// we never hold an unbounded byte slice per request.  Zero or
+	// negative means "use DefaultMaxRetryableBodyBytes".
+	MaxRetryableBodyBytes int64
 }
 
 // Defaults returns a Config with all zero fields replaced by sensible defaults.
@@ -274,7 +307,40 @@ func (c Config) Defaults() Config {
 	if c.DegradedSignal == "" {
 		c.DegradedSignal = DefaultDegradedSignal
 	}
+	if c.MaxRetryableBodyBytes <= 0 {
+		c.MaxRetryableBodyBytes = DefaultMaxRetryableBodyBytes
+	}
 	return c
+}
+
+// Validate returns a non-nil error when cfg contains a value we cannot
+// safely use at runtime.  It is intentionally strict about things that
+// silently-fall-through today (unknown backend, oversize degraded signal,
+// unknown mode) so a typo in the YAML surfaces at startup instead of
+// manifesting as surprising behaviour under load.
+func (c Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	switch c.Backend {
+	case "", "memory", "redis":
+	default:
+		return fmt.Errorf("circuit: unsupported backend %q (supported: memory, redis)", c.Backend)
+	}
+	switch c.Mode {
+	case "", ModeLog, ModeEnforce:
+	default:
+		return fmt.Errorf("circuit: unsupported mode %q (supported: %s, %s)", c.Mode, ModeLog, ModeEnforce)
+	}
+	switch c.RetryContributionMode {
+	case "", "off", "log", "on":
+	default:
+		return fmt.Errorf("circuit: unsupported retry_contribution_mode %q (supported: off, log, on)", c.RetryContributionMode)
+	}
+	if len(c.DegradedSignal) > MaxDegradedSignalLength {
+		return fmt.Errorf("circuit: degraded_signal length %d exceeds max %d", len(c.DegradedSignal), MaxDegradedSignalLength)
+	}
+	return nil
 }
 
 // ProviderStats is returned by the Store for health / observability endpoints.

--- a/internal/circuit/types.go
+++ b/internal/circuit/types.go
@@ -2,11 +2,52 @@ package circuit
 
 import "time"
 
-// MagicString is injected into every degraded error response body so that
-// downstream callers (e.g. Finch Python SDKs) can detect provider degradation
-// by checking `"[FINCH_PROVIDER_DEGRADED]" in str(e)` regardless of which SDK
-// exception type wraps the HTTP error.
-const MagicString = "[FINCH_PROVIDER_DEGRADED]"
+// DefaultDegradedSignal is the default marker embedded in synthetic degraded
+// error response bodies.  Callers can override it per-deployment via
+// Config.DegradedSignal; e.g. an operator that wants a provider-neutral tag
+// might set it to "[LLM_PROXY_PROVIDER_DEGRADED]" or an org-specific string.
+//
+// ─── Why a body marker instead of a status code? ────────────────────────────
+//
+// The proxy already sets HTTP 503 and an X-Llm-Proxy-Error-Class response
+// header on every synthesised degradation response, but neither is sufficient
+// on its own for downstream clients to reliably detect a proxy-originated
+// degradation:
+//
+//  1. **5xx is ambiguous.**  The proxy streams real 5xx responses straight
+//     from providers (Anthropic 529, OpenAI 500/502/503/504, Gemini 500/503,
+//     etc.) through unmodified.  A client that only looks at status code
+//     cannot tell the difference between a passthrough upstream 503 and a
+//     proxy-synthesised "circuit open" 503.  They have very different
+//     semantics for retry / fallback decisions.
+//
+//  2. **4xx is wrong.**  The caller has done nothing wrong — the upstream is
+//     degraded.  Using 4xx would break SDK retry logic that (correctly)
+//     treats 4xx as a client-side error and refuses to retry.
+//
+//  3. **A novel status code (e.g. 599) is hostile to the ecosystem.**  Many
+//     reverse proxies, CDNs, and HTTP clients coerce unknown status codes
+//     to 500 or strip them entirely.  Anthropic / OpenAI / Google SDKs all
+//     map any ≥500 response into a generic APIError / ServerError class.
+//
+//  4. **Custom headers get stripped by the SDK exception layer.**  By the
+//     time an HTTPS error propagates up through e.g. the OpenAI Python SDK
+//     or LangChain, the caller typically only sees `str(exception)` — the
+//     response body in the exception message.  Response headers are usually
+//     only accessible if the caller catches a specific, provider-native
+//     exception type *before* any framework wraps it.  A substring of the
+//     body, on the other hand, survives every wrapping layer because the
+//     body ends up in the exception's message.
+//
+// So the contract is:
+//   - HTTP 503 + `X-Llm-Proxy-Error-Class: provider_degraded` for clients
+//     that read response metadata directly.
+//   - DegradedSignal substring in the JSON error message for SDK / framework
+//     consumers that only see the exception body.
+//
+// Clients should treat the presence of DegradedSignal anywhere in the
+// exception / response body as authoritative.
+const DefaultDegradedSignal = "[LLM_PROXY_PROVIDER_DEGRADED]"
 
 // TestModeHeader is the HTTP request header used to force specific failure
 // scenarios in integration tests without hitting real providers.
@@ -41,7 +82,8 @@ const (
 
 	// StateOpen is the degraded/cooldown state: the circuit has tripped.  The
 	// proxy fast-fails every request without hitting the network and returns
-	// the MagicString degraded error to Finch.
+	// a synthetic degraded error (503 + DegradedSignal in the body) to the
+	// caller.
 	StateOpen
 
 	// StateHalfOpen is the probing state: the cooldown period has expired and
@@ -139,6 +181,16 @@ type Config struct {
 	RedisAddress  string
 	RedisPassword string
 	RedisDB       int
+
+	// DegradedSignal is the opaque substring embedded in every synthesised
+	// degraded error body so downstream clients can detect proxy-originated
+	// provider degradation even after SDK / framework exception wrapping
+	// discards headers and remaps status codes.  See DefaultDegradedSignal
+	// for the rationale on why a body marker is used in addition to the 503
+	// status and X-Llm-Proxy-Error-Class header.
+	//
+	// Defaults to DefaultDegradedSignal when empty.
+	DegradedSignal string
 }
 
 // Defaults returns a Config with all zero fields replaced by sensible defaults.
@@ -163,6 +215,9 @@ func (c Config) Defaults() Config {
 	}
 	if c.GlobalRateLimitEscalationWindow <= 0 {
 		c.GlobalRateLimitEscalationWindow = 60
+	}
+	if c.DegradedSignal == "" {
+		c.DegradedSignal = DefaultDegradedSignal
 	}
 	return c
 }

--- a/internal/circuit/types.go
+++ b/internal/circuit/types.go
@@ -134,12 +134,40 @@ const (
 	FailureClassNone FailureClass = ""
 )
 
+// Operational modes for the circuit breaker.
+const (
+	// ModeEnforce is the normal, enforcing mode: retries transient failures,
+	// opens the circuit when the threshold is crossed, and returns synthetic
+	// 503 degraded responses on open or after retry exhaustion.
+	ModeEnforce = "enforce"
+
+	// ModeLog is a fully observe-only / shadow mode: the transport performs
+	// exactly one upstream round trip, classifies the response, records
+	// observed failures in the Store (so /health stats and counters are
+	// accurate), and emits structured counterfactual log lines describing
+	// what ModeEnforce would have done — but it never retries, never
+	// short-circuits when the circuit is "open", and never returns a
+	// synthetic response.  The caller always sees the real upstream
+	// response.  Intended for pre-rollout validation where we want to
+	// measure would-trip rates without touching live traffic.
+	ModeLog = "log"
+)
+
 // Config holds all circuit-breaker and retry tuning parameters.  Zero values
 // are replaced by the defaults documented on each field.
 type Config struct {
 	// Enabled gates the entire circuit-breaker feature.  When false the
 	// transport behaves as a simple pass-through with no retries.
 	Enabled bool
+
+	// Mode selects the operational mode: ModeLog (default) is observe-only
+	// (one round trip, record + log, return real response); ModeEnforce
+	// runs the full retry + fast-fail + synthetic-response behaviour.
+	//
+	// Defaulting to ModeLog is deliberate: a misconfigured or partially
+	// rolled-out deployment should err on the side of not altering user-
+	// facing traffic.  Operators opt in to enforcement explicitly.
+	Mode string
 
 	// Backend selects the state store: "memory" (default) or "redis".
 	Backend string
@@ -178,6 +206,21 @@ type Config struct {
 	GlobalRateLimitEscalationWindow int
 
 	// Redis connection settings, used when Backend == "redis".
+	//
+	// Two mutually compatible ways to supply the connection:
+	//   1. RedisURL — a full `redis://[:password@]host:port[/db]` (or
+	//      `rediss://...` for TLS) URL.  Parsed via redis.ParseURL so
+	//      every option it supports is honoured.  Intended to be populated
+	//      from a secret (e.g. SSM) so we can share Finch's Redis
+	//      instance without duplicating password/hostname config.
+	//   2. RedisAddress / RedisPassword / RedisDB — individual fields.
+	//
+	// If both are provided, RedisURL is parsed first and the individual
+	// fields overlay its result (so you can, for example, point the URL
+	// at Finch's cluster but explicitly pin DB to a dedicated circuit-
+	// breaker database).  A zero RedisDB is treated as "don't override"
+	// when a URL is also provided; set it explicitly to 0 via URL path.
+	RedisURL      string
 	RedisAddress  string
 	RedisPassword string
 	RedisDB       int
@@ -195,6 +238,18 @@ type Config struct {
 
 // Defaults returns a Config with all zero fields replaced by sensible defaults.
 func (c Config) Defaults() Config {
+	switch c.Mode {
+	case "":
+		c.Mode = ModeLog
+	case ModeEnforce, ModeLog:
+		// valid
+	default:
+		// Unknown mode — fall back to the safest default (log / observe-
+		// only) rather than silently enforcing, so misconfigurations
+		// don't translate into traffic-impacting behaviour.  We don't
+		// panic because Defaults() is called from many hot paths.
+		c.Mode = ModeLog
+	}
 	if c.FailureThreshold <= 0 {
 		c.FailureThreshold = 5
 	}

--- a/internal/config/circuit_breaker_yaml_test.go
+++ b/internal/config/circuit_breaker_yaml_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCircuitBreaker_EnvConfigsLoad is a guardrail that ensures every
+// environment YAML in `configs/` still parses and that production + staging
+// stay in observe-only mode until someone explicitly flips them.
+//
+// This catches two classes of mistake:
+//  1. Typos in the new `mode:` / `redis:` keys that would silently fall
+//     back to defaults.
+//  2. A future "make it live" change that sets mode=enforce in prod/staging
+//     without an accompanying test update — forcing the author to
+//     acknowledge the behavioural flip here.
+func TestCircuitBreaker_EnvConfigsLoad(t *testing.T) {
+	// Tests run from the package directory; configs live two levels up.
+	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
+	if err != nil {
+		t.Fatalf("resolve configs dir: %v", err)
+	}
+	if _, err := os.Stat(configsDir); err != nil {
+		t.Skipf("configs dir not found (%s) — skipping", configsDir)
+	}
+
+	tests := []struct {
+		file        string
+		wantEnabled bool
+		wantMode    string // "" skips the mode assertion
+		wantBackend string // "" skips the backend assertion
+	}{
+		// Production and staging must stay observe-only until an
+		// operator intentionally flips them and updates this test.
+		{"production.yml", true, "log", "redis"},
+		{"staging.yml", true, "log", "redis"},
+		// Dev is free to enforce + use memory; just assert it parses.
+		{"dev.yml", true, "", ""},
+		// Base is the shared root; no circuit-breaker assertions.
+		{"base.yml", false, "", ""},
+	}
+
+	basePath := filepath.Join(configsDir, "base.yml")
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.file, func(t *testing.T) {
+			envPath := filepath.Join(configsDir, tc.file)
+			// Env configs are delta-merged atop base.yml at runtime;
+			// validating the merged result is what actually matters.
+			paths := []string{basePath}
+			if tc.file != "base.yml" {
+				paths = append(paths, envPath)
+			}
+			cfg, err := LoadAndMergeConfigs(paths)
+			if err != nil {
+				t.Fatalf("load %s: %v", tc.file, err)
+			}
+			cb := cfg.Features.CircuitBreaker
+			if cb.Enabled != tc.wantEnabled {
+				t.Errorf("%s: cb.enabled want %v, got %v", tc.file, tc.wantEnabled, cb.Enabled)
+			}
+			if tc.wantMode != "" && cb.Mode != tc.wantMode {
+				t.Errorf("%s: cb.mode want %q, got %q (if you intentionally flipped the rollout mode, update this test)",
+					tc.file, tc.wantMode, cb.Mode)
+			}
+			if tc.wantBackend != "" && cb.Backend != tc.wantBackend {
+				t.Errorf("%s: cb.backend want %q, got %q", tc.file, tc.wantBackend, cb.Backend)
+			}
+		})
+	}
+}
+
+// TestCircuitBreaker_ProdAndStaging_RedisPinnedToDedicatedDB verifies that
+// the shared Finch Redis cluster can't accidentally collide with the
+// circuit-breaker namespace: we pin to a dedicated DB so a future operator
+// mistake in ML_CACHE_URL can't start overwriting app cache keys.
+func TestCircuitBreaker_ProdAndStaging_RedisPinnedToDedicatedDB(t *testing.T) {
+	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
+	if err != nil {
+		t.Fatalf("resolve configs dir: %v", err)
+	}
+	if _, err := os.Stat(configsDir); err != nil {
+		t.Skipf("configs dir not found (%s) — skipping", configsDir)
+	}
+
+	basePath := filepath.Join(configsDir, "base.yml")
+	for _, file := range []string{"production.yml", "staging.yml"} {
+		cfg, err := LoadAndMergeConfigs([]string{basePath, filepath.Join(configsDir, file)})
+		if err != nil {
+			t.Fatalf("load %s: %v", file, err)
+		}
+		cb := cfg.Features.CircuitBreaker
+		if cb.Redis == nil {
+			t.Fatalf("%s: cb.redis must be populated for shared-cluster rollout", file)
+		}
+		if cb.Redis.DB == 0 {
+			t.Errorf("%s: cb.redis.db must be explicitly non-zero so we don't collide with Finch (got 0)", file)
+		}
+		if cb.Redis.URL == "" {
+			t.Errorf("%s: cb.redis.url must be set (expected `${REDIS_URL}` from ECS secret)", file)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,17 @@ type CircuitBreakerConfig struct {
 	// Enabled gates the feature entirely.
 	Enabled bool `yaml:"enabled"`
 
+	// Mode selects the operational mode.  "log" (default) is observe-only:
+	// the transport does one round trip, classifies the response, records
+	// failures in the store for observability, emits counterfactual log
+	// lines, and returns the real upstream response — no retries, no
+	// fast-fail on open circuit, no synthetic 503s.  "enforce" runs the
+	// full retry + fast-fail + synthetic-response behaviour.
+	//
+	// The safe default is "log" so that partially rolled-out or
+	// misconfigured deployments never alter user-facing traffic.
+	Mode string `yaml:"mode"`
+
 	// Backend selects the state store: "memory" (default, single-process) or
 	// "redis" (recommended for production with multiple proxy instances).
 	Backend string `yaml:"backend"`
@@ -183,9 +194,21 @@ type EstimationConfig struct {
 
 // RedisConfig contains Redis backend settings
 type RedisConfig struct {
+	// URL is a full Redis connection string (e.g. `redis://:pw@host:6379/3`
+	// or `rediss://...` for TLS).  Takes priority over Address/Password
+	// when set, and any `${VAR}` / `$VAR` token is expanded from the
+	// process environment at load time so secrets (e.g. Finch's
+	// ML_CACHE_URL SSM parameter) can be passed in via container
+	// environment without baking credentials into YAML.
+	URL      string `yaml:"url"`
 	Address  string `yaml:"address"`
 	Password string `yaml:"password"`
-	DB       int    `yaml:"db"`
+	// DB pins which Redis database the circuit breaker uses.  When the
+	// URL already encodes a DB (via `/N`) this field overrides it — set
+	// this explicitly when sharing a Redis instance with another tenant
+	// that owns a different DB.  A zero value is treated as "don't
+	// override".
+	DB int `yaml:"db"`
 }
 
 // ProviderConfig represents configuration for a specific provider
@@ -753,6 +776,7 @@ func GetDefaultYAMLConfig() *YAMLConfig {
 		Features: FeaturesConfig{
 			CircuitBreaker: CircuitBreakerConfig{
 				Enabled:                         false,
+				Mode:                            "log",
 				Backend:                         "memory",
 				FailureThreshold:                5,
 				WindowSeconds:                   120,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,53 @@ type FeaturesConfig struct {
 	CostTracking     CostTrackingConfig     `yaml:"cost_tracking"`
 	APIKeyManagement APIKeyManagementConfig `yaml:"api_key_management"`
 	RateLimiting     RateLimitingConfig     `yaml:"rate_limiting"`
+	CircuitBreaker   CircuitBreakerConfig   `yaml:"circuit_breaker"`
+}
+
+// CircuitBreakerConfig configures the proxy-side circuit breaker and retry
+// policies for provider degradation detection.
+type CircuitBreakerConfig struct {
+	// Enabled gates the feature entirely.
+	Enabled bool `yaml:"enabled"`
+
+	// Backend selects the state store: "memory" (default, single-process) or
+	// "redis" (recommended for production with multiple proxy instances).
+	Backend string `yaml:"backend"`
+
+	// FailureThreshold is the number of terminal failures within WindowSeconds
+	// that trips the circuit.  Default: 5.
+	FailureThreshold int `yaml:"failure_threshold"`
+
+	// WindowSeconds is the sliding-window TTL for failure counters.  Default: 120.
+	WindowSeconds int `yaml:"window_seconds"`
+
+	// CooldownSeconds is how long the circuit stays Open before probing.
+	// Default: 300.
+	CooldownSeconds int `yaml:"cooldown_seconds"`
+
+	// MaxTransientRetries is the retry limit for degraded-class failures.
+	// Default: 2.
+	MaxTransientRetries int `yaml:"max_transient_retries"`
+
+	// MaxRateLimitRetries is the retry limit for rate-limit failures.
+	// Default: 2.
+	MaxRateLimitRetries int `yaml:"max_rate_limit_retries"`
+
+	// RetryContributionMode controls whether retried failures count toward the
+	// circuit-breaker threshold.  Values: "off", "log" (default), "on".
+	RetryContributionMode string `yaml:"retry_contribution_mode"`
+
+	// GlobalRateLimitEscalationWindow is the number of seconds of sustained
+	// global rate-limit failures that must elapse before escalating to
+	// provider_degraded.  Default: 60.
+	GlobalRateLimitEscalationWindow int `yaml:"global_rate_limit_escalation_window"`
+
+	// Redis connection settings when Backend is "redis".
+	Redis *RedisConfig `yaml:"redis,omitempty"`
+
+	// TestModeEnabled allows the X-LLM-Proxy-Test-Mode header to be honoured.
+	// Should be false in production.
+	TestModeEnabled bool `yaml:"test_mode_enabled"`
 }
 
 // CostTrackingConfig represents cost tracking feature configuration
@@ -697,6 +744,18 @@ func GetDefaultYAMLConfig() *YAMLConfig {
 	return &YAMLConfig{
 		Enabled: true,
 		Features: FeaturesConfig{
+			CircuitBreaker: CircuitBreakerConfig{
+				Enabled:                         false,
+				Backend:                         "memory",
+				FailureThreshold:                5,
+				WindowSeconds:                   120,
+				CooldownSeconds:                 300,
+				MaxTransientRetries:             2,
+				MaxRateLimitRetries:             2,
+				RetryContributionMode:           "log",
+				GlobalRateLimitEscalationWindow: 60,
+				TestModeEnabled:                 false,
+			},
 			CostTracking: CostTrackingConfig{
 				Enabled: true,
 				Transports: []TransportConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,13 @@ type CircuitBreakerConfig struct {
 	// TestModeEnabled allows the X-LLM-Proxy-Test-Mode header to be honoured.
 	// Should be false in production.
 	TestModeEnabled bool `yaml:"test_mode_enabled"`
+
+	// DegradedSignal overrides the substring embedded in synthesised
+	// degraded error bodies so downstream clients can detect proxy-
+	// originated degradation.  Leave empty to use the default
+	// (see circuit.DefaultDegradedSignal).  Change it only if your clients
+	// already key off a different, project-specific tag.
+	DegradedSignal string `yaml:"degraded_signal,omitempty"`
 }
 
 // CostTrackingConfig represents cost tracking feature configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -707,10 +707,10 @@ func (c *YAMLConfig) validateCircuitBreakerConfig() error {
 		// default to memory
 	case "redis":
 		if cb.Redis == nil {
-			return fmt.Errorf("backend redis requires redis configuration")
+			return fmt.Errorf("backend redis requires RedisConfig")
 		}
 		if cb.Redis.URL == "" && cb.Redis.Address == "" {
-			return fmt.Errorf("backend redis requires redis.url or redis.address")
+			return fmt.Errorf("backend redis requires RedisConfig.url or RedisConfig.address")
 		}
 	default:
 		return fmt.Errorf("backend must be one of memory, redis (got %q)", cb.Backend)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -196,19 +198,115 @@ type EstimationConfig struct {
 type RedisConfig struct {
 	// URL is a full Redis connection string (e.g. `redis://:pw@host:6379/3`
 	// or `rediss://...` for TLS).  Takes priority over Address/Password
-	// when set, and any `${VAR}` / `$VAR` token is expanded from the
-	// process environment at load time so secrets (e.g. Finch's
-	// ML_CACHE_URL SSM parameter) can be passed in via container
-	// environment without baking credentials into YAML.
+	// when set.  YAML unmarshalling does not expand `${VAR}` / `$VAR`
+	// tokens; callers may expand them later during wiring/initialization
+	// so secrets (e.g. Finch's ML_CACHE_URL SSM parameter) can be passed
+	// in via container environment without baking credentials into YAML.
 	URL      string `yaml:"url"`
 	Address  string `yaml:"address"`
 	Password string `yaml:"password"`
 	// DB pins which Redis database the circuit breaker uses.  When the
 	// URL already encodes a DB (via `/N`) this field overrides it — set
 	// this explicitly when sharing a Redis instance with another tenant
-	// that owns a different DB.  A zero value is treated as "don't
-	// override".
-	DB int `yaml:"db"`
+	// that owns a different DB.  DBSet tracks whether YAML explicitly
+	// provided db, allowing an explicit db: 0 to override a URL DB.
+	DB    int  `yaml:"db"`
+	DBSet bool `yaml:"-"`
+}
+
+type redisConfigYAML struct {
+	URL      string `yaml:"url,omitempty"`
+	Address  string `yaml:"address,omitempty"`
+	Password string `yaml:"password,omitempty"`
+	DB       *int   `yaml:"db,omitempty"`
+}
+
+// UnmarshalYAML records whether db was explicitly present so db: 0 can be
+// distinguished from an omitted DB value.
+func (c *RedisConfig) UnmarshalYAML(value *yaml.Node) error {
+	var raw redisConfigYAML
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+
+	c.URL = raw.URL
+	c.Address = raw.Address
+	c.Password = raw.Password
+	if raw.DB != nil {
+		c.DB = *raw.DB
+		c.DBSet = true
+	} else {
+		c.DB = 0
+		c.DBSet = false
+	}
+	return nil
+}
+
+// MarshalYAML preserves the distinction between omitted db and explicit db: 0
+// across config merge round-trips.
+func (c RedisConfig) MarshalYAML() (interface{}, error) {
+	out := redisConfigYAML{
+		URL:      c.URL,
+		Address:  c.Address,
+		Password: c.Password,
+	}
+	if c.DBSet {
+		db := c.DB
+		out.DB = &db
+	}
+	return out, nil
+}
+
+// MarshalJSON redacts secret-bearing fields on RedisConfig so the full
+// configuration can be safely dumped by the --version / /health paths
+// (or any other JSON diagnostic output) without leaking credentials.
+// Password is replaced with a fixed sentinel when present, and any
+// userinfo in URL is stripped by re-marshalling the parsed URL.  The
+// output schema is stable: every field the YAML form uses is still
+// present so diagnostic tooling does not have to special-case
+// redacted payloads.
+//
+// Note: this only affects JSON marshalling.  The YAML-tagged struct
+// can still be serialised unchanged for round-trip writes (see
+// SaveConfigurationToFile) — in that code path the config is written
+// back to an operator-owned file where the original credentials must
+// be preserved.
+func (c RedisConfig) MarshalJSON() ([]byte, error) {
+	const redacted = "***REDACTED***"
+	// Use an alias type to avoid an infinite MarshalJSON recursion on
+	// the embedded struct literal.  The alias has no methods.
+	type redisConfigJSON struct {
+		URL      string `json:"url,omitempty"`
+		Address  string `json:"address,omitempty"`
+		Password string `json:"password,omitempty"`
+		DB       int    `json:"db"`
+	}
+	out := redisConfigJSON{
+		URL:     redactedRedisURL(c.URL),
+		Address: c.Address,
+		DB:      c.DB,
+	}
+	if c.Password != "" {
+		out.Password = redacted
+	}
+	return json.Marshal(out)
+}
+
+// redactedRedisURL returns u with any embedded userinfo (`user:pw@`)
+// replaced by `***:***@`.  An unparseable URL is fully redacted to
+// "***" since we cannot safely strip credentials we cannot locate.
+func redactedRedisURL(u string) string {
+	if u == "" {
+		return ""
+	}
+	parsed, err := url.Parse(u)
+	if err != nil || parsed == nil {
+		return "***"
+	}
+	if parsed.User != nil {
+		parsed.User = url.UserPassword("***", "***")
+	}
+	return parsed.String()
 }
 
 // ProviderConfig represents configuration for a specific provider
@@ -490,6 +588,13 @@ func (c *YAMLConfig) Validate() error {
 		}
 	}
 
+	// Validate circuit breaker configuration if enabled
+	if c.Features.CircuitBreaker.Enabled {
+		if err := c.validateCircuitBreakerConfig(); err != nil {
+			return fmt.Errorf("invalid CircuitBreakerConfig: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -559,8 +664,8 @@ func (c *YAMLConfig) validateRateLimitingConfig() error {
 	case "", "memory":
 		// default to memory
 	case "redis":
-		if rl.Redis == nil || rl.Redis.Address == "" {
-			return fmt.Errorf("redis backend selected but redis.address is empty")
+		if rl.Redis == nil || (rl.Redis.URL == "" && rl.Redis.Address == "") {
+			return fmt.Errorf("redis backend selected but redis.url and redis.address are empty")
 		}
 	default:
 		return fmt.Errorf("unsupported backend: %s (supported: memory, redis)", rl.Backend)
@@ -583,6 +688,68 @@ func (c *YAMLConfig) validateRateLimitingConfig() error {
 			}
 		}
 	}
+	return nil
+}
+
+// validateCircuitBreakerConfig validates the circuit_breaker feature config
+// early so --validate-config catches rollout typos before runtime.
+func (c *YAMLConfig) validateCircuitBreakerConfig() error {
+	cb := c.Features.CircuitBreaker
+
+	switch cb.Mode {
+	case "", "log", "enforce":
+	default:
+		return fmt.Errorf("mode must be one of log, enforce (got %q)", cb.Mode)
+	}
+
+	switch cb.Backend {
+	case "", "memory":
+		// default to memory
+	case "redis":
+		if cb.Redis == nil {
+			return fmt.Errorf("backend redis requires redis configuration")
+		}
+		if cb.Redis.URL == "" && cb.Redis.Address == "" {
+			return fmt.Errorf("backend redis requires redis.url or redis.address")
+		}
+	default:
+		return fmt.Errorf("backend must be one of memory, redis (got %q)", cb.Backend)
+	}
+
+	if cb.FailureThreshold < 0 {
+		return fmt.Errorf("failure_threshold cannot be negative")
+	}
+	if cb.FailureThreshold == 0 {
+		return fmt.Errorf("failure_threshold must be greater than 0")
+	}
+	if cb.WindowSeconds < 0 {
+		return fmt.Errorf("window_seconds cannot be negative")
+	}
+	if cb.WindowSeconds == 0 {
+		return fmt.Errorf("window_seconds must be greater than 0")
+	}
+	if cb.CooldownSeconds < 0 {
+		return fmt.Errorf("cooldown_seconds cannot be negative")
+	}
+	if cb.CooldownSeconds == 0 {
+		return fmt.Errorf("cooldown_seconds must be greater than 0")
+	}
+	if cb.MaxTransientRetries < 0 {
+		return fmt.Errorf("max_transient_retries cannot be negative")
+	}
+	if cb.MaxRateLimitRetries < 0 {
+		return fmt.Errorf("max_rate_limit_retries cannot be negative")
+	}
+	if cb.GlobalRateLimitEscalationWindow < 0 {
+		return fmt.Errorf("global_rate_limit_escalation_window cannot be negative")
+	}
+
+	switch cb.RetryContributionMode {
+	case "", "off", "log", "on":
+	default:
+		return fmt.Errorf("retry_contribution_mode must be one of off, log, on (got %q)", cb.RetryContributionMode)
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -379,5 +380,84 @@ func TestDefaultConfig(t *testing.T) {
 	// Test cost tracking is enabled by default
 	if !config.Features.CostTracking.Enabled {
 		t.Error("Expected cost tracking to be enabled in default config")
+	}
+}
+
+func TestRedisConfig_ExplicitZeroDBIsRecordedAsSet(t *testing.T) {
+	var cfg RedisConfig
+	if err := yaml.Unmarshal([]byte("url: redis://cache.example.com:6379/6\ndb: 0\n"), &cfg); err != nil {
+		t.Fatalf("unmarshal redis config: %v", err)
+	}
+	if cfg.DB != 0 {
+		t.Fatalf("want DB=0, got %d", cfg.DB)
+	}
+	if !cfg.DBSet {
+		t.Fatal("explicit db: 0 should set DBSet")
+	}
+}
+
+func TestValidateRateLimitingConfig_RedisURLOrAddress(t *testing.T) {
+	cfg := &YAMLConfig{
+		Providers: map[string]ProviderConfig{"openai": {Enabled: true}},
+		Features: FeaturesConfig{
+			RateLimiting: RateLimitingConfig{
+				Enabled: true,
+				Backend: "redis",
+				Redis:   &RedisConfig{URL: "redis://cache.example.com:6379/0"},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("redis.url should satisfy rate limiting validation: %v", err)
+	}
+
+	cfg.Features.RateLimiting.Redis = &RedisConfig{Address: "cache.example.com:6379"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("redis.address should satisfy rate limiting validation: %v", err)
+	}
+}
+
+func TestValidateCircuitBreakerConfig(t *testing.T) {
+	valid := &YAMLConfig{
+		Providers: map[string]ProviderConfig{"openai": {Enabled: true}},
+		Features: FeaturesConfig{
+			CircuitBreaker: CircuitBreakerConfig{
+				Enabled:                         true,
+				Mode:                            "log",
+				Backend:                         "redis",
+				FailureThreshold:                5,
+				WindowSeconds:                   120,
+				CooldownSeconds:                 300,
+				MaxTransientRetries:             2,
+				MaxRateLimitRetries:             2,
+				RetryContributionMode:           "log",
+				GlobalRateLimitEscalationWindow: 60,
+				Redis:                           &RedisConfig{URL: "redis://cache.example.com:6379/0"},
+			},
+		},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid CircuitBreakerConfig rejected: %v", err)
+	}
+
+	invalidMode := *valid
+	invalidMode.Features.CircuitBreaker.Mode = "observe"
+	err := invalidMode.Validate()
+	if err == nil || !strings.Contains(err.Error(), "CircuitBreakerConfig") {
+		t.Fatalf("invalid mode should produce CircuitBreakerConfig validation error, got %v", err)
+	}
+
+	missingRedis := *valid
+	missingRedis.Features.CircuitBreaker.Redis = nil
+	err = missingRedis.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires redis configuration") {
+		t.Fatalf("redis backend without config should fail, got %v", err)
+	}
+
+	negativeRetries := *valid
+	negativeRetries.Features.CircuitBreaker.MaxTransientRetries = -1
+	err = negativeRetries.Validate()
+	if err == nil || !strings.Contains(err.Error(), "max_transient_retries") {
+		t.Fatalf("negative retry count should fail, got %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -450,7 +450,7 @@ func TestValidateCircuitBreakerConfig(t *testing.T) {
 	missingRedis := *valid
 	missingRedis.Features.CircuitBreaker.Redis = nil
 	err = missingRedis.Validate()
-	if err == nil || !strings.Contains(err.Error(), "requires redis configuration") {
+	if err == nil || !strings.Contains(err.Error(), "requires RedisConfig") {
 		t.Fatalf("redis backend without config should fail, got %v", err)
 	}
 

--- a/internal/middleware/testmode.go
+++ b/internal/middleware/testmode.go
@@ -8,6 +8,33 @@ import (
 	"github.com/Instawork/llm-proxy/internal/circuit"
 )
 
+// knownProviders is the allowlist writeDegradedResponse uses to decide
+// whether it is safe to reflect a path-derived provider name into the
+// JSON `message` field.  Anything outside this set is coerced to
+// "unknown" so an attacker-controlled URL path cannot smuggle
+// arbitrary substrings into a response body that will surface in
+// client-side logs, SDK exceptions, or error-reporting pipelines.
+//
+// The list is intentionally short and static; if you add a new
+// provider to the proxy, extend this map too.  (We prefer an explicit
+// allowlist over regex/sanitisation because the set of supported
+// providers is closed and small.)
+var knownProviders = map[string]struct{}{
+	"openai":    {},
+	"anthropic": {},
+	"gemini":    {},
+}
+
+// safeProviderName returns provider verbatim when it appears in
+// knownProviders; otherwise it returns "unknown".  See knownProviders
+// for the rationale.
+func safeProviderName(provider string) string {
+	if _, ok := knownProviders[provider]; ok {
+		return provider
+	}
+	return "unknown"
+}
+
 // NewTestModeMiddleware returns middleware that intercepts requests carrying
 // the X-LLM-Proxy-Test-Mode header (or the llm_proxy_test_mode query param)
 // and returns synthetic responses without hitting real LLM providers.
@@ -83,10 +110,12 @@ func providerFromRequest(r *http.Request) string {
 }
 
 // writeDegradedResponse writes a 503 JSON response whose message contains
-// the configured degraded signal.
+// the configured degraded signal.  The provider name is validated
+// against an allowlist before being reflected into the response body
+// so a caller cannot inject arbitrary text via the URL path.
 func writeDegradedResponse(w http.ResponseWriter, provider, signal string) {
 	msg := fmt.Sprintf("%s Provider %s is currently degraded or unavailable. Please try again later.",
-		signal, provider)
+		signal, safeProviderName(provider))
 
 	body := map[string]interface{}{
 		"error": map[string]interface{}{

--- a/internal/middleware/testmode.go
+++ b/internal/middleware/testmode.go
@@ -8,48 +8,63 @@ import (
 	"github.com/Instawork/llm-proxy/internal/circuit"
 )
 
-// TestModeMiddleware intercepts requests that carry the X-LLM-Proxy-Test-Mode
-// header and returns synthetic responses without hitting real LLM providers.
+// NewTestModeMiddleware returns middleware that intercepts requests carrying
+// the X-LLM-Proxy-Test-Mode header (or the llm_proxy_test_mode query param)
+// and returns synthetic responses without hitting real LLM providers.
 //
-// This is intended exclusively for integration tests.  It should be disabled
-// in production via the TestModeEnabled config flag.
+// This is intended exclusively for integration tests.  It should stay
+// disabled in production via the TestModeEnabled config flag.
 //
-// Supported header values:
-//   - force_degraded: immediately return a 503 with the MagicString degraded
-//     error body, exactly as the circuit breaker would when the circuit is open.
+// The `signal` argument is the degraded-body marker that will be embedded in
+// synthetic degraded responses; pass circuit.Config.DegradedSignal (falls
+// back to circuit.DefaultDegradedSignal when empty).  See the docstring on
+// circuit.DefaultDegradedSignal for the full rationale on why we use a body
+// substring in addition to the 503 status and response headers.
 //
-// The force_transient_recover scenario is handled at the Transport level (see
-// internal/circuit/transport.go) because it needs to interact with the
+// Supported test mode values:
+//
+//   - force_degraded: immediately return a 503 with the degraded error body
+//     (including `signal`), exactly as the circuit breaker would when the
+//     circuit is open.
+//
+// The force_transient_recover scenario is handled at the Transport level
+// (see internal/circuit/transport.go) because it needs to interact with the
 // internal retry loop.
-func TestModeMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mode := testModeValue(r)
-		if mode == "" {
-			next.ServeHTTP(w, r)
-			return
-		}
+func NewTestModeMiddleware(signal string) func(http.Handler) http.Handler {
+	if signal == "" {
+		signal = circuit.DefaultDegradedSignal
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mode := testModeValue(r)
+			if mode == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
 
-		// Promote query-param to header so the circuit Transport sees it too,
-		// then strip the param from the URL before forwarding downstream.
-		if r.URL.Query().Get(circuit.TestModeQueryParam) != "" {
-			r = r.Clone(r.Context())
-			r.Header.Set(circuit.TestModeHeader, mode)
-			q := r.URL.Query()
-			q.Del(circuit.TestModeQueryParam)
-			r.URL.RawQuery = q.Encode()
-		}
+			// Promote query-param to header so the circuit Transport sees it
+			// too, then strip the param from the URL before forwarding.
+			if r.URL.Query().Get(circuit.TestModeQueryParam) != "" {
+				r = r.Clone(r.Context())
+				r.Header.Set(circuit.TestModeHeader, mode)
+				q := r.URL.Query()
+				q.Del(circuit.TestModeQueryParam)
+				r.URL.RawQuery = q.Encode()
+			}
 
-		switch mode {
-		case circuit.TestModeForceDegraded:
-			provider := providerFromRequest(r)
-			writeDegradedResponse(w, provider)
-			return
+			switch mode {
+			case circuit.TestModeForceDegraded:
+				provider := providerFromRequest(r)
+				writeDegradedResponse(w, provider, signal)
+				return
 
-		default:
-			// Unknown test mode — pass through so the transport can handle it.
-			next.ServeHTTP(w, r)
-		}
-	})
+			default:
+				// Unknown test mode — pass through so the transport can
+				// handle it.
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
 }
 
 // testModeValue returns the test mode string from the header or, as a fallback,
@@ -67,10 +82,11 @@ func providerFromRequest(r *http.Request) string {
 	return circuit.ProviderFromPath(r.URL.Path)
 }
 
-// writeDegradedResponse writes a 503 JSON response containing MagicString.
-func writeDegradedResponse(w http.ResponseWriter, provider string) {
+// writeDegradedResponse writes a 503 JSON response whose message contains
+// the configured degraded signal.
+func writeDegradedResponse(w http.ResponseWriter, provider, signal string) {
 	msg := fmt.Sprintf("%s Provider %s is currently degraded or unavailable. Please try again later.",
-		circuit.MagicString, provider)
+		signal, provider)
 
 	body := map[string]interface{}{
 		"error": map[string]interface{}{

--- a/internal/middleware/testmode.go
+++ b/internal/middleware/testmode.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Instawork/llm-proxy/internal/circuit"
+)
+
+// TestModeMiddleware intercepts requests that carry the X-LLM-Proxy-Test-Mode
+// header and returns synthetic responses without hitting real LLM providers.
+//
+// This is intended exclusively for integration tests.  It should be disabled
+// in production via the TestModeEnabled config flag.
+//
+// Supported header values:
+//   - force_degraded: immediately return a 503 with the MagicString degraded
+//     error body, exactly as the circuit breaker would when the circuit is open.
+//
+// The force_transient_recover scenario is handled at the Transport level (see
+// internal/circuit/transport.go) because it needs to interact with the
+// internal retry loop.
+func TestModeMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mode := testModeValue(r)
+		if mode == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Promote query-param to header so the circuit Transport sees it too,
+		// then strip the param from the URL before forwarding downstream.
+		if r.URL.Query().Get(circuit.TestModeQueryParam) != "" {
+			r = r.Clone(r.Context())
+			r.Header.Set(circuit.TestModeHeader, mode)
+			q := r.URL.Query()
+			q.Del(circuit.TestModeQueryParam)
+			r.URL.RawQuery = q.Encode()
+		}
+
+		switch mode {
+		case circuit.TestModeForceDegraded:
+			provider := providerFromRequest(r)
+			writeDegradedResponse(w, provider)
+			return
+
+		default:
+			// Unknown test mode — pass through so the transport can handle it.
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+// testModeValue returns the test mode string from the header or, as a fallback,
+// the URL query parameter.  Header takes precedence.
+func testModeValue(r *http.Request) string {
+	if v := r.Header.Get(circuit.TestModeHeader); v != "" {
+		return v
+	}
+	return r.URL.Query().Get(circuit.TestModeQueryParam)
+}
+
+// providerFromRequest extracts the provider name from the URL path.
+// E.g. "/openai/v1/chat/completions" → "openai".
+func providerFromRequest(r *http.Request) string {
+	return circuit.ProviderFromPath(r.URL.Path)
+}
+
+// writeDegradedResponse writes a 503 JSON response containing MagicString.
+func writeDegradedResponse(w http.ResponseWriter, provider string) {
+	msg := fmt.Sprintf("%s Provider %s is currently degraded or unavailable. Please try again later.",
+		circuit.MagicString, provider)
+
+	body := map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": msg,
+			"type":    "provider_degraded",
+			"code":    "provider_degraded",
+		},
+	}
+	b, _ := json.Marshal(body)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Llm-Proxy-Error-Class", string(circuit.FailureClassDegraded))
+	w.WriteHeader(http.StatusServiceUnavailable)
+	w.Write(b) //nolint:errcheck
+}

--- a/internal/middleware/testmode_test.go
+++ b/internal/middleware/testmode_test.go
@@ -1,0 +1,229 @@
+package middleware
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/circuit"
+)
+
+func TestTestModeMiddleware_ForceDegraded(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TestModeMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+	req.Header.Set(circuit.TestModeHeader, circuit.TestModeForceDegraded)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Fatal("next handler should NOT be called for force_degraded")
+	}
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rr.Code)
+	}
+	body, _ := io.ReadAll(rr.Body)
+	if !strings.Contains(string(body), circuit.MagicString) {
+		t.Fatalf("MagicString not found in response body: %s", body)
+	}
+	// Verify valid JSON.
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("body is not valid JSON: %v\nbody: %s", err, body)
+	}
+	errObj, _ := payload["error"].(map[string]interface{})
+	if errObj == nil {
+		t.Fatal("expected 'error' key in JSON")
+	}
+}
+
+func TestTestModeMiddleware_NoHeader_PassThrough(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TestModeMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Fatal("next handler should be called when no test-mode header")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+}
+
+func TestTestModeMiddleware_UnknownMode_PassThrough(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TestModeMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", nil)
+	req.Header.Set(circuit.TestModeHeader, "unknown_mode")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Fatal("next handler should be called for unknown test mode")
+	}
+}
+
+func TestTestModeMiddleware_QueryParam_ForceDegraded(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TestModeMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/gemini/v1beta/models/gemini-2.5-flash:generateContent?llm_proxy_test_mode=force_degraded", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Fatal("next handler should NOT be called for force_degraded via query param")
+	}
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rr.Code)
+	}
+	body, _ := io.ReadAll(rr.Body)
+	if !strings.Contains(string(body), circuit.MagicString) {
+		t.Fatalf("MagicString not found in query-param response body: %s", body)
+	}
+}
+
+func TestTestModeMiddleware_QueryParam_StrippedFromURL(t *testing.T) {
+	var forwardedURL string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwardedURL = r.URL.String()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TestModeMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/openai/v1/chat/completions?llm_proxy_test_mode=force_transient_recover&other=123", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if strings.Contains(forwardedURL, "llm_proxy_test_mode") {
+		t.Fatalf("query param should be stripped from forwarded URL, got: %s", forwardedURL)
+	}
+	if !strings.Contains(forwardedURL, "other=123") {
+		t.Fatalf("other query params should be preserved, got: %s", forwardedURL)
+	}
+}
+
+func TestTestModeMiddleware_ForceDegraded_SetsErrorClassHeader(t *testing.T) {
+	handler := TestModeMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+	req.Header.Set(circuit.TestModeHeader, circuit.TestModeForceDegraded)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("X-Llm-Proxy-Error-Class"); got != string(circuit.FailureClassDegraded) {
+		t.Fatalf("want X-Llm-Proxy-Error-Class=%q, got %q", circuit.FailureClassDegraded, got)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("want Content-Type application/json, got %q", got)
+	}
+}
+
+// TestTestModeMiddleware_HeaderTakesPrecedenceOverQueryParam ensures that when
+// both the header and query param are set, the header value wins.  This matters
+// because the circuit Transport reads the header and we don't want query-param
+// typos to silently override an explicit header value.
+func TestTestModeMiddleware_HeaderTakesPrecedenceOverQueryParam(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TestModeMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/openai/v1/chat/completions?llm_proxy_test_mode=unknown_mode", nil)
+	req.Header.Set(circuit.TestModeHeader, circuit.TestModeForceDegraded)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Fatal("header force_degraded should take precedence over query param unknown_mode")
+	}
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 from header-driven force_degraded, got %d", rr.Code)
+	}
+}
+
+// TestTestModeMiddleware_QueryParamPromotedToHeader ensures that a
+// query-param-driven test mode is forwarded downstream as a header so the
+// circuit Transport (which only reads the header) can also see it when the
+// middleware forwards transient-recover.
+func TestTestModeMiddleware_QueryParamPromotedToHeader(t *testing.T) {
+	var seenHeader string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeader = r.Header.Get(circuit.TestModeHeader)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TestModeMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/openai/v1/chat/completions?llm_proxy_test_mode=force_transient_recover", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if seenHeader != circuit.TestModeForceTransientRecover {
+		t.Fatalf("query-param test mode should be promoted to header, got header=%q", seenHeader)
+	}
+}
+
+func TestTestModeMiddleware_ForceDegraded_ContainsProvider(t *testing.T) {
+	handler := TestModeMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	for _, path := range []string{
+		"/openai/v1/chat/completions",
+		"/anthropic/v1/messages",
+		"/gemini/v1beta/models/gemini-2.5-flash:generateContent",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req.Header.Set(circuit.TestModeHeader, circuit.TestModeForceDegraded)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		body, _ := io.ReadAll(rr.Body)
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Errorf("path %s: want 503, got %d", path, rr.Code)
+		}
+		if !strings.Contains(string(body), circuit.MagicString) {
+			t.Errorf("path %s: MagicString not in body: %s", path, body)
+		}
+	}
+}

--- a/internal/middleware/testmode_test.go
+++ b/internal/middleware/testmode_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/Instawork/llm-proxy/internal/circuit"
 )
 
+// newTestMiddleware builds a TestModeMiddleware with the default signal,
+// matching the behaviour of the old package-level function.
+func newTestMiddleware() func(http.Handler) http.Handler {
+	return NewTestModeMiddleware(circuit.DefaultDegradedSignal)
+}
+
 func TestTestModeMiddleware_ForceDegraded(t *testing.T) {
 	called := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +24,7 @@ func TestTestModeMiddleware_ForceDegraded(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := TestModeMiddleware(next)
+	handler := newTestMiddleware()(next)
 
 	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
 	req.Header.Set(circuit.TestModeHeader, circuit.TestModeForceDegraded)
@@ -33,8 +39,8 @@ func TestTestModeMiddleware_ForceDegraded(t *testing.T) {
 		t.Fatalf("want 503, got %d", rr.Code)
 	}
 	body, _ := io.ReadAll(rr.Body)
-	if !strings.Contains(string(body), circuit.MagicString) {
-		t.Fatalf("MagicString not found in response body: %s", body)
+	if !strings.Contains(string(body), circuit.DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found in response body: %s", body)
 	}
 	// Verify valid JSON.
 	var payload map[string]interface{}
@@ -54,7 +60,7 @@ func TestTestModeMiddleware_NoHeader_PassThrough(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := TestModeMiddleware(next)
+	handler := newTestMiddleware()(next)
 
 	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
 	rr := httptest.NewRecorder()
@@ -76,7 +82,7 @@ func TestTestModeMiddleware_UnknownMode_PassThrough(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := TestModeMiddleware(next)
+	handler := newTestMiddleware()(next)
 
 	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", nil)
 	req.Header.Set(circuit.TestModeHeader, "unknown_mode")
@@ -96,7 +102,7 @@ func TestTestModeMiddleware_QueryParam_ForceDegraded(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := TestModeMiddleware(next)
+	handler := newTestMiddleware()(next)
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/gemini/v1beta/models/gemini-2.5-flash:generateContent?llm_proxy_test_mode=force_degraded", nil)
@@ -111,8 +117,8 @@ func TestTestModeMiddleware_QueryParam_ForceDegraded(t *testing.T) {
 		t.Fatalf("want 503, got %d", rr.Code)
 	}
 	body, _ := io.ReadAll(rr.Body)
-	if !strings.Contains(string(body), circuit.MagicString) {
-		t.Fatalf("MagicString not found in query-param response body: %s", body)
+	if !strings.Contains(string(body), circuit.DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found in query-param response body: %s", body)
 	}
 }
 
@@ -123,7 +129,7 @@ func TestTestModeMiddleware_QueryParam_StrippedFromURL(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := TestModeMiddleware(next)
+	handler := newTestMiddleware()(next)
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/openai/v1/chat/completions?llm_proxy_test_mode=force_transient_recover&other=123", nil)
@@ -140,7 +146,7 @@ func TestTestModeMiddleware_QueryParam_StrippedFromURL(t *testing.T) {
 }
 
 func TestTestModeMiddleware_ForceDegraded_SetsErrorClassHeader(t *testing.T) {
-	handler := TestModeMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	handler := newTestMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
 	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
 	req.Header.Set(circuit.TestModeHeader, circuit.TestModeForceDegraded)
@@ -166,7 +172,7 @@ func TestTestModeMiddleware_HeaderTakesPrecedenceOverQueryParam(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := TestModeMiddleware(next)
+	handler := newTestMiddleware()(next)
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/openai/v1/chat/completions?llm_proxy_test_mode=unknown_mode", nil)
@@ -193,7 +199,7 @@ func TestTestModeMiddleware_QueryParamPromotedToHeader(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := TestModeMiddleware(next)
+	handler := newTestMiddleware()(next)
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/openai/v1/chat/completions?llm_proxy_test_mode=force_transient_recover", nil)
@@ -206,7 +212,7 @@ func TestTestModeMiddleware_QueryParamPromotedToHeader(t *testing.T) {
 }
 
 func TestTestModeMiddleware_ForceDegraded_ContainsProvider(t *testing.T) {
-	handler := TestModeMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	handler := newTestMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
 	for _, path := range []string{
 		"/openai/v1/chat/completions",
@@ -222,8 +228,8 @@ func TestTestModeMiddleware_ForceDegraded_ContainsProvider(t *testing.T) {
 		if rr.Code != http.StatusServiceUnavailable {
 			t.Errorf("path %s: want 503, got %d", path, rr.Code)
 		}
-		if !strings.Contains(string(body), circuit.MagicString) {
-			t.Errorf("path %s: MagicString not in body: %s", path, body)
+		if !strings.Contains(string(body), circuit.DefaultDegradedSignal) {
+			t.Errorf("path %s: DefaultDegradedSignal not in body: %s", path, body)
 		}
 	}
 }

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -189,6 +189,11 @@ func (a *AnthropicProxy) Proxy() http.Handler {
 	return a.proxy
 }
 
+// WrapTransport replaces the proxy's transport with fn(current transport).
+func (a *AnthropicProxy) WrapTransport(fn func(http.RoundTripper) http.RoundTripper) {
+	a.proxy.Transport = fn(a.proxy.Transport)
+}
+
 // GetHealthStatus returns the health status of the Anthropic proxy
 func (a *AnthropicProxy) GetHealthStatus() map[string]interface{} {
 	return map[string]interface{}{

--- a/internal/providers/anthropic_integration_test.go
+++ b/internal/providers/anthropic_integration_test.go
@@ -23,17 +23,27 @@ type anthropicTestModel struct {
 	testPrompt string
 }
 
-// Test models to use in parameterized tests
+// Test models to use in parameterized tests.
+//
+// Model selection notes (April 2026):
+//   - Claude 3.5 family (`claude-3-5-haiku-latest`, `claude-3-5-sonnet-latest`)
+//     was retired by Anthropic — Haiku 3.5 on 2026-02-19, Sonnet 3.5 in 2025-10.
+//     The `-latest` aliases no longer resolve and the dated IDs return 404.
+//   - `claude-haiku-4-5` and `claude-sonnet-4-5` are the current stable
+//     replacements recommended by Anthropic for production workloads.
+//   - We prefer aliased IDs (no date suffix) so the tests don't require a
+//     code change every time Anthropic rolls a new snapshot.  If you need
+//     reproducibility, pin to the dated form (e.g. `claude-haiku-4-5-20251001`).
 var anthropicTestModels = []anthropicTestModel{
 	{
-		name:       "Claude-3.5-Haiku",
-		modelID:    "claude-3-5-haiku-latest",
+		name:       "Claude-Haiku-4.5",
+		modelID:    "claude-haiku-4-5",
 		maxTokens:  50,
 		testPrompt: "What is 2+2?",
 	},
 	{
-		name:       "Claude-3.5-Sonnet",
-		modelID:    "claude-3-5-sonnet-latest",
+		name:       "Claude-Sonnet-4.5",
+		modelID:    "claude-sonnet-4-5",
 		maxTokens:  100,
 		testPrompt: "Hello! Can you tell me a short joke?",
 	},

--- a/internal/providers/circuit_integration_test.go
+++ b/internal/providers/circuit_integration_test.go
@@ -1,0 +1,125 @@
+package providers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/circuit"
+)
+
+// roundTripFunc lets tests build a RoundTripper from a plain func.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// upstreamServer creates a test HTTP server that returns the given status on
+// every request.  The caller is responsible for calling server.Close().
+func upstreamServer(status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+}
+
+// wrapProviderTransport injects a circuit-breaking transport into provider p.
+func wrapProviderTransport(
+	p interface {
+		WrapTransport(func(http.RoundTripper) http.RoundTripper)
+	},
+	store circuit.Store,
+	cfg circuit.Config,
+	name string,
+) {
+	p.WrapTransport(func(inner http.RoundTripper) http.RoundTripper {
+		return circuit.NewTransport(inner, store, cfg, name, nil)
+	})
+}
+
+// TestProviderCircuitBreaker_OpenAI_DegradedSignal ensures that after
+// MaxTransientRetries+1 consecutive 503 responses the circuit-breaking
+// transport returns a 503 with MagicString to the upstream caller.
+func TestProviderCircuitBreaker_OpenAI_DegradedSignal(t *testing.T) {
+	server := upstreamServer(503)
+	defer server.Close()
+
+	cfg := circuit.Config{
+		Enabled:             true,
+		FailureThreshold:    10, // high so the circuit doesn't open yet
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1, // one retry then give up
+	}.Defaults()
+	store := circuit.NewMemoryStore(cfg)
+
+	provider := NewOpenAIProxy()
+	wrapProviderTransport(provider, store, cfg, "openai")
+
+	// Re-point the proxy's transport target at our test server.
+	// The circuit transport wraps the existing transport, which would normally
+	// point at OpenAI.  We use the test server instead by creating a request
+	// directly against the circuit transport.
+	innerTransport := &http.Transport{}
+	cbTransport := circuit.NewTransport(innerTransport, store, cfg, "openai", nil)
+
+	req, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := cbTransport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 degraded response, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), circuit.MagicString) {
+		t.Fatalf("MagicString not found in body: %s", body)
+	}
+}
+
+// TestProviderCircuitBreaker_TestMode_ForceDegraded verifies that the
+// test-mode header causes an immediate degraded response without contacting
+// the provider.
+func TestProviderCircuitBreaker_TestMode_ForceDegraded(t *testing.T) {
+	// If the inner transport is called at all, the test fails.
+	callCount := 0
+	inner := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		callCount++
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	cfg := circuit.Config{Enabled: true}.Defaults()
+	store := circuit.NewMemoryStore(cfg)
+	tr := circuit.NewTransport(inner, store, cfg, "anthropic", nil)
+
+	req, _ := http.NewRequest(http.MethodPost,
+		"http://proxy/anthropic/v1/messages",
+		strings.NewReader(`{}`))
+	req.Header.Set(circuit.TestModeHeader, circuit.TestModeForceDegraded)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if callCount != 0 {
+		t.Fatalf("inner transport should not be called in force_degraded mode, called %d times", callCount)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), circuit.MagicString) {
+		t.Fatalf("MagicString not in body: %s", body)
+	}
+}

--- a/internal/providers/circuit_integration_test.go
+++ b/internal/providers/circuit_integration_test.go
@@ -4,7 +4,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Instawork/llm-proxy/internal/circuit"
@@ -15,34 +17,23 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
-// upstreamServer creates a test HTTP server that returns the given status on
-// every request.  The caller is responsible for calling server.Close().
-func upstreamServer(status int) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(status)
-	}))
-}
-
-// wrapProviderTransport injects a circuit-breaking transport into provider p.
-func wrapProviderTransport(
-	p interface {
-		WrapTransport(func(http.RoundTripper) http.RoundTripper)
-	},
-	store circuit.Store,
-	cfg circuit.Config,
-	name string,
-) {
-	p.WrapTransport(func(inner http.RoundTripper) http.RoundTripper {
-		return circuit.NewTransport(inner, store, cfg, name, nil)
-	})
-}
-
 // TestProviderCircuitBreaker_OpenAI_DegradedSignal ensures that after
-// MaxTransientRetries+1 consecutive 503 responses the circuit-breaking
-// transport returns a 503 containing the DefaultDegradedSignal to the upstream caller.
+// MaxTransientRetries+1 consecutive 503 responses a real request routed
+// through OpenAIProxy.Proxy() receives a synthesised 503 containing
+// DefaultDegradedSignal in its body.
+//
+// This exercises the actual provider wiring: WrapTransport → circuit
+// transport → inner (pointed at the test server) → reverse proxy → client.
+// The previous version bypassed WrapTransport entirely by invoking
+// circuit.NewTransport directly, which meant a regression that broke the
+// provider-level wrapping would not be caught.
 func TestProviderCircuitBreaker_OpenAI_DegradedSignal(t *testing.T) {
-	server := upstreamServer(503)
-	defer server.Close()
+	var upstreamCalls int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&upstreamCalls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
 
 	cfg := circuit.Config{
 		Enabled:             true,
@@ -55,20 +46,40 @@ func TestProviderCircuitBreaker_OpenAI_DegradedSignal(t *testing.T) {
 	store := circuit.NewMemoryStore(cfg)
 
 	provider := NewOpenAIProxy()
-	wrapProviderTransport(provider, store, cfg, "openai")
 
-	// Re-point the proxy's transport target at our test server.
-	// The circuit transport wraps the existing transport, which would normally
-	// point at OpenAI.  We use the test server instead by creating a request
-	// directly against the circuit transport.
-	innerTransport := &http.Transport{}
-	cbTransport := circuit.NewTransport(innerTransport, store, cfg, "openai", nil)
+	// Install the circuit-breaking transport via the provider's own
+	// WrapTransport hook — this is the production code path.  The inner
+	// RoundTripper rewrites the request URL to target the test upstream
+	// in place of api.openai.com, so the reverse proxy never actually
+	// reaches the internet.
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	provider.WrapTransport(func(_ http.RoundTripper) http.RoundTripper {
+		inner := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL.Scheme = upstreamURL.Scheme
+			r.URL.Host = upstreamURL.Host
+			r.Host = upstreamURL.Host
+			return http.DefaultTransport.RoundTrip(r)
+		})
+		return circuit.NewTransport(inner, store, cfg, "openai", nil)
+	})
 
-	req, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/chat/completions",
+	// Front the provider with a local test server so we can issue a real
+	// client request against the wired-up proxy.Handler.
+	front := httptest.NewServer(provider.Proxy())
+	defer front.Close()
+
+	req, err := http.NewRequest(http.MethodPost,
+		front.URL+"/v1/chat/completions",
 		strings.NewReader(`{"model":"gpt-4o","messages":[]}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := cbTransport.RoundTrip(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -77,9 +88,19 @@ func TestProviderCircuitBreaker_OpenAI_DegradedSignal(t *testing.T) {
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("want 503 degraded response, got %d", resp.StatusCode)
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
 	if !strings.Contains(string(body), circuit.DefaultDegradedSignal) {
 		t.Fatalf("DefaultDegradedSignal not found in body: %s", body)
+	}
+
+	// Retry budget is one, so we expect initial attempt + one retry before
+	// giving up — the upstream must have been hit exactly twice.  If the
+	// wrapping were not applied (regression) this would be 1.
+	if got := atomic.LoadInt32(&upstreamCalls); got != 2 {
+		t.Fatalf("expected upstream to be called twice (attempt + 1 retry), got %d", got)
 	}
 }
 
@@ -98,7 +119,10 @@ func TestProviderCircuitBreaker_TestMode_ForceDegraded(t *testing.T) {
 		}, nil
 	})
 
-	cfg := circuit.Config{Enabled: true, Mode: circuit.ModeEnforce}.Defaults()
+	// Explicitly opt-in to honouring the X-LLM-Proxy-Test-Mode header;
+	// the transport refuses to interpret it in the default (prod-safe)
+	// configuration.  See TestTransport_TestMode_DisabledByDefault_*.
+	cfg := circuit.Config{Enabled: true, Mode: circuit.ModeEnforce, TestModeEnabled: true}.Defaults()
 	store := circuit.NewMemoryStore(cfg)
 	tr := circuit.NewTransport(inner, store, cfg, "anthropic", nil)
 

--- a/internal/providers/circuit_integration_test.go
+++ b/internal/providers/circuit_integration_test.go
@@ -39,7 +39,7 @@ func wrapProviderTransport(
 
 // TestProviderCircuitBreaker_OpenAI_DegradedSignal ensures that after
 // MaxTransientRetries+1 consecutive 503 responses the circuit-breaking
-// transport returns a 503 with MagicString to the upstream caller.
+// transport returns a 503 containing the DefaultDegradedSignal to the upstream caller.
 func TestProviderCircuitBreaker_OpenAI_DegradedSignal(t *testing.T) {
 	server := upstreamServer(503)
 	defer server.Close()
@@ -77,8 +77,8 @@ func TestProviderCircuitBreaker_OpenAI_DegradedSignal(t *testing.T) {
 		t.Fatalf("want 503 degraded response, got %d", resp.StatusCode)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), circuit.MagicString) {
-		t.Fatalf("MagicString not found in body: %s", body)
+	if !strings.Contains(string(body), circuit.DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not found in body: %s", body)
 	}
 }
 
@@ -119,7 +119,7 @@ func TestProviderCircuitBreaker_TestMode_ForceDegraded(t *testing.T) {
 		t.Fatalf("want 503, got %d", resp.StatusCode)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), circuit.MagicString) {
-		t.Fatalf("MagicString not in body: %s", body)
+	if !strings.Contains(string(body), circuit.DefaultDegradedSignal) {
+		t.Fatalf("DefaultDegradedSignal not in body: %s", body)
 	}
 }

--- a/internal/providers/circuit_integration_test.go
+++ b/internal/providers/circuit_integration_test.go
@@ -46,6 +46,7 @@ func TestProviderCircuitBreaker_OpenAI_DegradedSignal(t *testing.T) {
 
 	cfg := circuit.Config{
 		Enabled:             true,
+		Mode:                circuit.ModeEnforce,
 		FailureThreshold:    10, // high so the circuit doesn't open yet
 		WindowSeconds:       60,
 		CooldownSeconds:     300,
@@ -97,7 +98,7 @@ func TestProviderCircuitBreaker_TestMode_ForceDegraded(t *testing.T) {
 		}, nil
 	})
 
-	cfg := circuit.Config{Enabled: true}.Defaults()
+	cfg := circuit.Config{Enabled: true, Mode: circuit.ModeEnforce}.Defaults()
 	store := circuit.NewMemoryStore(cfg)
 	tr := circuit.NewTransport(inner, store, cfg, "anthropic", nil)
 

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -50,8 +50,11 @@ func NewGeminiProxy() *GeminiProxy {
 	originalDirector := proxy.Director
 	proxy.Director = CreateGenericDirector(geminiProxy, targetURL, originalDirector)
 
-	// Customize the transport for optimal streaming performance
-	proxy.Transport = newProxyTransport()
+	// Customize the transport for optimal streaming performance.
+	// Gemini can be significantly slower to return response headers than other providers,
+	// so give it a dedicated transport with a longer ResponseHeaderTimeout to avoid
+	// premature 502s that trigger repeated retries in the client.
+	proxy.Transport = newGeminiProxyTransport()
 
 	// Add custom response modifier for streaming support
 	proxy.ModifyResponse = func(resp *http.Response) error {
@@ -158,6 +161,11 @@ func (g *GeminiProxy) isStreamingResponse(resp *http.Response) bool {
 // Proxy returns the HTTP handler for the Gemini provider
 func (g *GeminiProxy) Proxy() http.Handler {
 	return g.proxy
+}
+
+// WrapTransport replaces the proxy's transport with fn(current transport).
+func (g *GeminiProxy) WrapTransport(fn func(http.RoundTripper) http.RoundTripper) {
+	g.proxy.Transport = fn(g.proxy.Transport)
 }
 
 // GetHealthStatus returns the health status of the Gemini proxy

--- a/internal/providers/gemini_integration_test.go
+++ b/internal/providers/gemini_integration_test.go
@@ -22,15 +22,24 @@ type geminiTestModel struct {
 	testPrompt string
 }
 
-// Test models to use in parameterized tests
+// Test models to use in parameterized tests.
+//
+// Model selection notes (April 2026):
+//   - Gemini 1.5 family (`gemini-1.5-flash`, `gemini-1.5-pro`) was retired by
+//     Google in October 2025.
+//   - `gemini-2.0-flash` is deprecated and its free-tier quota is tiny enough
+//     that these tests routinely hit `429 RESOURCE_EXHAUSTED` on CI.
+//   - `gemini-2.5-flash` is the current stable replacement; it sits in a
+//     different quota bucket and is Google's recommended low-latency default.
+//   - We prefer the aliased ID (no date suffix) so the tests don't need code
+//     changes on every snapshot; pin to a dated form if you need bit-for-bit
+//     reproducibility.
 var geminiTestModels = []geminiTestModel{
 	{
-		name:       "Gemini-2.0-Flash",
-		modelID:    "gemini-2.0-flash",
+		name:       "Gemini-2.5-Flash",
+		modelID:    "gemini-2.5-flash",
 		testPrompt: "Hello! Can you tell me a short joke?",
 	},
-	// Note: Gemini 1.5 models (gemini-1.5-flash and gemini-1.5-pro) have been deprecated
-	// by Google and are no longer available in the API as of October 2025
 }
 
 // TestGeminiIntegration_Models tests multiple Gemini models using subtests
@@ -366,21 +375,22 @@ func TestGeminiIntegration_V1BetaRoutes(t *testing.T) {
 		})
 	}
 
-	// Test v1beta embedding models
+	// Test v1beta embedding models.
+	//
+	// Legacy `text-embedding-004` was deprecated on 2026-01-14 and `embedding-001`
+	// on 2025-08-14.  `gemini-embedding-001` is the current GA multimodal
+	// embedding model and the recommended replacement for both.  We only test
+	// the single current model here; if more variants ship in the future,
+	// add them alongside this entry.
 	embeddingModels := []struct {
 		name    string
 		modelID string
 		text    string
 	}{
 		{
-			name:    "TextEmbedding004",
-			modelID: "text-embedding-004",
+			name:    "GeminiEmbedding001",
+			modelID: "gemini-embedding-001",
 			text:    "The quick brown fox jumps over the lazy dog.",
-		},
-		{
-			name:    "Embedding001",
-			modelID: "embedding-001",
-			text:    "Hello, world! This is a test of the embedding API.",
 		},
 	}
 
@@ -774,18 +784,18 @@ func TestGeminiIntegration_EmbedContent(t *testing.T) {
 	server, providerManager := setupTestServer(t)
 	defer server.Close()
 
-	// Embedding models to test
+	// Embedding models to test.  Legacy `text-embedding-004` and `embedding-001`
+	// are deprecated; `gemini-embedding-001` is the current GA replacement.
 	embeddingModels := []struct {
 		name    string
 		modelID string
 		text    string
 	}{
 		{
-			name:    "TextEmbedding004",
-			modelID: "text-embedding-004",
+			name:    "GeminiEmbedding001",
+			modelID: "gemini-embedding-001",
 			text:    "The quick brown fox jumps over the lazy dog.",
 		},
-		// Add more embedding models as needed
 	}
 
 	for _, model := range embeddingModels {

--- a/internal/providers/gemini_integration_test.go
+++ b/internal/providers/gemini_integration_test.go
@@ -379,18 +379,19 @@ func TestGeminiIntegration_V1BetaRoutes(t *testing.T) {
 
 	// Test v1beta embedding models.
 	//
-	// Legacy `text-embedding-004` was deprecated on 2026-01-14 and `embedding-001`
-	// on 2025-08-14.  `gemini-embedding-001` is the current GA multimodal
+	// Legacy `text-embedding-004` was retired on 2026-01-14 and `embedding-001`
+	// on 2025-10-30.  `gemini-embedding-001` is the current GA multimodal
 	// embedding model and the recommended replacement for both.  We only test
 	// the single current model here; if more variants ship in the future,
-	// add them alongside this entry.
+	// add them alongside this entry.  Source:
+	// https://ai.google.dev/gemini-api/docs/deprecations.
 	embeddingModels := []struct {
 		name    string
 		modelID string
 		text    string
 	}{
 		// text-embedding-004 (retired 2026-01-14) and embedding-001 (retired
-		// 2025-10-30) were consolidated into gemini-embedding-001. See
+		// 2025-10-30) were consolidated into gemini-embedding-001. Source:
 		// https://ai.google.dev/gemini-api/docs/deprecations.
 		{
 			name:    "GeminiEmbedding001",
@@ -789,8 +790,10 @@ func TestGeminiIntegration_EmbedContent(t *testing.T) {
 	server, providerManager := setupTestServer(t)
 	defer server.Close()
 
-	// Embedding models to test.  Legacy `text-embedding-004` and `embedding-001`
-	// are deprecated; `gemini-embedding-001` is the current GA replacement.
+	// Embedding models to test.  Legacy `text-embedding-004` (retired
+	// 2026-01-14) and `embedding-001` (retired 2025-10-30) are retired;
+	// `gemini-embedding-001` is the current GA replacement.  Source:
+	// https://ai.google.dev/gemini-api/docs/deprecations.
 	embeddingModels := []struct {
 		name    string
 		modelID string
@@ -801,8 +804,10 @@ func TestGeminiIntegration_EmbedContent(t *testing.T) {
 			modelID: "gemini-embedding-001",
 			text:    "The quick brown fox jumps over the lazy dog.",
 		},
-		// Add more embedding models as needed. Note: text-embedding-004 and
-		// embedding-001 were both retired in favor of gemini-embedding-001.
+		// Add more embedding models as needed. Note: text-embedding-004
+		// (retired 2026-01-14) and embedding-001 (retired 2025-10-30) were
+		// both retired in favor of gemini-embedding-001. Source:
+		// https://ai.google.dev/gemini-api/docs/deprecations.
 	}
 
 	for _, model := range embeddingModels {
@@ -823,8 +828,10 @@ func TestGeminiIntegration_EmbedContent(t *testing.T) {
 			}
 
 			// gemini-embedding-001 is only served on v1beta, not v1. The former
-			// /v1/ embedding models (text-embedding-004, embedding-001) were
-			// retired by Google before the v1 endpoint was promoted.
+			// /v1/ embedding models (text-embedding-004 retired 2026-01-14,
+			// embedding-001 retired 2025-10-30) were retired by Google before
+			// the v1 endpoint was promoted. Source:
+			// https://ai.google.dev/gemini-api/docs/deprecations.
 			url := fmt.Sprintf("%s/gemini/v1beta/models/%s:embedContent?key=%s", server.URL, model.modelID, apiKey)
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 			if err != nil {

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -190,6 +190,13 @@ func (o *OpenAIProxy) Proxy() http.Handler {
 	return o.proxy
 }
 
+// WrapTransport replaces the proxy's transport with the result of calling fn
+// on the current transport.  Call this after construction to inject circuit
+// breaking, tracing, or other transport-level middleware.
+func (o *OpenAIProxy) WrapTransport(fn func(http.RoundTripper) http.RoundTripper) {
+	o.proxy.Transport = fn(o.proxy.Transport)
+}
+
 // GetHealthStatus returns the health status of the OpenAI proxy
 func (o *OpenAIProxy) GetHealthStatus() map[string]interface{} {
 	return map[string]interface{}{

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -188,6 +188,17 @@ func newProxyTransport() *http.Transport {
 	}
 }
 
+// newGeminiProxyTransport creates a transport specifically for Gemini requests.
+// Gemini models (especially larger ones) can take significantly longer to start
+// returning response headers than other providers, so we use a longer
+// ResponseHeaderTimeout to avoid premature 502s that the google-genai client
+// would then retry multiple times, leading to very long total request durations.
+func newGeminiProxyTransport() *http.Transport {
+	t := newProxyTransport()
+	t.ResponseHeaderTimeout = 5 * time.Minute
+	return t
+}
+
 // DecompressResponseIfNeeded checks if the response is gzip compressed and decompresses it.
 // This is a shared utility function that all providers can use to handle gzip-compressed responses
 // when DisableCompression is set to true in the transport.

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -208,6 +208,27 @@ func TestNewProxyTransport(t *testing.T) {
 	}
 }
 
+func TestNewGeminiProxyTransport(t *testing.T) {
+	transport := newGeminiProxyTransport()
+
+	if transport == nil {
+		t.Fatal("newGeminiProxyTransport() returned nil")
+	}
+
+	if transport.ResponseHeaderTimeout != 5*time.Minute {
+		t.Errorf("Expected Gemini ResponseHeaderTimeout=5m, got %v", transport.ResponseHeaderTimeout)
+	}
+
+	// Other settings should inherit from the base transport
+	if transport.MaxIdleConns != 100 {
+		t.Errorf("Expected MaxIdleConns=100, got %d", transport.MaxIdleConns)
+	}
+
+	if !transport.DisableCompression {
+		t.Error("Expected DisableCompression=true")
+	}
+}
+
 // Test data structures
 
 func TestLLMResponseMetadata_Struct(t *testing.T) {


### PR DESCRIPTION
# 🤖 AI Generated Description 🤖 

### Summary

Adds a proxy-side circuit breaker that classifies upstream failures, retries transient / rate-limit errors with jittered backoff, and injects a configurable "provider degraded" marker into a synthetic 503 so any downstream client can detect proxy-originated degradation regardless of which SDK / framework wraps the HTTP error.

### Why a body marker instead of a status code?

The proxy already sets HTTP 503 and `X-Llm-Proxy-Error-Class: provider_degraded` on every synthesised degradation response, but neither is sufficient on its own:

1. **5xx is ambiguous.** The proxy streams real 5xx responses from providers (Anthropic 529, OpenAI 500/502/503/504, Gemini 500/503, etc.) straight through. A client that only looks at status code cannot tell a passthrough upstream 503 from a proxy-synthesised "circuit open" 503 — they have very different retry / fallback semantics.
2. **4xx is wrong.** The caller has done nothing wrong; the upstream is degraded. Using 4xx would break SDK retry logic that (correctly) refuses to retry 4xx.
3. **A novel status code (e.g. 599) is hostile to the ecosystem.** Many reverse proxies, CDNs, and HTTP clients coerce unknown codes to 500 or strip them entirely, and the OpenAI / Anthropic / Google SDKs all map any ≥500 response into a generic APIError / ServerError class.
4. **Custom response headers get stripped by SDK exception wrappers.** By the time an HTTPS error propagates up through the OpenAI Python SDK or LangChain, the caller typically only sees `str(exception)` — i.e. the body. A substring in the body survives every wrapping layer.

So the contract is: **503 status + `X-Llm-Proxy-Error-Class` header + `Config.DegradedSignal` substring in the body**, and callers can key off any of them. The full rationale is in the docstring on `circuit.DefaultDegradedSignal`.

### Configurable signal

`circuit.Config.DegradedSignal` is the substring injected into every synthesised degraded body. Operators can override it via `features.circuit_breaker.degraded_signal` in YAML. Empty → `circuit.DefaultDegradedSignal` (`"[LLM_PROXY_PROVIDER_DEGRADED]"`). `TestTransport_CustomDegradedSignal` locks in the override path end-to-end.

### How to use this

#### 1. Turn the feature on

`configs/dev.yml` ships with sane defaults — enable it in your own config:

```yaml
features:
  circuit_breaker:
    enabled: true
    backend: "memory"        # or "redis" for multi-instance
    failure_threshold: 5
    window_seconds: 120
    cooldown_seconds: 300
    max_transient_retries: 2
    max_rate_limit_retries: 2
    # degraded_signal: "[MY_COMPANY_UPSTREAM_DOWN]"  # optional override
```

Then point your SDK at the proxy as usual (`base_url = "http://llm-proxy:9002/openai/v1"`, etc.).

#### 2. Detect the signal on the client

The proxy emits **three** signals you can key off — use whichever is reachable from where you catch the error:

| Signal                                                     | Where to read it                                                                        |
| ---------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| HTTP `503`                                                  | `response.status_code` (only useful if you have the raw response)                       |
| `X-Llm-Proxy-Error-Class: provider_degraded`               | `response.headers` (only useful if you have the raw response)                           |
| `[LLM_PROXY_PROVIDER_DEGRADED]` substring in the body      | `str(exception)` — works regardless of how deeply the SDK / framework wrapped the error |

The body-marker substring is the most portable. It survives `openai.APIError`, `anthropic.APIStatusError`, LangChain wrappers, retry layers, and anything else that only carries the response message text forward.

#### 3. Implement your own fallback

**The proxy does not fall back for you.** It only signals. Falling back — switching to a different provider, swapping models, serving a cached response, degrading to a cheaper path, failing closed, queueing for later — is a business-logic decision that lives in your application.

This is intentional:

- The proxy can't know which fallback is acceptable for a given call (cost budget, quality floor, PII constraints, feature flags, user tier, prompt compatibility across providers).
- A built-in fallback matrix would silently override whatever your SDK / framework is already doing and make behaviour harder to reason about.
- Different callers want different strategies for the same upstream outage — e.g. "retry with GPT-5 → Claude → cached response" for a chat UI but "fail fast with a 503 back to the user" for a batch job.

Minimal Python example (works for the OpenAI SDK, LangChain, Anthropic SDK, and google-genai alike, because all of them surface the body text in `str(exc)`):

```python
PROVIDER_DEGRADED_SIGNAL = "[LLM_PROXY_PROVIDER_DEGRADED]"

def is_provider_degraded(exc: BaseException) -> bool:
    return PROVIDER_DEGRADED_SIGNAL in str(exc)

def call_with_fallback(primary, fallback, **kwargs):
    try:
        return primary.invoke(**kwargs)
    except Exception as exc:
        if is_provider_degraded(exc):
            return fallback.invoke(**kwargs)
        raise
```

Recommended fallback targets:

- **Pick a different provider family** (Anthropic outage → OpenAI / Gemini, etc.). Picking another model from the same provider is unlikely to help; they usually share fate.
- **Keep the fallback model compatible with your prompt shape** (tool-calling, JSON mode, system prompt format).
- **Cap the fallback depth** — one hop, not a chain. If the fallback also degrades, bubble the error up.
- **Emit a metric / log line** when you fall back so you can alert on prolonged degradation.

### What's in the box

- **`internal/circuit/`** — new package:
  - `types.go`: `FailureClass` (local/global rate limit vs degraded), `State` (closed/open/half-open), `Config` with sensible defaults, and `DefaultDegradedSignal` plus the "why" rationale above.
  - `classifier.go`: per-provider HTTP + network error classification. Anthropic `529` → degraded, Gemini `429` → local rate-limit, granular `x-ratelimit-remaining-*` headers distinguish local vs global exhaustion.
  - `store.go` + `memory.go` + `redis.go`: pluggable state backend. Memory is the default for dev; Redis (sorted-set sliding window, TTL-based cooldown, Lua-atomic failure record) is recommended for multi-instance prod.
  - `transport.go`: `http.RoundTripper` that does the retry loop, escalation window for sustained global rate limits, half-open probe with a single-slot lock, and emits the degraded JSON body on terminal failure / open circuit.
- **`internal/middleware/testmode.go`** — gated `X-LLM-Proxy-Test-Mode` header / `llm_proxy_test_mode` query param for integration tests (`force_degraded`, `force_transient_recover`). Now a factory `NewTestModeMiddleware(signal)` so the test-mode response uses the operator's configured signal.
- **Providers** — `OpenAIProxy` / `AnthropicProxy` / `GeminiProxy` each gain `WrapTransport(func(RoundTripper) RoundTripper)` so `main.go` can layer the circuit transport without touching per-provider construction logic.
- **Gemini transport** — dedicated `newGeminiProxyTransport()` with `ResponseHeaderTimeout = 5m`. The google-genai client retry-storms on slow-to-first-byte large models; lengthening this specifically for Gemini eliminates spurious 502s.
- **`/health`** — surfaces `circuit_state`, `circuit_failures`, `circuit_cooldown_until` per provider when the feature is on.
- **Config** — `features.circuit_breaker.*` YAML section wired end-to-end with safe defaults: threshold 5, window 120s, cooldown 5m, 2 retries each for transient and rate-limit buckets. `configs/dev.yml` enables it for local dev.
- **README** — new "Circuit Breaker & Provider Degradation" section documenting the feature, the body-marker rationale, full config reference, and the test-mode header.

### Tests

- `internal/circuit/*_test.go`: unit coverage for the classifier, memory store (state transitions + sliding window + probe slot), the transport retry/probe paths (success passthrough, transient → recover, rate-limit → backoff → escalate, degraded → terminal → open, half-open probe success/failure), and the configurable `DegradedSignal` override.
- `internal/middleware/testmode_test.go`: middleware short-circuits correctly for each mode, strips the query param before forwarding, promotes query-param → header, and respects header precedence.
- `internal/providers/circuit_integration_test.go`: end-to-end with a real `http.Server` stand-in to confirm the provider proxy emits the expected degraded body and headers.
- `go vet ./...`, `go build ./...`, `go test ./...` all green.

### Checklist

- [x] `make fmt vet build` green, `go test ./...` green (all packages).
- [x] Backwards-compatible: feature is off by default in `GetDefaultYAMLConfig`; existing deployments see no behaviour change unless they opt in.
- [x] No production surface for `test_mode_enabled` unless explicitly toggled in YAML.
- [x] Redis backend keys are namespaced (`cb:failures:`, `cb:state:`, `cb:probe:`) to avoid collisions with other features.
- [x] No project-specific branding in package code / docs; default signal is `[LLM_PROXY_PROVIDER_DEGRADED]` and fully overridable via config.
- [x] README documents how to use the feature and makes it explicit that client-side fallback routing is the caller's responsibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Circuit breaker for provider requests (fast-fail, cooldown, half-open probes, retries) applied to OpenAI, Anthropic, and Gemini; transports are wrapped when enabled.
  * Per-provider circuit stats exposed on /health; circuit_breaker feature flag and test-mode controls added.

* **Configuration**
  * New features.circuit_breaker config (enable, mode, backend memory/redis, thresholds, window, cooldown, retry limits, retry_contribution_mode, degraded-signal).

* **Tests**
  * Extensive unit and integration tests for classification, stores, transport, middleware, and provider integration.

* **Documentation**
  * README updated with behavior, degraded signaling, and health diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
