### PR TITLE
Support LLM_PROXY_CONFIG_PROFILE for sidecar overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ that the client computes and the proxy forwards verbatim.
 
 ## Configuration
 
+- `ENVIRONMENT`: Selects the deploy overlay YAML (`configs/{ENVIRONMENT}.yml`, default `dev`).
+- `LLM_PROXY_CONFIG_PROFILE`: Optional second overlay merged after the env file (e.g. `sidecar` for co-located containers in the same task — keeps `ENVIRONMENT=production` while disabling PII redaction and the admin dashboard via `configs/sidecar.yml`).
 - `PORT`: Environment variable to set the server port (default: 9002)
 - `AWS_REGION`: Region for the upstream Bedrock endpoint host (default:
   `us-west-2`). Only consulted when `providers.bedrock.enabled` is true.
@@ -186,7 +188,7 @@ that the client computes and the proxy forwards verbatim.
 - Disabled by default. Enable via config: see `configs/base.yml` and `configs/dev.yml`.
 - Supports provisional token estimation with post-response reconciliation using `X-LLM-Input-Tokens` (input tokens only).
 - Returns `429 Too Many Requests` with `Retry-After` and `X-RateLimit-*` headers when throttled.
- - Redis backend is currently not supported; only the in-process memory backend is available.
+- Redis backend is currently not supported; only the in-process memory backend is available.
 
 Minimal dev example (see `configs/dev.yml` for a full setup):
 
@@ -434,6 +436,47 @@ Each provider implements its own:
 - Response metadata parsing
 
 ## Development
+
+### Local development: Docker + the admin dashboard
+
+Local dev runs the Go proxy, its datastores, and the admin dashboard from
+Docker Compose:
+
+1. **Start the full dev stack**:
+
+   ```bash
+   make docker-compose-up        # ENVIRONMENT=dev docker compose up -d
+   ```
+
+   This starts four containers: `llm-proxy` (the Go server, live-reloaded via
+   `air` on `:9002`), `redis` (circuit breaker / rate limiting / admin
+   rollups), `dynamodb` (local API-key + cost-tracking tables), and `web` (the
+   Vite admin dashboard on `:5173`). Check them with `docker compose ps`; tail
+   logs with `make docker-compose-logs`.
+
+2. **Open the admin dashboard**:
+
+   | URL | Served by | Use when |
+   | --- | --- | --- |
+   | `http://localhost:9002/admin/` | The Go proxy (embedded build) | You just want to click around; matches production exactly. No extra process. |
+   | `http://localhost:5173/admin/` | The Vite dev server from Docker Compose | You're editing `web/` and want hot reload. |
+
+   If you prefer to run Vite directly on the host, stop the `web` container and
+   start the same dev server from `web/`:
+
+   ```bash
+   cd web
+   npm install        # first time only
+   npm run dev        # serves http://localhost:5173/admin/
+   ```
+
+   Vite proxies `/admin/api` and `/admin/auth` to the Go proxy at `:9002`
+   (override with `VITE_API_PROXY_TARGET`), so the proxy containers must be up
+   for the dashboard to load data or log in.
+
+> **`localhost:5173` refused to connect?** Check that the `web` container is
+> running with `docker compose ps`, or use the embedded SPA at
+> `http://localhost:9002/admin/` instead.
 
 ### Available Make Commands
 

--- a/configs/sidecar.yml
+++ b/configs/sidecar.yml
@@ -1,6 +1,8 @@
-# Sidecar deployment config (llm-proxy container co-located with an app).
-# PII redaction and admin dashboard stay off — observability redaction runs
-# only on the standalone llm-proxy service.
+# Sidecar deployment profile (llm-proxy container co-located with an app).
+# Set LLM_PROXY_CONFIG_PROFILE=sidecar alongside ENVIRONMENT=production (or
+# staging) so deploy identity and infra settings stay on the env file while
+# PII redaction and the admin dashboard stay off here — observability redaction
+# runs only on the standalone llm-proxy service.
 
 enabled: true
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -567,8 +567,11 @@ func loadYAMLConfigWithoutValidation(filename string) (*YAMLConfig, error) {
 	return &config, nil
 }
 
-// LoadEnvironmentConfig loads base configuration and overlays environment-specific configuration
-// based on the ENVIRONMENT variable (defaults to "dev")
+// LoadEnvironmentConfig loads base configuration and overlays environment-specific
+// configuration based on the ENVIRONMENT variable (defaults to "dev"). When
+// LLM_PROXY_CONFIG_PROFILE is set, its YAML file is merged last — e.g.
+// ENVIRONMENT=production + LLM_PROXY_CONFIG_PROFILE=sidecar keeps prod infra
+// settings while applying the sidecar feature toggles.
 func LoadEnvironmentConfig() (*YAMLConfig, error) {
 	configDir := "configs"
 
@@ -585,21 +588,36 @@ func LoadEnvironmentConfig() (*YAMLConfig, error) {
 	}
 	slog.Info("Loading environment configuration", "environment", env)
 
+	mergedConfig := baseConfig
+
 	// Load environment-specific configuration (skip validation since it's just overrides)
 	envConfigPath := filepath.Join(configDir, fmt.Sprintf("%s.yml", env))
 	envConfig, err := loadYAMLConfigWithoutValidation(envConfigPath)
 	if err != nil {
 		// If environment config doesn't exist, just use base config
-		if os.IsNotExist(err) {
-			return baseConfig, nil
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to load environment configuration for %s: %w", env, err)
 		}
-		return nil, fmt.Errorf("failed to load environment configuration for %s: %w", env, err)
+	} else {
+		mergedConfig, err = mergeConfigs(mergedConfig, envConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge configurations: %w", err)
+		}
 	}
 
-	// Merge environment config into base config
-	mergedConfig, err := mergeConfigs(baseConfig, envConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge configurations: %w", err)
+	profile := os.Getenv("LLM_PROXY_CONFIG_PROFILE")
+	if profile != "" {
+		slog.Info("Loading config profile overlay", "profile", profile)
+		profileConfigPath := filepath.Join(configDir, fmt.Sprintf("%s.yml", profile))
+		if _, err := os.Stat(profileConfigPath); os.IsNotExist(err) {
+			return nil, fmt.Errorf("config profile %q not found at %s", profile, profileConfigPath)
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to stat config profile %s: %w", profile, err)
+		}
+		mergedConfig, err = mergeConfigFromYAMLFile(mergedConfig, profileConfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge config profile %s: %w", profile, err)
+		}
 	}
 
 	return mergedConfig, nil
@@ -646,6 +664,53 @@ func mergeConfigs(base, env *YAMLConfig) (*YAMLConfig, error) {
 	}
 
 	// Validate and parse pricing
+	if err := mergedConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid merged configuration: %w", err)
+	}
+
+	if err := mergedConfig.ParsePricing(); err != nil {
+		return nil, fmt.Errorf("failed to parse pricing in merged configuration: %w", err)
+	}
+
+	return &mergedConfig, nil
+}
+
+// mergeConfigFromYAMLFile deep-merges a YAML file into base. Only keys present
+// in the file participate — partial overlays (e.g. configs/sidecar.yml) do not
+// inject zero-value feature toggles from a struct round-trip.
+func mergeConfigFromYAMLFile(base *YAMLConfig, filename string) (*YAMLConfig, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", filename, err)
+	}
+
+	var overlayMap map[string]interface{}
+	if err := yaml.Unmarshal(data, &overlayMap); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML config %s: %w", filename, err)
+	}
+
+	baseBytes, err := yaml.Marshal(base)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal base config: %w", err)
+	}
+
+	var baseMap map[string]interface{}
+	if err := yaml.Unmarshal(baseBytes, &baseMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal base config to map: %w", err)
+	}
+
+	mergedMap := deepMerge(baseMap, overlayMap)
+
+	mergedBytes, err := yaml.Marshal(mergedMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal merged config: %w", err)
+	}
+
+	var mergedConfig YAMLConfig
+	if err := yaml.Unmarshal(mergedBytes, &mergedConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal merged config: %w", err)
+	}
+
 	if err := mergedConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid merged configuration: %w", err)
 	}

--- a/internal/config/loading_test.go
+++ b/internal/config/loading_test.go
@@ -54,6 +54,78 @@ providers:
 	require.Contains(t, cfg.Providers["openai"].Models["gpt-4o"].Aliases, "g4")
 }
 
+func TestLoadEnvironmentConfig_ConfigProfileOverlay(t *testing.T) {
+	tmpRoot := t.TempDir()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	require.NoError(t, os.Chdir(tmpRoot))
+
+	configDir := filepath.Join(tmpRoot, "configs")
+	writeYAML(t, configDir, "base.yml", `
+enabled: true
+features:
+  pii_redact:
+    enabled: false
+  admin_dashboard:
+    enabled: false
+providers:
+  openai:
+    enabled: true
+`)
+	writeYAML(t, configDir, "production.yml", `
+features:
+  pii_redact:
+    enabled: true
+    analyzer_url: "http://localhost:3000"
+  admin_dashboard:
+    enabled: true
+  circuit_breaker:
+    enabled: true
+    failure_threshold: 5
+    window_seconds: 120
+    cooldown_seconds: 300
+`)
+	writeYAML(t, configDir, "sidecar.yml", `
+features:
+  pii_redact:
+    enabled: false
+  admin_dashboard:
+    enabled: false
+`)
+
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("LLM_PROXY_CONFIG_PROFILE", "sidecar")
+	cfg, err := LoadEnvironmentConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.False(t, cfg.Features.PIIRedact.Enabled)
+	assert.False(t, cfg.Features.AdminDashboard.Enabled)
+	assert.True(t, cfg.Features.CircuitBreaker.Enabled)
+}
+
+func TestLoadEnvironmentConfig_MissingConfigProfileErrors(t *testing.T) {
+	tmpRoot := t.TempDir()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	require.NoError(t, os.Chdir(tmpRoot))
+
+	configDir := filepath.Join(tmpRoot, "configs")
+	writeYAML(t, configDir, "base.yml", `
+enabled: true
+providers:
+  openai:
+    enabled: true
+`)
+
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("LLM_PROXY_CONFIG_PROFILE", "missing-profile")
+	_, err = LoadEnvironmentConfig()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-profile")
+}
+
 func TestLoadEnvironmentConfig_DefaultEnvIsDev(t *testing.T) {
 	tmpRoot := t.TempDir()
 	cwd, _ := os.Getwd()
@@ -295,8 +367,35 @@ func TestDevConfig_PerUserOverridesNotMisnested(t *testing.T) {
 	// dev.yml defines an `example-user` override at the correct anchor.
 	override, ok := cfg.Features.RateLimiting.Overrides.PerUser["example-user"]
 	assert.True(t, ok, "features.rate_limiting.overrides.per_user.example-user missing — likely mis-nested under redis:")
-	if ok {
+		if ok {
 		assert.Equal(t, 5, override.RequestsPerMinute, "per_user override decoded with wrong limits")
 		assert.Equal(t, 2000, override.TokensPerMinute)
 	}
+}
+
+func TestRealEnvConfigs_ProductionSidecarProfile(t *testing.T) {
+	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
+	require.NoError(t, err)
+	if _, err := os.Stat(configsDir); err != nil {
+		t.Skipf("configs dir not found (%s) — skipping", configsDir)
+	}
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	require.NoError(t, os.Chdir(repoRoot))
+
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("LLM_PROXY_CONFIG_PROFILE", "sidecar")
+	cfg, err := LoadEnvironmentConfig()
+	require.NoError(t, err)
+
+	assert.True(t, cfg.Features.CircuitBreaker.Enabled,
+		"production infra (circuit breaker) must survive the sidecar profile overlay")
+	assert.False(t, cfg.Features.PIIRedact.Enabled,
+		"sidecar profile must disable PII redaction")
+	assert.False(t, cfg.Features.AdminDashboard.Enabled,
+		"sidecar profile must disable the admin dashboard")
 }

--- a/internal/config/loading_test.go
+++ b/internal/config/loading_test.go
@@ -367,7 +367,7 @@ func TestDevConfig_PerUserOverridesNotMisnested(t *testing.T) {
 	// dev.yml defines an `example-user` override at the correct anchor.
 	override, ok := cfg.Features.RateLimiting.Overrides.PerUser["example-user"]
 	assert.True(t, ok, "features.rate_limiting.overrides.per_user.example-user missing — likely mis-nested under redis:")
-		if ok {
+	if ok {
 		assert.Equal(t, 5, override.RequestsPerMinute, "per_user override decoded with wrong limits")
 		assert.Equal(t, 2000, override.TokensPerMinute)
 	}


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary
- Add `LLM_PROXY_CONFIG_PROFILE` env var to merge an optional YAML overlay after the `ENVIRONMENT` file (e.g. `sidecar` disables PII redaction and admin dashboard while keeping production circuit-breaker settings).
- Merge profile overlays from raw YAML so partial `sidecar.yml` does not zero out other feature toggles.
- Document the variable in README and update `configs/sidecar.yml` header.

## Test plan
- [x] `go test -race ./internal/config/...`
- [x] `go run ./cmd/config-validator/`
- [x] Open-source audit on changed files
- [ ] Deploy new llm-proxy image to ECR before infrastructure sidecar env var PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration profile support via `LLM_PROXY_CONFIG_PROFILE` environment variable
  * `ENVIRONMENT` variable for selecting overlay YAML files

* **Documentation**
  * New local development guide for Docker and admin dashboard setup
  * Clarified environment variable configuration options and rate-limiting behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->