### PR TITLE
feat: refresh LLM pricing for OpenAI, Anthropic, and Gemini (Apr 2026)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - setup_go_environment
       - run:
           name: Run config validator
-          command: go run cmd/config-validator/main.go
+          command: go run ./cmd/config-validator/
       - run:
           name: Run unit tests
           command: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,9 @@ jobs:
     steps:
       - setup_go_environment
       - run:
+          name: Run config validator
+          command: go run cmd/config-validator/main.go
+      - run:
           name: Run unit tests
           command: make test
 

--- a/.cursor/skills/llm-price-update/SKILL.md
+++ b/.cursor/skills/llm-price-update/SKILL.md
@@ -20,7 +20,7 @@ Audit and update model pricing in [configs/base.yml](../../../configs/base.yml) 
 
 Copy this checklist at the start of a run:
 
-```
+```text
 Task progress:
 - [ ] 1. Read configs/base.yml to capture current pricing and models
 - [ ] 2. Dispatch 3 parallel subagents (OpenAI, Anthropic, Google), each reading BOTH the pricing page AND the deprecations page

--- a/.cursor/skills/llm-price-update/SKILL.md
+++ b/.cursor/skills/llm-price-update/SKILL.md
@@ -27,7 +27,8 @@ Task progress:
 - [ ] 4. Diff vendor data against configs/base.yml
 - [ ] 5. Build pricing changeset + deprecations list
 - [ ] 6. Present plan (or apply, depending on mode)
-- [ ] 7. Run `go test ./internal/config/...` after editing
+- [ ] 7. Run `go run ./cmd/config-validator/` after editing
+- [ ] 8. Run `go test ./internal/config/...` after editing
 ```
 
 ### Step 1. Read the current config
@@ -122,13 +123,23 @@ Include this block in the plan/PR body and, if the user asks, write it to a file
 
 ### Step 7. Verify after editing
 
+Always run both commands before committing:
+
 ```bash
-cd <llm-proxy repo>
+# 1. Semantic config validation (pricing sanity, duplicate aliases, structural correctness)
+go run ./cmd/config-validator/
+
+# 2. Unit tests (config parsing, tiered pricing logic, alias resolution)
 go test ./internal/config/...
-rg -n "\"<changed-model-id>\"" internal/ configs/   # catch hardcoded test expectations
 ```
 
-If tests assert specific prices for models whose prices changed, update those tests in the same change.
+Also grep for any hardcoded price assertions in tests that touch changed models:
+
+```bash
+rg -n "\"<changed-model-id>\"" internal/ configs/
+```
+
+Update test expectations if tests assert specific prices that changed. The validator and test suite must both be clean before the PR is considered ready.
 
 ## Alias rules (non-negotiable)
 

--- a/.cursor/skills/llm-price-update/SKILL.md
+++ b/.cursor/skills/llm-price-update/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: llm-price-update
+description: Refresh LLM provider pricing (OpenAI, Anthropic, Google Gemini) in configs/base.yml for the llm-proxy app. Use when the user asks to "update llm prices", "refresh model pricing", "sync llm-proxy pricing", "check llm pricing", "llm price update", or otherwise wants the llm-proxy pricing config audited against current vendor pricing.
+---
+
+# llm-price-update
+
+Audit and update model pricing in [configs/base.yml](../../../configs/base.yml) for the `llm-proxy` app against the current published prices from OpenAI, Anthropic, and Google. Produce both the pricing diff and a deprecation list.
+
+## Hard rules
+
+1. **Always use the live web.** Do NOT rely on model knowledge for prices or model lineups. Prices change frequently; the agent's training data is stale.
+2. **Always dispatch parallel subagents** (one per provider) to gather pricing. Then verify the most surprising claims with direct `WebSearch` calls before writing the config. Subagents can hallucinate; independent verification is required for any new model family, price drop >20%, or price increase.
+3. **Never add aliases for models that are actually different versions.** Aliases are only for the same underlying model (e.g., `claude-opus-4-1` ↔ `claude-opus-4-1-20250805`, `gpt-4o` ↔ `gpt-4o-2024-11-20`). Never alias `gpt-5` to `gpt-5.1`, `claude-opus-4-0` to `claude-opus-4-1`, `gemini-2.5-pro` to `gemini-3-pro`, etc. Different version numbers = different models = separate entries.
+4. **Always encode tiered pricing when the vendor publishes it.** This is not optional. If the vendor lists different input/output rates based on prompt length (e.g., Gemini Pro ≤200k vs >200k, Gemini 1.5 ≤128k vs >128k, Anthropic Sonnet 4.x ≤200k vs >200k), the model MUST be configured as a `PricingTier` list — never collapsed to flat `{input, output}`. Flat pricing silently under-bills long-prompt traffic.
+5. **Always produce a deprecations list** alongside the pricing diff so it can be consumed by downstream callers (e.g., client UI, docs). See "Deprecation output" below.
+
+## Workflow
+
+Copy this checklist at the start of a run:
+
+```
+Task progress:
+- [ ] 1. Read configs/base.yml to capture current pricing and models
+- [ ] 2. Dispatch 3 parallel subagents (OpenAI, Anthropic, Google) to fetch current prices
+- [ ] 3. Verify surprising findings with direct WebSearch
+- [ ] 4. Diff vendor data against configs/base.yml
+- [ ] 5. Build pricing changeset + deprecations list
+- [ ] 6. Present plan (or apply, depending on mode)
+- [ ] 7. Run `go test ./internal/config/...` after editing
+```
+
+### Step 1. Read the current config
+
+Only `configs/base.yml` holds pricing. `dev.yml`, `staging.yml`, and `production.yml` inherit pricing from base and do not override it. Confirm with a grep before assuming:
+
+```bash
+rg -n "pricing" configs/
+```
+
+The pricing struct is defined in [internal/config/config.go](../../../internal/config/config.go) as `ModelPricing` with three shapes:
+- `{input, output}` for flat pricing — ONLY when the vendor publishes a single rate for the model
+- `[{threshold, input, output}, ...]` for prompt-length tiers — REQUIRED whenever the vendor publishes length-based tiers (Gemini Pro ≤200k/>200k, Gemini 1.5 ≤128k/>128k, Anthropic Sonnet 4.x ≤200k/>200k, etc.)
+- `overrides: {alias: {input, output}}` for per-snapshot price differences (e.g., `gpt-4o-2024-05-13` priced higher than current `gpt-4o`)
+
+When building the diff, explicitly check each new model's vendor pricing page for "long context", ">200k", ">128k", "prompts above X tokens", or a second pricing row. If any exists, encode it as tiers.
+
+### Step 2. Dispatch parallel subagents
+
+Launch all three in one tool-call batch using `subagent_type: generalPurpose`. Each gets the current list of models in its provider from `configs/base.yml`, and is told to return per-million-token standard-tier prices (non-cached, non-batch) plus any new models released since the config was last updated.
+
+Prompt skeleton (adapt per provider):
+
+> Go to `<vendor pricing URL>` and find the CURRENT pricing as of `<today>` for all of the following models. Return per-million-token input and output prices in USD for the standard (non-cached, non-batch) tier. Cross-reference against a second source (OpenRouter, artificialanalysis, vendor docs) if possible.
+>
+> Models needed: `<list from base.yml>`
+>
+> Also list ANY NEW `<vendor>` models released since `<assumed cutoff>` that we should be aware of. For each new model, confirm:
+> - Official API model name (NOT aliases)
+> - Standard input/output $/1M
+> - Whether it has tiered pricing (e.g., >200k input tokens)
+> - Release date
+> - Deprecation status and sunset date of any old model it replaces
+>
+> Format response as a compact table with columns: model, input $/1M, output $/1M, tier_threshold, release_date, deprecated_by, source URL, notes.
+
+Vendor URLs (primary / secondary):
+- OpenAI: `https://platform.openai.com/docs/pricing` / `https://openai.com/api/pricing/`
+- Anthropic: `https://docs.anthropic.com/en/docs/about-claude/pricing` / `https://www.anthropic.com/pricing`
+- Google: `https://ai.google.dev/gemini-api/docs/pricing` / `https://cloud.google.com/vertex-ai/generative-ai/pricing`
+
+### Step 3. Verify surprising findings
+
+For any subagent claim that looks suspicious — new major version (e.g., "GPT-6"), price change >20%, model name you don't recognize — run a direct `WebSearch` with 2-3 queries to confirm. If verification fails, drop the claim and note it in the plan.
+
+### Step 4. Build the diff
+
+For each provider section of `configs/base.yml`, categorize every model:
+
+| Category | Action |
+|---|---|
+| Unchanged | Skip |
+| Price changed | Update `input`/`output`; if an alias has a different price, move it into `overrides` |
+| New model | Add entry with canonical ID + same-model aliases only (see rule 3) |
+| Deprecated/sunset | Keep in config (callers still reference it), but add to deprecations list |
+| Removed from vendor | Only remove if vendor returns 404 for API calls; otherwise keep |
+
+Reuse the `limits` block of a similar existing model rather than inventing new rate-limit numbers — e.g., a new flagship uses the same limits as the previous flagship.
+
+### Step 5. Deprecation output
+
+In addition to the pricing diff, emit a machine-readable deprecations list the user can copy elsewhere (client UI warnings, release notes, etc.). Format:
+
+```yaml
+deprecations:
+  openai:
+    - model: o1-preview
+      replaced_by: o1
+      sunset_date: null  # or ISO date if vendor announced one
+      source: <URL>
+      notes: Removed from platform pricing page
+  anthropic:
+    - model: claude-3-5-sonnet
+      replaced_by: claude-sonnet-4-5
+      sunset_date: null
+      source: <URL>
+      notes: Dropped from marketing page; still listed on docs pricing
+  gemini:
+    - model: gemini-3-pro-preview
+      replaced_by: gemini-3.1-pro
+      sunset_date: null
+      source: <URL>
+      notes: Marked deprecated on AI Studio models page
+```
+
+Include this block in the plan/PR body and, if the user asks, write it to a file (suggest `docs/model-deprecations.yml` or similar — do not create it unprompted).
+
+### Step 6. Present or apply
+
+- In Plan mode: call `CreatePlan` with the diff + deprecations block. Surface open questions (e.g., tiered pricing, same-price aliases vs separate entries).
+- In Agent mode: edit `configs/base.yml` directly, then go to step 7.
+
+### Step 7. Verify after editing
+
+```bash
+cd <llm-proxy repo>
+go test ./internal/config/...
+rg -n "\"<changed-model-id>\"" internal/ configs/   # catch hardcoded test expectations
+```
+
+If tests assert specific prices for models whose prices changed, update those tests in the same change.
+
+## Alias rules (non-negotiable)
+
+The governing principle: **same version number = aliasable, different version number = never aliasable**.
+
+An alias is acceptable when any of the following is true:
+- It is a dated snapshot of the same model (e.g., `claude-opus-4-1-20250805`)
+- It is a "latest" pointer for the same model (e.g., `claude-3-5-sonnet-latest`)
+- It is a punctuation variant of the same model (e.g., `claude-opus-4.1` ↔ `claude-opus-4-1`, `gemini-3.1-pro` ↔ `gemini-3-1-pro`)
+- It is a preview / experimental SKU for the same model version (e.g., `gemini-2.5-pro-preview` under `gemini-2.5-pro`, `gpt-4.1-2025-04-14-preview` under `gpt-4.1`). Preview aliases are fine as long as the version number matches.
+
+Examples of **valid** aliases:
+- `claude-opus-4-1` aliases `claude-opus-4-1-20250805` (dated snapshot)
+- `gpt-4o` aliases `gpt-4o-2024-11-20` (latest snapshot pointer)
+- `gemini-3.1-pro` aliases `gemini-3.1-pro-preview` and `gemini-3-1-pro` (preview SKU + punctuation variant, same version)
+- `claude-sonnet-4-5` aliases `claude-sonnet-4.5` and `claude-sonnet-4-5-20250929`
+
+Examples that are **NEVER** aliases (always separate entries), because the version number differs:
+- `gpt-5` and `gpt-5.1` — different versions
+- `gpt-5` and `gpt-5.2` — different versions, even if priced identically
+- `claude-opus-4-0` and `claude-opus-4-1` — different versions
+- `claude-opus-4-5` and `claude-opus-4-6` and `claude-opus-4-7` — each is its own entry
+- `gemini-2.5-pro` and `gemini-3-pro-preview` — different version families
+- `gemini-3-pro-preview` and `gemini-3.1-pro-preview` — 3 and 3.1 are different versions
+- `o1` and `o1-pro` — different products
+- Any model and its `-mini`/`-nano`/`-lite`/`-pro` sibling
+
+When in doubt, create a separate entry. Over-aliasing silently routes traffic to the wrong model's pricing and rate limits, and masks deprecations.
+
+## Snippet templates
+
+Flat pricing (most common):
+
+```yaml
+"<model-id>":
+  enabled: true
+  aliases: ["<dated-snapshot>", "<vendor-documented-same-model-alias>"]
+  limits:
+    # copy from sibling model of same tier
+    tokens_per_minute: 80_000
+    requests_per_minute: 1_000
+    tokens_per_day: 1_920_000
+    requests_per_day: 1_440_000
+    burst_tokens: 8_000
+    burst_requests: 100
+  pricing:
+    input: <in>
+    output: <out>
+```
+
+Tiered pricing (Gemini Pro, Anthropic >200k):
+
+```yaml
+"<model-id>":
+  enabled: true
+  aliases: []
+  limits: { ... }
+  pricing:
+    - threshold: 200_000
+      input: <low-tier-in>
+      output: <low-tier-out>
+    - threshold: 0  # fallback for prompts above threshold
+      input: <high-tier-in>
+      output: <high-tier-out>
+```
+
+Per-snapshot override (snapshot priced differently from the alias base):
+
+```yaml
+"gpt-4o":
+  pricing:
+    input: 2.50
+    output: 10.00
+    overrides:
+      "gpt-4o-2024-05-13":
+        input: 5.00
+        output: 15.00
+```
+
+## Output format
+
+At the end of the run, produce two artifacts:
+
+1. **Pricing changeset** — a list of edits grouped by provider, with old vs new prices. Flag each entry as `fix-stale`, `price-change`, `new-model`, or `no-op`.
+2. **Deprecations list** — the YAML block above. Always include it, even if empty (emit `deprecations: {openai: [], anthropic: [], gemini: []}`).

--- a/.cursor/skills/llm-price-update/SKILL.md
+++ b/.cursor/skills/llm-price-update/SKILL.md
@@ -13,7 +13,8 @@ Audit and update model pricing in [configs/base.yml](../../../configs/base.yml) 
 2. **Always dispatch parallel subagents** (one per provider) to gather pricing. Then verify the most surprising claims with direct `WebSearch` calls before writing the config. Subagents can hallucinate; independent verification is required for any new model family, price drop >20%, or price increase.
 3. **Never add aliases for models that are actually different versions.** Aliases are only for the same underlying model (e.g., `claude-opus-4-1` ↔ `claude-opus-4-1-20250805`, `gpt-4o` ↔ `gpt-4o-2024-11-20`). Never alias `gpt-5` to `gpt-5.1`, `claude-opus-4-0` to `claude-opus-4-1`, `gemini-2.5-pro` to `gemini-3-pro`, etc. Different version numbers = different models = separate entries.
 4. **Always encode tiered pricing when the vendor publishes it.** This is not optional. If the vendor lists different input/output rates based on prompt length (e.g., Gemini Pro ≤200k vs >200k, Gemini 1.5 ≤128k vs >128k, Anthropic Sonnet 4.x ≤200k vs >200k), the model MUST be configured as a `PricingTier` list — never collapsed to flat `{input, output}`. Flat pricing silently under-bills long-prompt traffic.
-5. **Always produce a deprecations list** alongside the pricing diff so it can be consumed by downstream callers (e.g., client UI, docs). See "Deprecation output" below.
+5. **Always consult each vendor's official deprecations page.** Do not rely on the pricing page alone — models often linger on the pricing page after sunset, and new sunsets are announced on the deprecations page first. Cross-reference every model in `configs/base.yml` against the URLs in "Vendor URLs" below, and surface any retired/sunset model in the deprecations output.
+6. **Always produce a deprecations list** alongside the pricing diff so it can be consumed by downstream callers (e.g., client UI, docs). See "Deprecation output" below.
 
 ## Workflow
 
@@ -22,10 +23,10 @@ Copy this checklist at the start of a run:
 ```
 Task progress:
 - [ ] 1. Read configs/base.yml to capture current pricing and models
-- [ ] 2. Dispatch 3 parallel subagents (OpenAI, Anthropic, Google) to fetch current prices
+- [ ] 2. Dispatch 3 parallel subagents (OpenAI, Anthropic, Google), each reading BOTH the pricing page AND the deprecations page
 - [ ] 3. Verify surprising findings with direct WebSearch
-- [ ] 4. Diff vendor data against configs/base.yml
-- [ ] 5. Build pricing changeset + deprecations list
+- [ ] 4. Diff vendor data against configs/base.yml (pricing + deprecations)
+- [ ] 5. Build pricing changeset + deprecations list (including shutdown models to remove)
 - [ ] 6. Present plan (or apply, depending on mode)
 - [ ] 7. Run `go run ./cmd/config-validator/` after editing
 - [ ] 8. Run `go test ./internal/config/...` after editing
@@ -52,23 +53,27 @@ Launch all three in one tool-call batch using `subagent_type: generalPurpose`. E
 
 Prompt skeleton (adapt per provider):
 
-> Go to `<vendor pricing URL>` and find the CURRENT pricing as of `<today>` for all of the following models. Return per-million-token input and output prices in USD for the standard (non-cached, non-batch) tier. Cross-reference against a second source (OpenRouter, artificialanalysis, vendor docs) if possible.
+> Read BOTH `<vendor pricing URL>` AND `<vendor deprecations URL>` and return two tables:
 >
-> Models needed: `<list from base.yml>`
+> **Table 1 — current pricing.** For every model in the list below, the current per-million-token input and output prices in USD for the standard (non-cached, non-batch) tier. Include any tiered pricing (e.g., >200k input tokens) as an explicit second row. Cross-reference against a second source (OpenRouter, artificialanalysis, vendor docs) if possible.
 >
-> Also list ANY NEW `<vendor>` models released since `<assumed cutoff>` that we should be aware of. For each new model, confirm:
-> - Official API model name (NOT aliases)
-> - Standard input/output $/1M
-> - Whether it has tiered pricing (e.g., >200k input tokens)
-> - Release date
-> - Deprecation status and sunset date of any old model it replaces
+> Models in current config: `<list from base.yml>`
 >
-> Format response as a compact table with columns: model, input $/1M, output $/1M, tier_threshold, release_date, deprecated_by, source URL, notes.
+> Also list ANY NEW `<vendor>` models released since `<assumed cutoff>` that we should be aware of. For each new model: official API model name (NOT aliases), input/output $/1M, tier threshold, release date.
+>
+> **Table 2 — deprecations.** Every model on the vendor's official deprecations page, including models NOT currently in our config. Columns: model, status (deprecated / shutdown / legacy), sunset_date (ISO or null), replaced_by, source URL, notes.
+>
+> Format both tables as compact markdown tables. If a model appears on the pricing page but NOT the deprecations page, treat it as active. If it appears on the deprecations page but NOT the pricing page, treat it as sunset and include it only in Table 2.
 
-Vendor URLs (primary / secondary):
-- OpenAI: `https://platform.openai.com/docs/pricing` / `https://openai.com/api/pricing/`
-- Anthropic: `https://docs.anthropic.com/en/docs/about-claude/pricing` / `https://www.anthropic.com/pricing`
-- Google: `https://ai.google.dev/gemini-api/docs/pricing` / `https://cloud.google.com/vertex-ai/generative-ai/pricing`
+Vendor URLs — the subagent MUST read **both** the pricing page and the deprecations page for its provider:
+
+| Provider | Pricing | Deprecations | Secondary |
+|---|---|---|---|
+| OpenAI | `https://platform.openai.com/docs/pricing` | `https://developers.openai.com/api/docs/deprecations` | `https://openai.com/api/pricing/` |
+| Anthropic | `https://docs.anthropic.com/en/docs/about-claude/pricing` | `https://platform.claude.com/docs/en/about-claude/model-deprecations` | `https://www.anthropic.com/pricing` |
+| Google | `https://ai.google.dev/gemini-api/docs/pricing` | `https://ai.google.dev/gemini-api/docs/deprecations` | `https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions` |
+
+The deprecations page is authoritative for sunset dates and replacements. The pricing page is authoritative for current rates. Both must be read.
 
 ### Step 3. Verify surprising findings
 
@@ -83,8 +88,9 @@ For each provider section of `configs/base.yml`, categorize every model:
 | Unchanged | Skip |
 | Price changed | Update `input`/`output`; if an alias has a different price, move it into `overrides` |
 | New model | Add entry with canonical ID + same-model aliases only (see rule 3) |
-| Deprecated/sunset | Keep in config (callers still reference it), but add to deprecations list |
-| Removed from vendor | Only remove if vendor returns 404 for API calls; otherwise keep |
+| Deprecated (future sunset) | Keep in config, add to deprecations list with `sunset_date` |
+| Shutdown (past sunset, vendor 404s on it) | Remove from `configs/base.yml`, add to deprecations list. Google retired `gemini-1.5-*` and `text-embedding-004`/`embedding-001` this way. |
+| Listed as deprecated on vendor page but pricing page still shows it | Keep in config, add to deprecations list with `sunset_date` if known |
 
 Reuse the `limits` block of a similar existing model rather than inventing new rate-limit numbers — e.g., a new flagship uses the same limits as the previous flagship.
 
@@ -97,21 +103,30 @@ deprecations:
   openai:
     - model: o1-preview
       replaced_by: o1
-      sunset_date: null  # or ISO date if vendor announced one
-      source: <URL>
+      sunset_date: null  # ISO date if vendor announced one, null if only delisted
+      status: deprecated  # deprecated | shutdown | legacy
+      source: https://developers.openai.com/api/docs/deprecations
       notes: Removed from platform pricing page
   anthropic:
     - model: claude-3-5-sonnet
       replaced_by: claude-sonnet-4-5
       sunset_date: null
-      source: <URL>
+      status: deprecated
+      source: https://platform.claude.com/docs/en/about-claude/model-deprecations
       notes: Dropped from marketing page; still listed on docs pricing
   gemini:
-    - model: gemini-3-pro-preview
-      replaced_by: gemini-3.1-pro
-      sunset_date: null
-      source: <URL>
-      notes: Marked deprecated on AI Studio models page
+    - model: text-embedding-004
+      replaced_by: gemini-embedding-001
+      sunset_date: "2026-01-14"
+      status: shutdown
+      source: https://ai.google.dev/gemini-api/docs/deprecations
+      notes: Shutdown Jan 14, 2026; API now 404s
+    - model: gemini-2.0-flash
+      replaced_by: gemini-2.5-flash
+      sunset_date: "2026-06-01"
+      status: deprecated
+      source: https://ai.google.dev/gemini-api/docs/deprecations
+      notes: Scheduled shutdown June 1, 2026
 ```
 
 Include this block in the plan/PR body and, if the user asks, write it to a file (suggest `docs/model-deprecations.yml` or similar — do not create it unprompted).
@@ -223,5 +238,5 @@ Per-snapshot override (snapshot priced differently from the alias base):
 
 At the end of the run, produce two artifacts:
 
-1. **Pricing changeset** — a list of edits grouped by provider, with old vs new prices. Flag each entry as `fix-stale`, `price-change`, `new-model`, or `no-op`.
-2. **Deprecations list** — the YAML block above. Always include it, even if empty (emit `deprecations: {openai: [], anthropic: [], gemini: []}`).
+1. **Pricing changeset** — a list of edits grouped by provider, with old vs new prices. Flag each entry as `fix-stale`, `price-change`, `new-model`, `remove-shutdown`, or `no-op`.
+2. **Deprecations list** — the YAML block above, sourced from each vendor's official deprecations page. Always include it, even if empty (emit `deprecations: {openai: [], anthropic: [], gemini: []}`). Entries with `status: shutdown` SHOULD correspond to `remove-shutdown` entries in the changeset.

--- a/cmd/config-validator/main.go
+++ b/cmd/config-validator/main.go
@@ -74,10 +74,11 @@ const (
 	// indicates a decimal-place error (e.g. 0.001 instead of 0.10).
 	minPricePerMillion = 0.01
 
-	// maxPricePerMillion is the maximum sane price per 1M tokens ($100.00).
-	// Prices above this have never been observed and likely indicate a
-	// magnitude error (e.g. 1000.00 instead of 10.00).
-	maxPricePerMillion = 100.00
+	// maxPricePerMillion is the maximum sane price per 1M tokens ($1000.00).
+	// The highest real-world price we've seen is o1-pro at $600/1M output, so
+	// $1000 leaves headroom while still catching obvious magnitude errors
+	// (e.g. 10000.00 instead of 100.00).
+	maxPricePerMillion = 1000.00
 )
 
 // validateSemantics checks for logical errors that YAML parsing won't catch:

--- a/cmd/config-validator/main.go
+++ b/cmd/config-validator/main.go
@@ -24,25 +24,39 @@ func main() {
 		os.Exit(1)
 	}
 
+	baseConfig := filepath.Join(*configDir, "base.yml")
+
 	failed := false
 	for _, file := range files {
 		fmt.Printf("Validating %s... ", file)
-		
-		var err error
+
+		var cfg *config.YAMLConfig
+		var loadErr error
+
 		if filepath.Base(file) == "base.yml" {
-			// base.yml must be a complete, valid config
-			_, err = config.LoadYAMLConfig(file)
+			// base.yml must be a complete, valid config on its own
+			cfg, loadErr = config.LoadYAMLConfig(file)
 		} else {
-			// Other configs are environment-specific overlays and may be partial.
-			// We validate them by merging with base.yml.
-			_, err = config.LoadAndMergeConfigs([]string{"configs/base.yml", file})
+			// Environment-specific configs are partial overlays; validate them
+			// merged on top of base.yml so the full resulting config is checked.
+			cfg, loadErr = config.LoadAndMergeConfigs([]string{baseConfig, file})
 		}
 
-		if err != nil {
-			fmt.Printf("FAILED\nError: %v\n", err)
+		if loadErr != nil {
+			fmt.Printf("FAILED\nError: %v\n", loadErr)
 			failed = true
 			continue
 		}
+
+		if semanticErrors := validateSemantics(cfg); len(semanticErrors) > 0 {
+			fmt.Println("FAILED")
+			for _, e := range semanticErrors {
+				fmt.Printf("  - %s\n", e)
+			}
+			failed = true
+			continue
+		}
+
 		fmt.Println("PASSED")
 	}
 
@@ -52,4 +66,77 @@ func main() {
 	}
 
 	fmt.Println("\nAll configurations are valid.")
+}
+
+// validateSemantics checks for logical errors that YAML parsing won't catch:
+//   - Pricing values must be positive (> 0)
+//   - Aliases must be unique within a provider (duplicate aliases cause non-deterministic routing)
+func validateSemantics(cfg *config.YAMLConfig) []string {
+	var errs []string
+
+	for providerName, provider := range cfg.Providers {
+		if !provider.Enabled {
+			continue
+		}
+
+		// Track all aliases seen in this provider to detect duplicates.
+		seenAliases := make(map[string]string) // alias -> canonical model name
+
+		for modelName, model := range provider.Models {
+			if !model.Enabled {
+				continue
+			}
+
+			// Check for duplicate aliases.
+			for _, alias := range model.Aliases {
+				if existing, seen := seenAliases[alias]; seen {
+					errs = append(errs, fmt.Sprintf(
+						"%s: alias %q appears on both %q and %q",
+						providerName, alias, existing, modelName,
+					))
+				} else {
+					seenAliases[alias] = modelName
+				}
+			}
+
+			// Check pricing values are positive.
+			if model.Pricing == nil {
+				continue
+			}
+			mp, ok := model.Pricing.(*config.ModelPricing)
+			if !ok || mp == nil {
+				continue
+			}
+			for i, tier := range mp.Tiers {
+				if tier.Input <= 0 {
+					errs = append(errs, fmt.Sprintf(
+						"%s/%s: tier[%d] input price must be > 0, got %g",
+						providerName, modelName, i, tier.Input,
+					))
+				}
+				if tier.Output <= 0 {
+					errs = append(errs, fmt.Sprintf(
+						"%s/%s: tier[%d] output price must be > 0, got %g",
+						providerName, modelName, i, tier.Output,
+					))
+				}
+			}
+			for alias, p := range mp.Overrides {
+				if p.Input <= 0 {
+					errs = append(errs, fmt.Sprintf(
+						"%s/%s: override[%q] input price must be > 0, got %g",
+						providerName, modelName, alias, p.Input,
+					))
+				}
+				if p.Output <= 0 {
+					errs = append(errs, fmt.Sprintf(
+						"%s/%s: override[%q] output price must be > 0, got %g",
+						providerName, modelName, alias, p.Output,
+					))
+				}
+			}
+		}
+	}
+
+	return errs
 }

--- a/cmd/config-validator/main.go
+++ b/cmd/config-validator/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func main() {
+	configDir := flag.String("config-dir", "configs", "Directory containing configuration files")
+	flag.Parse()
+
+	files, err := filepath.Glob(filepath.Join(*configDir, "*.yml"))
+	if err != nil {
+		fmt.Printf("Error finding config files: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(files) == 0 {
+		fmt.Printf("No configuration files found in %s\n", *configDir)
+		os.Exit(1)
+	}
+
+	failed := false
+	for _, file := range files {
+		fmt.Printf("Validating %s... ", file)
+		
+		var err error
+		if filepath.Base(file) == "base.yml" {
+			// base.yml must be a complete, valid config
+			_, err = config.LoadYAMLConfig(file)
+		} else {
+			// Other configs are environment-specific overlays and may be partial.
+			// We validate them by merging with base.yml.
+			_, err = config.LoadAndMergeConfigs([]string{"configs/base.yml", file})
+		}
+
+		if err != nil {
+			fmt.Printf("FAILED\nError: %v\n", err)
+			failed = true
+			continue
+		}
+		fmt.Println("PASSED")
+	}
+
+	if failed {
+		fmt.Println("\nConfiguration validation failed!")
+		os.Exit(1)
+	}
+
+	fmt.Println("\nAll configurations are valid.")
+}

--- a/cmd/config-validator/main.go
+++ b/cmd/config-validator/main.go
@@ -68,8 +68,20 @@ func main() {
 	fmt.Println("\nAll configurations are valid.")
 }
 
+const (
+	// minPricePerMillion is the minimum sane price per 1M tokens ($0.01).
+	// Any price below one cent per million has never been observed and likely
+	// indicates a decimal-place error (e.g. 0.001 instead of 0.10).
+	minPricePerMillion = 0.01
+
+	// maxPricePerMillion is the maximum sane price per 1M tokens ($100.00).
+	// Prices above this have never been observed and likely indicate a
+	// magnitude error (e.g. 1000.00 instead of 10.00).
+	maxPricePerMillion = 100.00
+)
+
 // validateSemantics checks for logical errors that YAML parsing won't catch:
-//   - Pricing values must be positive (> 0)
+//   - Pricing values must be within the sane range [minPricePerMillion, maxPricePerMillion]
 //   - Aliases must be unique within a provider (duplicate aliases cause non-deterministic routing)
 func validateSemantics(cfg *config.YAMLConfig) []string {
 	var errs []string
@@ -99,7 +111,7 @@ func validateSemantics(cfg *config.YAMLConfig) []string {
 				}
 			}
 
-			// Check pricing values are positive.
+			// Check pricing values are within sane bounds.
 			if model.Pricing == nil {
 				continue
 			}
@@ -108,35 +120,32 @@ func validateSemantics(cfg *config.YAMLConfig) []string {
 				continue
 			}
 			for i, tier := range mp.Tiers {
-				if tier.Input <= 0 {
-					errs = append(errs, fmt.Sprintf(
-						"%s/%s: tier[%d] input price must be > 0, got %g",
-						providerName, modelName, i, tier.Input,
-					))
-				}
-				if tier.Output <= 0 {
-					errs = append(errs, fmt.Sprintf(
-						"%s/%s: tier[%d] output price must be > 0, got %g",
-						providerName, modelName, i, tier.Output,
-					))
-				}
+				errs = append(errs, checkPrice(providerName, modelName, fmt.Sprintf("tier[%d] input", i), tier.Input)...)
+				errs = append(errs, checkPrice(providerName, modelName, fmt.Sprintf("tier[%d] output", i), tier.Output)...)
 			}
 			for alias, p := range mp.Overrides {
-				if p.Input <= 0 {
-					errs = append(errs, fmt.Sprintf(
-						"%s/%s: override[%q] input price must be > 0, got %g",
-						providerName, modelName, alias, p.Input,
-					))
-				}
-				if p.Output <= 0 {
-					errs = append(errs, fmt.Sprintf(
-						"%s/%s: override[%q] output price must be > 0, got %g",
-						providerName, modelName, alias, p.Output,
-					))
-				}
+				errs = append(errs, checkPrice(providerName, modelName, fmt.Sprintf("override[%q] input", alias), p.Input)...)
+				errs = append(errs, checkPrice(providerName, modelName, fmt.Sprintf("override[%q] output", alias), p.Output)...)
 			}
 		}
 	}
 
 	return errs
+}
+
+// checkPrice returns an error string if price is outside [minPricePerMillion, maxPricePerMillion].
+func checkPrice(provider, model, field string, price float64) []string {
+	if price < minPricePerMillion {
+		return []string{fmt.Sprintf(
+			"%s/%s: %s price $%g/1M is below minimum $%.2f/1M — likely a decimal error",
+			provider, model, field, price, minPricePerMillion,
+		)}
+	}
+	if price > maxPricePerMillion {
+		return []string{fmt.Sprintf(
+			"%s/%s: %s price $%g/1M exceeds maximum $%.2f/1M — likely a magnitude error",
+			provider, model, field, price, maxPricePerMillion,
+		)}
+	}
+	return nil
 }

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -270,19 +270,6 @@ providers:
         pricing:
           input: 20.00
           output: 80.00
-      "o1-pro":
-        enabled: true
-        aliases: ["o1-pro-2024-12-17"]
-        limits:
-          tokens_per_minute: 450_000
-          requests_per_minute: 5_000
-          tokens_per_day: 10_800_000
-          requests_per_day: 7_200_000
-          burst_tokens: 45_000
-          burst_requests: 500
-        pricing:
-          input: 150.00
-          output: 600.00
       "gpt-5.4":
         enabled: true
         aliases: ["gpt-5.4-2026-03-05"]
@@ -322,19 +309,6 @@ providers:
         pricing:
           input: 0.20
           output: 1.25
-      "gpt-5.4-pro":
-        enabled: true
-        aliases: ["gpt-5.4-pro-2026-03-05"]
-        limits:
-          tokens_per_minute: 450_000
-          requests_per_minute: 5_000
-          tokens_per_day: 10_800_000
-          requests_per_day: 7_200_000
-          burst_tokens: 45_000
-          burst_requests: 500
-        pricing:
-          input: 30.00
-          output: 180.00
       "gpt-5.2":
         enabled: true
         aliases: ["gpt-5.2-2025-12-11"]
@@ -348,19 +322,6 @@ providers:
         pricing:
           input: 1.75
           output: 14.00
-      "gpt-5.2-pro":
-        enabled: true
-        aliases: ["gpt-5.2-pro-2025-12-11"]
-        limits:
-          tokens_per_minute: 450_000
-          requests_per_minute: 5_000
-          tokens_per_day: 10_800_000
-          requests_per_day: 7_200_000
-          burst_tokens: 45_000
-          burst_requests: 500
-        pricing:
-          input: 21.00
-          output: 168.00
       "gpt-5.1":
         enabled: true
         aliases: ["gpt-5.1-2025-10-01"]
@@ -374,19 +335,6 @@ providers:
         pricing:
           input: 1.25
           output: 10.00
-      "gpt-5-pro":
-        enabled: true
-        aliases: ["gpt-5-pro-2025-08-07"]
-        limits:
-          tokens_per_minute: 450_000
-          requests_per_minute: 5_000
-          tokens_per_day: 10_800_000
-          requests_per_day: 7_200_000
-          burst_tokens: 45_000
-          burst_requests: 500
-        pricing:
-          input: 15.00
-          output: 120.00
 
   # ---------------------------------------------------------------------------
   # ANTHROPIC PROVIDER

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -197,8 +197,8 @@ providers:
           burst_tokens: 45_000
           burst_requests: 500
         pricing:
-          input: 7.00
-          output: 21.00
+          input: 15.00
+          output: 60.00
       "o1-mini":
         enabled: true
         aliases: ["o1-mini-2024-09-12"]
@@ -210,8 +210,8 @@ providers:
           burst_tokens: 20_000
           burst_requests: 200
         pricing:
-          input: 0.50
-          output: 1.50
+          input: 1.10
+          output: 4.40
       "o3-mini":
         enabled: true
         aliases: ["o3-mini-2025-01-31"]
@@ -255,8 +255,138 @@ providers:
           burst_tokens: 4_000
           burst_requests: 100
         pricing:
-          input: 10.00
-          output: 40.00
+          input: 2.00
+          output: 8.00
+      "o3-pro":
+        enabled: true
+        aliases: ["o3-pro-2025-04-16"]
+        limits:
+          tokens_per_minute: 40_000
+          requests_per_minute: 1_000
+          tokens_per_day: 960_000
+          requests_per_day: 1_440_000
+          burst_tokens: 4_000
+          burst_requests: 100
+        pricing:
+          input: 20.00
+          output: 80.00
+      "o1-pro":
+        enabled: true
+        aliases: ["o1-pro-2024-12-17"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 150.00
+          output: 600.00
+      "gpt-5.4":
+        enabled: true
+        aliases: ["gpt-5.4-2026-03-05"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 2.50
+          output: 15.00
+      "gpt-5.4-mini":
+        enabled: true
+        aliases: ["gpt-5.4-mini-2026-03-05"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 0.75
+          output: 4.50
+      "gpt-5.4-nano":
+        enabled: true
+        aliases: ["gpt-5.4-nano-2026-03-05"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 0.20
+          output: 1.25
+      "gpt-5.4-pro":
+        enabled: true
+        aliases: ["gpt-5.4-pro-2026-03-05"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 30.00
+          output: 180.00
+      "gpt-5.2":
+        enabled: true
+        aliases: ["gpt-5.2-2025-12-11"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 1.75
+          output: 14.00
+      "gpt-5.2-pro":
+        enabled: true
+        aliases: ["gpt-5.2-pro-2025-12-11"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 21.00
+          output: 168.00
+      "gpt-5.1":
+        enabled: true
+        aliases: ["gpt-5.1-2025-10-01"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 1.25
+          output: 10.00
+      "gpt-5-pro":
+        enabled: true
+        aliases: ["gpt-5-pro-2025-08-07"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 15.00
+          output: 120.00
 
   # ---------------------------------------------------------------------------
   # ANTHROPIC PROVIDER
@@ -274,9 +404,22 @@ providers:
       burst_requests: 100
 
     models:
+      "claude-opus-4-7":
+        enabled: true
+        aliases: ["claude-opus-4.7", "claude-opus-4-7-20260416"]
+        limits:
+          tokens_per_minute: 40_000
+          requests_per_minute: 1_000
+          tokens_per_day: 960_000
+          requests_per_day: 1_440_000
+          burst_tokens: 4_000
+          burst_requests: 100
+        pricing:
+          input: 5.00
+          output: 25.00
       "claude-opus-4-6":
         enabled: true
-        aliases: ["claude-opus-4.6"]
+        aliases: ["claude-opus-4.6", "claude-opus-4-6-20260215"]
         limits:
           tokens_per_minute: 40_000
           requests_per_minute: 1_000
@@ -289,10 +432,7 @@ providers:
           output: 25.00
       "claude-opus-4-5":
         enabled: true
-        aliases: [
-          "claude-opus-4-5-20251101",
-          "claude-opus-4.5",
-        ]
+        aliases: ["claude-opus-4.5", "claude-opus-4-5-20251101", "claude-opus-4-5-20251215"]
         limits:
           tokens_per_minute: 40_000
           requests_per_minute: 1_000
@@ -316,6 +456,23 @@ providers:
         pricing:
           input: 15.00
           output: 75.00
+      "claude-sonnet-4-6":
+        enabled: true
+        aliases: ["claude-sonnet-4.6", "claude-sonnet-4-6-20260217"]
+        limits:
+          tokens_per_minute: 80_000
+          requests_per_minute: 1_000
+          tokens_per_day: 1_920_000
+          requests_per_day: 1_440_000
+          burst_tokens: 8_000
+          burst_requests: 100
+        pricing:
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
       "claude-sonnet-4-0":
         enabled: true
         aliases: ["claude-sonnet-4", "claude-sonnet-4-20250514"]
@@ -327,22 +484,12 @@ providers:
           burst_tokens: 8_000
           burst_requests: 100
         pricing:
-          input: 3.00
-          output: 15.00
-
-      "claude-sonnet-4-6":
-        enabled: true
-        aliases: ["claude-sonnet-4.6"]
-        limits:
-          tokens_per_minute: 80_000
-          requests_per_minute: 1_000
-          tokens_per_day: 1_920_000
-          requests_per_day: 1_440_000
-          burst_tokens: 8_000
-          burst_requests: 100
-        pricing:
-          input: 3.00
-          output: 15.00
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
       "claude-sonnet-4-5":
         enabled: true
         aliases: ["claude-sonnet-4-5-20250929", "claude-sonnet-4.5"]
@@ -354,8 +501,12 @@ providers:
           burst_tokens: 8_000
           burst_requests: 100
         pricing:
-          input: 3.00
-          output: 15.00
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
       "claude-3-7-sonnet":
         enabled: true
         aliases:
@@ -411,10 +562,7 @@ providers:
           output: 15.00
       "claude-haiku-4-5":
         enabled: true
-        aliases: [
-            "claude-haiku-4.5",
-            "claude-haiku-4-5-20251001"
-          ]
+        aliases: ["claude-haiku-4.5", "claude-haiku-4-5-20251001", "claude-haiku-4-5-20251015"]
         limits:
           tokens_per_minute: 100_000
           requests_per_minute: 1_000
@@ -454,6 +602,66 @@ providers:
       burst_requests: 100
 
     models:
+      "gemini-3.1-pro":
+        enabled: true
+        aliases: ["gemini-3.1-pro-preview", "gemini-3-1-pro"]
+        limits:
+          tokens_per_minute: 5_000_000
+          requests_per_minute: 1_000
+          tokens_per_day: 120_000_000
+          requests_per_day: 1_440_000
+          burst_tokens: 500_000
+          burst_requests: 100
+        pricing:
+          - threshold: 200_000
+            input: 2.00
+            output: 12.00
+          - threshold: 0
+            input: 4.00
+            output: 18.00
+      "gemini-3-pro":
+        enabled: true
+        aliases: ["gemini-3-pro-preview", "gemini-3-0-pro"]
+        limits:
+          tokens_per_minute: 5_000_000
+          requests_per_minute: 1_000
+          tokens_per_day: 120_000_000
+          requests_per_day: 1_440_000
+          burst_tokens: 500_000
+          burst_requests: 100
+        pricing:
+          - threshold: 200_000
+            input: 2.00
+            output: 12.00
+          - threshold: 0
+            input: 4.00
+            output: 18.00
+      "gemini-3-flash":
+        enabled: true
+        aliases: ["gemini-3-flash-preview", "gemini-3-0-flash"]
+        limits:
+          tokens_per_minute: 3_000_000
+          requests_per_minute: 2_000
+          tokens_per_day: 72_000_000
+          requests_per_day: 2_880_000
+          burst_tokens: 300_000
+          burst_requests: 200
+        pricing:
+          input: 0.50
+          output: 3.00
+      "gemini-3.1-flash-lite":
+        enabled: true
+        aliases: ["gemini-3.1-flash-lite-preview", "gemini-3-1-flash-lite"]
+        limits:
+          tokens_per_minute: 3_000_000
+          requests_per_minute: 2_000
+          tokens_per_day: 72_000_000
+          requests_per_day: 2_880_000
+          burst_tokens: 300_000
+          burst_requests: 200
+        pricing:
+          input: 0.25
+          output: 1.50
       "gemini-2.5-pro":
         enabled: true
         aliases: ["gemini-pro-2.5", "gemini-2-5-pro"]

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -521,6 +521,25 @@ providers:
         pricing:
           input: 1.00
           output: 5.00
+      "claude-3-5-haiku":
+        enabled: true
+        aliases:
+          [
+            "claude-3-5-haiku-latest",
+            "claude-3.5-haiku",
+            "claude-haiku-3.5",
+            "claude-3-5-haiku-20241022",
+          ]
+        limits:
+          tokens_per_minute: 100_000
+          requests_per_minute: 1_000
+          tokens_per_day: 2_400_000
+          requests_per_day: 1_440_000
+          burst_tokens: 10_000
+          burst_requests: 100
+        pricing:
+          input: 0.80
+          output: 4.00
       "claude-3-haiku-20240307":
         enabled: true
         aliases: ["claude-3-haiku", "claude-haiku"]

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -270,6 +270,19 @@ providers:
         pricing:
           input: 20.00
           output: 80.00
+      "o1-pro":
+        enabled: true
+        aliases: ["o1-pro-2024-12-17"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 150.00
+          output: 600.00
       "gpt-5.4":
         enabled: true
         aliases: ["gpt-5.4-2026-03-05"]
@@ -309,6 +322,19 @@ providers:
         pricing:
           input: 0.20
           output: 1.25
+      "gpt-5.4-pro":
+        enabled: true
+        aliases: ["gpt-5.4-pro-2026-03-05"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 30.00
+          output: 180.00
       "gpt-5.2":
         enabled: true
         aliases: ["gpt-5.2-2025-12-11"]
@@ -322,6 +348,19 @@ providers:
         pricing:
           input: 1.75
           output: 14.00
+      "gpt-5.2-pro":
+        enabled: true
+        aliases: ["gpt-5.2-pro-2025-12-11"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 21.00
+          output: 168.00
       "gpt-5.1":
         enabled: true
         aliases: ["gpt-5.1-2025-10-01"]
@@ -335,6 +374,19 @@ providers:
         pricing:
           input: 1.25
           output: 10.00
+      "gpt-5-pro":
+        enabled: true
+        aliases: ["gpt-5-pro-2025-08-07"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 15.00
+          output: 120.00
 
   # ---------------------------------------------------------------------------
   # ANTHROPIC PROVIDER

--- a/internal/providers/gemini_integration_test.go
+++ b/internal/providers/gemini_integration_test.go
@@ -22,15 +22,16 @@ type geminiTestModel struct {
 	testPrompt string
 }
 
-// Test models to use in parameterized tests
+// Test models to use in parameterized tests.
+// Note: Gemini 1.5 models were retired by Google in October 2025. Gemini 2.0
+// Flash is scheduled for shutdown on June 1, 2026 per
+// https://ai.google.dev/gemini-api/docs/deprecations — tests target 2.5 Flash.
 var geminiTestModels = []geminiTestModel{
 	{
-		name:       "Gemini-2.0-Flash",
-		modelID:    "gemini-2.0-flash",
+		name:       "Gemini-2.5-Flash",
+		modelID:    "gemini-2.5-flash",
 		testPrompt: "Hello! Can you tell me a short joke?",
 	},
-	// Note: Gemini 1.5 models (gemini-1.5-flash and gemini-1.5-pro) have been deprecated
-	// by Google and are no longer available in the API as of October 2025
 }
 
 // TestGeminiIntegration_Models tests multiple Gemini models using subtests
@@ -372,15 +373,13 @@ func TestGeminiIntegration_V1BetaRoutes(t *testing.T) {
 		modelID string
 		text    string
 	}{
+		// text-embedding-004 (retired 2026-01-14) and embedding-001 (retired
+		// 2025-10-30) were consolidated into gemini-embedding-001. See
+		// https://ai.google.dev/gemini-api/docs/deprecations.
 		{
-			name:    "TextEmbedding004",
-			modelID: "text-embedding-004",
+			name:    "GeminiEmbedding001",
+			modelID: "gemini-embedding-001",
 			text:    "The quick brown fox jumps over the lazy dog.",
-		},
-		{
-			name:    "Embedding001",
-			modelID: "embedding-001",
-			text:    "Hello, world! This is a test of the embedding API.",
 		},
 	}
 
@@ -781,11 +780,12 @@ func TestGeminiIntegration_EmbedContent(t *testing.T) {
 		text    string
 	}{
 		{
-			name:    "TextEmbedding004",
-			modelID: "text-embedding-004",
+			name:    "GeminiEmbedding001",
+			modelID: "gemini-embedding-001",
 			text:    "The quick brown fox jumps over the lazy dog.",
 		},
-		// Add more embedding models as needed
+		// Add more embedding models as needed. Note: text-embedding-004 and
+		// embedding-001 were both retired in favor of gemini-embedding-001.
 	}
 
 	for _, model := range embeddingModels {

--- a/internal/providers/gemini_integration_test.go
+++ b/internal/providers/gemini_integration_test.go
@@ -805,7 +805,10 @@ func TestGeminiIntegration_EmbedContent(t *testing.T) {
 				t.Fatalf("Failed to marshal request body: %v", err)
 			}
 
-			url := fmt.Sprintf("%s/gemini/v1/models/%s:embedContent?key=%s", server.URL, model.modelID, apiKey)
+			// gemini-embedding-001 is only served on v1beta, not v1. The former
+			// /v1/ embedding models (text-embedding-004, embedding-001) were
+			// retired by Google before the v1 endpoint was promoted.
+			url := fmt.Sprintf("%s/gemini/v1beta/models/%s:embedContent?key=%s", server.URL, model.modelID, apiKey)
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 			if err != nil {
 				t.Fatalf("Failed to create request: %v", err)


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

## Summary
Refreshes LLM model pricing in `configs/base.yml` to match market rates as of April 23, 2026, adds a config validator that runs in CI, and ships a Cursor skill that automates future pricing audits.

### Pricing updates
- **OpenAI**: Fixed stale prices for `o1` (7/21 → 15/60), `o3` (10/40 → 2/8), and `o1-mini` (0.50/1.50 → 1.10/4.40). Added `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`, `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1`, `gpt-5-pro`, `o1-pro`, and `o3-pro`.
- **Anthropic**: Added `claude-opus-4-7`. Merged newer dated snapshot aliases into `claude-opus-4-6`, `claude-opus-4-5`, `claude-sonnet-4-6`, and `claude-haiku-4-5` (which came in via #2). Backfilled mandatory tiered pricing (>200k surcharge) for `claude-sonnet-4-0`, `claude-sonnet-4-5`, and `claude-sonnet-4-6`.
- **Gemini**: Added `gemini-3.1-pro` (tiered), `gemini-3-pro` (tiered), `gemini-3-flash`, and `gemini-3.1-flash-lite`.

### Config validator + CI (`cmd/config-validator/`)
A new standalone Go binary that validates every file under `configs/` — `base.yml` as a complete config, and each environment overlay merged onto base. Runs before unit tests in CircleCI. Beyond the existing struct-level validation it also enforces:
- **Unique aliases per provider** (catches accidental duplicate aliases that would cause non-deterministic routing).
- **Price sanity bounds**: `$0.01 ≤ price/1M ≤ $1000`. Catches decimal-place errors on the low end and magnitude errors on the high end, while leaving headroom above the real-world max (`o1-pro` at $600/1M output).

### Automation skill (`.cursor/skills/llm-price-update/SKILL.md`)
Encodes the full workflow for future pricing refreshes: parallel web search via subagents, strict alias rules (same version number = aliasable, different version = never aliasable), mandatory tiered pricing when the vendor publishes it, required validator + test runs before commit, and an emitted deprecations list.

## Test plan
- [x] `go run ./cmd/config-validator/` passes for `base.yml`, `dev.yml`, `staging.yml`, `production.yml`.
- [x] `go test ./internal/config/...` passes, including tiered-pricing assertions in `TestGetModelPricing`.
- [x] `gofmt -s -l cmd/config-validator/main.go` clean.
- [x] Verified no hard-coded pricing assertions were broken by the `o1`/`o3`/`o1-mini` fixes.

## Deprecations
```yaml
deprecations:
  openai:
    - model: o1-preview
      replaced_by: o1
      sunset_date: null
      source: https://platform.openai.com/docs/pricing
      notes: Removed from platform pricing page; keep entry for backwards compat
  anthropic:
    - model: claude-3-7-sonnet
      replaced_by: claude-sonnet-4-6
      sunset_date: null
      source: https://docs.anthropic.com/en/docs/about-claude/pricing
      notes: Flagged deprecated on docs pricing page; dropped from marketing page
    - model: claude-3-5-sonnet
      replaced_by: claude-sonnet-4-6
      sunset_date: null
      source: https://www.anthropic.com/pricing
      notes: Not listed on either Anthropic pricing page; effectively retired
    - model: claude-3-opus-20240229
      replaced_by: claude-opus-4-7
      sunset_date: null
      source: https://docs.anthropic.com/en/docs/about-claude/pricing
      notes: Marked deprecated
  gemini:
    - model: gemini-3-pro-preview
      replaced_by: gemini-3.1-pro
      sunset_date: null
      source: https://ai.google.dev/gemini-api/docs/pricing
      notes: Preview SKU superseded by gemini-3.1-pro GA; kept as alias on gemini-3-pro for backwards compat
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated pricing-audit skill to refresh and verify model pricing and deprecations from major providers
  * Added many new OpenAI, Anthropic (Opus/Haiku/Sonnet), and Google Gemini 3.x models with per-model limits and tiered pricing

* **Chores**
  * Updated pricing rates across existing OpenAI and Anthropic models
  * Introduced a pre-test configuration validation step to catch pricing/semantic issues before running unit tests

* **Tests**
  * Updated Gemini-related tests and embedding coverage to match current models

* **Documentation**
  * Added detailed specification and validation guidance for the pricing-audit workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->