### PR TITLE
feat(adminrollup): atomic multi-writer Redis rollups and rate-limit wiring

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1466,6 +1466,18 @@ func gracefulShutdown(server *http.Server) {
 		}
 	}
 
+	// Release the rate limiter's Redis client (the memory backend is a no-op
+	// and does not implement io.Closer). Mirrors the circuit-breaker cleanup.
+	if globalRateLimiter != nil {
+		if closer, ok := globalRateLimiter.(interface{ Close() error }); ok {
+			if err := closer.Close(); err != nil {
+				logger.Warn("Rate limiter: Redis close failed", "error", err)
+			} else {
+				logger.Info("✅ Rate limiter: Redis client closed")
+			}
+		}
+	}
+
 	logger.Info("👋 Server shutdown complete")
 }
 

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -80,6 +80,15 @@ features:
     per_provider_rollup_window_seconds: 300
   rate_limiting:
     enabled: false
+    backend: "redis"
+    redis:
+      url: "${REDIS_URL}"
+      db: 4
+    limits:
+      requests_per_minute: 0
+      tokens_per_minute: 0
+      requests_per_day: 0
+      tokens_per_day: 0
   pii_redact:
     enabled: true
     analyzer_url: "http://localhost:3000"

--- a/internal/admin/auth_oauth_test.go
+++ b/internal/admin/auth_oauth_test.go
@@ -1,0 +1,508 @@
+package admin
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+const testOAuthClientID = "test-oauth-client-id"
+
+type testOIDCServer struct {
+	t          *testing.T
+	server     *httptest.Server
+	issuer     string
+	privateKey *rsa.PrivateKey
+	kid        string
+	lastCode     string
+	tokenClaims  idTokenClaims
+}
+
+func newTestOIDCServer(t *testing.T) *testOIDCServer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	td := &testOIDCServer{
+		t:          t,
+		privateKey: key,
+		kid:        "test-signing-key",
+		tokenClaims: idTokenClaims{
+			email:         "alice@example.com",
+			emailVerified: true,
+			name:          "Alice Example",
+			hd:            "example.com",
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", td.serveDiscovery)
+	mux.HandleFunc("/jwks", td.serveJWKS)
+	mux.HandleFunc("/token", td.serveToken)
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "authorize stub", http.StatusNotImplemented)
+	})
+	td.server = httptest.NewServer(mux)
+	td.issuer = td.server.URL
+	t.Cleanup(td.server.Close)
+	return td
+}
+
+func (td *testOIDCServer) serveDiscovery(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"issuer":                 td.issuer,
+		"authorization_endpoint": td.issuer + "/authorize",
+		"token_endpoint":         td.issuer + "/token",
+		"jwks_uri":               td.issuer + "/jwks",
+	})
+}
+
+func (td *testOIDCServer) serveJWKS(w http.ResponseWriter, _ *http.Request) {
+	n := base64.RawURLEncoding.EncodeToString(td.privateKey.PublicKey.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1})
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"keys": []map[string]string{
+			{
+				"kty": "RSA",
+				"kid": td.kid,
+				"alg": "RS256",
+				"use": "sig",
+				"n":   n,
+				"e":   e,
+			},
+		},
+	})
+}
+
+func (td *testOIDCServer) serveToken(w http.ResponseWriter, r *http.Request) {
+	require.NoError(td.t, r.ParseForm())
+	td.lastCode = r.Form.Get("code")
+	if td.lastCode == "" {
+		http.Error(w, "missing code", http.StatusBadRequest)
+		return
+	}
+	idToken := td.mintIDToken(td.tokenClaims)
+	writeJSON(w, http.StatusOK, map[string]string{
+		"access_token": "test-access-token",
+		"token_type":   "Bearer",
+		"id_token":     idToken,
+	})
+}
+
+type idTokenClaims struct {
+	email         string
+	emailVerified bool
+	name          string
+	picture       string
+	hd            string
+}
+
+func (td *testOIDCServer) mintIDToken(claims idTokenClaims) string {
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: td.privateKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", td.kid),
+	)
+	require.NoError(td.t, err)
+
+	now := time.Now()
+	raw, err := jwt.Signed(signer).
+		Claims(jwt.Claims{
+			Issuer:   td.issuer,
+			Subject:  claims.email,
+			Audience: jwt.Audience{testOAuthClientID},
+			Expiry:   jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt: jwt.NewNumericDate(now),
+		}).
+		Claims(map[string]interface{}{
+			"email":          claims.email,
+			"email_verified": claims.emailVerified,
+			"name":           claims.name,
+			"picture":        claims.picture,
+			"hd":             claims.hd,
+		}).
+		Serialize()
+	require.NoError(td.t, err)
+	return raw
+}
+
+func newTestOAuthAuthenticator(t *testing.T, oidcSrv *testOIDCServer, allowedDomain string) *authenticator {
+	t.Helper()
+	provider, err := oidc.NewProvider(context.Background(), oidcSrv.issuer)
+	require.NoError(t, err)
+
+	sessionStore := sessions.NewCookieStore([]byte("test-secret-at-least-32-bytes-long"))
+	sessionStore.Options = &sessions.Options{Path: "/", MaxAge: 3600, HttpOnly: true}
+
+	return &authenticator{
+		oauthConfig: &oauth2.Config{
+			ClientID:     testOAuthClientID,
+			ClientSecret: "test-secret",
+			RedirectURL:  "http://localhost/admin/auth/callback",
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  oidcSrv.issuer + "/authorize",
+				TokenURL: oidcSrv.issuer + "/token",
+			},
+			Scopes: []string{oidc.ScopeOpenID, "email", "profile"},
+		},
+		verifier:       provider.Verifier(&oidc.Config{ClientID: testOAuthClientID}),
+		sessionStore:   sessionStore,
+		allowedDomain:  allowedDomain,
+		devFrontendOrigin: "http://localhost:5173",
+		logger:         testLogger(),
+	}
+}
+
+func saveOAuthStateSession(t *testing.T, auth *authenticator, w http.ResponseWriter, r *http.Request, state string) {
+	t.Helper()
+	session, err := auth.sessionStore.Get(r, sessionName)
+	require.NoError(t, err)
+	session.Values[sessionOAuthState] = state
+	require.NoError(t, session.Save(r, w))
+}
+
+func sessionCookies(t *testing.T, rec *httptest.ResponseRecorder) []*http.Cookie {
+	t.Helper()
+	return rec.Result().Cookies()
+}
+
+func TestLoadAuthConfig_EnvOverrides(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_ALLOWED_DOMAIN", "instawork.com")
+	t.Setenv("LLM_PROXY_ADMIN_OAUTH_REDIRECT_URL", "https://llm.example.com/admin/auth/callback")
+
+	cfg, err := loadAuthConfig("example.com", "cid", "csecret", "ssecret")
+	require.NoError(t, err)
+	assert.Equal(t, "instawork.com", cfg.allowedDomain)
+	assert.Equal(t, "https://llm.example.com/admin/auth/callback", cfg.redirectURL)
+	assert.Equal(t, "cid", cfg.clientID)
+}
+
+func TestIsAllowedUser(t *testing.T) {
+	auth := &authenticator{allowedDomain: "example.com"}
+	assert.True(t, auth.isAllowedUser("alice@example.com", ""))
+	assert.True(t, auth.isAllowedUser("bob@example.com", "example.com"))
+	assert.False(t, auth.isAllowedUser("alice@other.com", ""))
+	assert.True(t, auth.isAllowedUser("alice@other.com", "example.com"), "hd match wins over email domain")
+	assert.False(t, auth.isAllowedUser("alice@example.com", "other.com"))
+	assert.False(t, auth.isAllowedUser("not-an-email", ""))
+}
+
+func TestRandomState_UniqueAndNonEmpty(t *testing.T) {
+	a, err := randomState()
+	require.NoError(t, err)
+	b, err := randomState()
+	require.NoError(t, err)
+	assert.NotEmpty(t, a)
+	assert.NotEmpty(t, b)
+	assert.NotEqual(t, a, b)
+}
+
+func TestRedirectURL_FromRequest(t *testing.T) {
+	auth := &authenticator{}
+	req := httptest.NewRequest(http.MethodGet, "/admin/auth/login", nil)
+	req.Host = "llm.instawork.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	assert.Equal(t, "https://llm.instawork.com/admin/auth/callback", auth.redirectURL(req))
+}
+
+func TestRedirectURL_EnvWins(t *testing.T) {
+	auth := &authenticator{redirectURLEnv: "https://fixed.example/callback"}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.Equal(t, "https://fixed.example/callback", auth.redirectURL(req))
+}
+
+func TestHandleLogin_RedirectsWithState(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/auth/login", nil)
+	auth.handleLogin(rec, req)
+
+	require.Equal(t, http.StatusFound, rec.Code)
+	loc := rec.Header().Get("Location")
+	require.NotEmpty(t, loc)
+	u, err := url.Parse(loc)
+	require.NoError(t, err)
+	assert.Contains(t, u.String(), "/authorize")
+	assert.NotEmpty(t, u.Query().Get("state"))
+
+	cookies := sessionCookies(t, rec)
+	require.NotEmpty(t, cookies)
+}
+
+func TestHandleLogin_OAuthNotConfigured(t *testing.T) {
+	auth := &authenticator{logger: testLogger(), sessionStore: sessions.NewCookieStore([]byte("test-secret-at-least-32-bytes-long"))}
+	rec := httptest.NewRecorder()
+	auth.handleLogin(rec, httptest.NewRequest(http.MethodGet, "/admin/auth/login", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleCallback_HappyPath(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+	state := "test-oauth-state-12345"
+
+	loginRec := httptest.NewRecorder()
+	loginReq := httptest.NewRequest(http.MethodGet, "/admin/auth/login", nil)
+	saveOAuthStateSession(t, auth, loginRec, loginReq, state)
+
+	cbRec := httptest.NewRecorder()
+	cbReq := httptest.NewRequest(http.MethodGet, "/admin/auth/callback?state="+state+"&code=auth-code-xyz", nil)
+	for _, c := range sessionCookies(t, loginRec) {
+		cbReq.AddCookie(c)
+	}
+	auth.handleCallback(cbRec, cbReq)
+
+	require.Equal(t, http.StatusFound, cbRec.Code)
+	assert.Equal(t, "http://localhost:5173/admin/", cbRec.Header().Get("Location"))
+	assert.Equal(t, "auth-code-xyz", oidcSrv.lastCode)
+
+	meReq := httptest.NewRequest(http.MethodGet, "/admin/api/me", nil)
+	for _, c := range sessionCookies(t, cbRec) {
+		meReq.AddCookie(c)
+	}
+	user, err := auth.currentUser(meReq)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", user.Email)
+	assert.Equal(t, "Alice Example", user.Name)
+}
+
+func TestHandleCallback_InvalidState(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/auth/callback?state=wrong&code=abc", nil)
+	saveOAuthStateSession(t, auth, rec, req, "expected-state")
+	for _, c := range sessionCookies(t, rec) {
+		req.AddCookie(c)
+	}
+
+	cbRec := httptest.NewRecorder()
+	auth.handleCallback(cbRec, req)
+	assert.Equal(t, http.StatusBadRequest, cbRec.Code)
+}
+
+func TestHandleCallback_MissingCode(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+	state := "state-abc"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/auth/callback?state="+state, nil)
+	saveOAuthStateSession(t, auth, rec, req, state)
+	for _, c := range sessionCookies(t, rec) {
+		req.AddCookie(c)
+	}
+
+	cbRec := httptest.NewRecorder()
+	auth.handleCallback(cbRec, req)
+	assert.Equal(t, http.StatusBadRequest, cbRec.Code)
+}
+
+func TestHandleCallback_DomainRejected(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	oidcSrv.tokenClaims = idTokenClaims{
+		email:         "intruder@evil.com",
+		emailVerified: true,
+		hd:            "evil.com",
+	}
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+	state := "state-deny"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/auth/callback?state="+state+"&code=code", nil)
+	saveOAuthStateSession(t, auth, rec, req, state)
+	for _, c := range sessionCookies(t, rec) {
+		req.AddCookie(c)
+	}
+
+	cbRec := httptest.NewRecorder()
+	auth.handleCallback(cbRec, req)
+	assert.Equal(t, http.StatusForbidden, cbRec.Code)
+}
+
+func TestHandleCallback_EmailNotVerified(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	oidcSrv.tokenClaims = idTokenClaims{
+		email:         "alice@example.com",
+		emailVerified: false,
+		hd:            "example.com",
+	}
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+	state := "state-unverified"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/auth/callback?state="+state+"&code=code", nil)
+	saveOAuthStateSession(t, auth, rec, req, state)
+	for _, c := range sessionCookies(t, rec) {
+		req.AddCookie(c)
+	}
+
+	cbRec := httptest.NewRecorder()
+	auth.handleCallback(cbRec, req)
+	assert.Equal(t, http.StatusForbidden, cbRec.Code)
+}
+
+func TestHandleLogout_ClearsSession(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+
+	loginRec := httptest.NewRecorder()
+	loginReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	saveOAuthStateSession(t, auth, loginRec, loginReq, "s")
+	session, _ := auth.sessionStore.Get(loginReq, sessionName)
+	session.Values[sessionUserEmail] = "alice@example.com"
+	require.NoError(t, session.Save(loginReq, loginRec))
+
+	logoutRec := httptest.NewRecorder()
+	logoutReq := httptest.NewRequest(http.MethodPost, "/admin/auth/logout", nil)
+	for _, c := range sessionCookies(t, loginRec) {
+		logoutReq.AddCookie(c)
+	}
+	auth.handleLogout(logoutRec, logoutReq)
+	assert.Equal(t, http.StatusNoContent, logoutRec.Code)
+
+	afterReq := httptest.NewRequest(http.MethodGet, "/admin/api/me", nil)
+	for _, c := range sessionCookies(t, logoutRec) {
+		afterReq.AddCookie(c)
+	}
+	_, err := auth.currentUser(afterReq)
+	require.Error(t, err)
+}
+
+func TestRequireSession_BlocksUnauthenticated(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+
+	called := false
+	rec := httptest.NewRecorder()
+	auth.requireSession(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/api/keys", nil))
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireSession_AllowsAuthenticated(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	session, _ := auth.sessionStore.Get(req, sessionName)
+	session.Values[sessionUserEmail] = "alice@example.com"
+	require.NoError(t, session.Save(req, rec))
+
+	called := false
+	apiRec := httptest.NewRecorder()
+	apiReq := httptest.NewRequest(http.MethodGet, "/admin/api/keys", nil)
+	for _, c := range sessionCookies(t, rec) {
+		apiReq.AddCookie(c)
+	}
+	auth.requireSession(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})).ServeHTTP(apiRec, apiReq)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, apiRec.Code)
+}
+
+func TestNewAuthenticator_DevBypassWithoutGoogleOAuth(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
+	t.Setenv("LLM_PROXY_ADMIN_GOOGLE_CLIENT_ID", "")
+	t.Setenv("LLM_PROXY_ADMIN_GOOGLE_CLIENT_SECRET", "")
+
+	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
+		DevBypassLogin: true,
+		AllowedDomain:  "example.com",
+	})
+	require.NoError(t, err)
+	assert.Nil(t, auth.oauthConfig)
+	assert.True(t, auth.devBypass)
+}
+
+func TestHandleCallback_OAuthNotConfigured(t *testing.T) {
+	auth := &authenticator{logger: testLogger(), sessionStore: sessions.NewCookieStore([]byte("test-secret-at-least-32-bytes-long"))}
+	rec := httptest.NewRecorder()
+	auth.handleCallback(rec, httptest.NewRequest(http.MethodGet, "/admin/auth/callback?state=x&code=y", nil))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestNewAuthenticator_RequiresSessionSecretInProd(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "")
+	_, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
+		DevBypassLogin: false,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM_PROXY_ADMIN_SESSION_SECRET")
+}
+
+func TestSanitizeRedirect(t *testing.T) {
+	ok, target := sanitizeRedirect("http://localhost:5173/admin/", "http://localhost:5173")
+	assert.True(t, ok)
+	assert.Equal(t, "http://localhost:5173/admin/", target)
+
+	ok, _ = sanitizeRedirect("https://evil.com/admin/", "http://localhost:5173")
+	assert.False(t, ok)
+
+	ok, _ = sanitizeRedirect("not-a-url", "")
+	assert.False(t, ok)
+}
+
+func TestRegisterRoutes_OAuthLoginRoute(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
+	oidcSrv := newTestOIDCServer(t)
+
+	provider, err := oidc.NewProvider(context.Background(), oidcSrv.issuer)
+	require.NoError(t, err)
+
+	yamlCfg := config.GetDefaultYAMLConfig()
+	yamlCfg.Features.AdminDashboard.DevBypassLogin = false
+	t.Setenv("LLM_PROXY_ADMIN_GOOGLE_CLIENT_ID", testOAuthClientID)
+	t.Setenv("LLM_PROXY_ADMIN_GOOGLE_CLIENT_SECRET", "secret")
+	t.Cleanup(func() {
+		t.Setenv("LLM_PROXY_ADMIN_GOOGLE_CLIENT_ID", "")
+		t.Setenv("LLM_PROXY_ADMIN_GOOGLE_CLIENT_SECRET", "")
+	})
+
+	// newAuthenticator hits real Google — register routes manually with test auth.
+	auth := &authenticator{
+		oauthConfig: &oauth2.Config{
+			ClientID:     testOAuthClientID,
+			ClientSecret: "secret",
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  oidcSrv.issuer + "/authorize",
+				TokenURL: oidcSrv.issuer + "/token",
+			},
+			Scopes: []string{oidc.ScopeOpenID, "email", "profile"},
+		},
+		verifier:     provider.Verifier(&oidc.Config{ClientID: testOAuthClientID}),
+		sessionStore: sessions.NewCookieStore([]byte("test-secret-at-least-32-bytes-long")),
+		allowedDomain: "example.com",
+		logger:       testLogger(),
+	}
+
+	r := mux.NewRouter()
+	r.PathPrefix("/admin/auth").Subrouter().HandleFunc("/login", auth.handleLogin).Methods(http.MethodGet)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/auth/login", nil))
+	assert.Equal(t, http.StatusFound, rec.Code)
+}

--- a/internal/admin/auth_oauth_test.go
+++ b/internal/admin/auth_oauth_test.go
@@ -25,13 +25,13 @@ import (
 const testOAuthClientID = "test-oauth-client-id"
 
 type testOIDCServer struct {
-	t          *testing.T
-	server     *httptest.Server
-	issuer     string
-	privateKey *rsa.PrivateKey
-	kid        string
-	lastCode     string
-	tokenClaims  idTokenClaims
+	t           *testing.T
+	server      *httptest.Server
+	issuer      string
+	privateKey  *rsa.PrivateKey
+	kid         string
+	lastCode    string
+	tokenClaims idTokenClaims
 }
 
 func newTestOIDCServer(t *testing.T) *testOIDCServer {
@@ -159,11 +159,11 @@ func newTestOAuthAuthenticator(t *testing.T, oidcSrv *testOIDCServer, allowedDom
 			},
 			Scopes: []string{oidc.ScopeOpenID, "email", "profile"},
 		},
-		verifier:       provider.Verifier(&oidc.Config{ClientID: testOAuthClientID}),
-		sessionStore:   sessionStore,
-		allowedDomain:  allowedDomain,
+		verifier:          provider.Verifier(&oidc.Config{ClientID: testOAuthClientID}),
+		sessionStore:      sessionStore,
+		allowedDomain:     allowedDomain,
 		devFrontendOrigin: "http://localhost:5173",
-		logger:         testLogger(),
+		logger:            testLogger(),
 	}
 }
 
@@ -493,10 +493,10 @@ func TestRegisterRoutes_OAuthLoginRoute(t *testing.T) {
 			},
 			Scopes: []string{oidc.ScopeOpenID, "email", "profile"},
 		},
-		verifier:     provider.Verifier(&oidc.Config{ClientID: testOAuthClientID}),
-		sessionStore: sessions.NewCookieStore([]byte("test-secret-at-least-32-bytes-long")),
+		verifier:      provider.Verifier(&oidc.Config{ClientID: testOAuthClientID}),
+		sessionStore:  sessions.NewCookieStore([]byte("test-secret-at-least-32-bytes-long")),
 		allowedDomain: "example.com",
-		logger:       testLogger(),
+		logger:        testLogger(),
 	}
 
 	r := mux.NewRouter()

--- a/internal/admin/dashboard_handlers_test.go
+++ b/internal/admin/dashboard_handlers_test.go
@@ -1,0 +1,315 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/coststats"
+	"github.com/Instawork/llm-proxy/internal/pii"
+	"github.com/Instawork/llm-proxy/internal/ratelimit"
+	"github.com/Instawork/llm-proxy/internal/usagestats"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testDashboardHandler(t *testing.T) (*handler, *apikeys.Store) {
+	t.Helper()
+	h, store := testAdminHandler(t)
+
+	costRec := coststats.NewRecorder()
+	usageRec := usagestats.NewRecorder()
+	piiRec := pii.NewRecorder()
+	costRec.RecordRequest("openai", "iw:abc1234", "user-1", "gpt-4", 0.01, 0.005, 0.005, 100, 50)
+	usageRec.RecordRequest("openai", "gpt-4", "iw:abc1234", "user-1", 100, 50)
+	piiRec.RecordRedaction("openai", "iw:secret-key", nil, 0, time.Millisecond, pii.OutcomeOK)
+
+	h.deps.YAMLConfig.Features.PIIRedact.Enabled = true
+	h.deps.CostSummary = costRec.Snapshot
+	h.deps.UsageSummary = usageRec.Snapshot
+	h.deps.PIISummary = piiRec.Snapshot
+	h.deps.RateLimiter = ratelimit.NewMemoryLimiter(h.deps.YAMLConfig)
+	h.deps.HealthFunc = func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+	return h, store
+}
+
+func decodeJSONBody(t *testing.T, rec *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	return out
+}
+
+func TestHandleCost_WithStats(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleCost(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/cost", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	assert.Equal(t, true, body["enabled"])
+	stats, ok := body["stats"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, stats["available"])
+	assert.Greater(t, stats["requests_today"], float64(0))
+}
+
+func TestHandleCost_StatsUnavailableWithoutRecorder(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleCost(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/cost", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	stats := body["stats"].(map[string]interface{})
+	assert.Equal(t, false, stats["available"])
+}
+
+func TestHandleUsageAndPII_StatsUnavailable(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	for _, fn := range []func(http.ResponseWriter, *http.Request){
+		h.handleUsage,
+		h.handlePII,
+	} {
+		rec := httptest.NewRecorder()
+		fn(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/stats", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+		stats := decodeJSONBody(t, rec)["stats"].(map[string]interface{})
+		assert.Equal(t, false, stats["available"])
+	}
+}
+
+func TestHandleListKeys_StoreUnavailable(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	h.deps.APIKeyStore = nil
+	rec := httptest.NewRecorder()
+	h.handleListKeys(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/keys", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleConfig_Unavailable(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	h.deps.YAMLConfig = nil
+	rec := httptest.NewRecorder()
+	h.handleConfig(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/config", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleCost_ConfigUnavailable(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	h.deps.YAMLConfig = nil
+	rec := httptest.NewRecorder()
+	h.handleCost(rec, httptest.NewRequest(http.MethodGet, "/admin/api/cost", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleUsage_WithStats(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleUsage(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/usage", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	stats := body["stats"].(map[string]interface{})
+	assert.Equal(t, true, stats["available"])
+	assert.Equal(t, "cost_tracking", body["source"])
+}
+
+func TestHandlePII_WithStats(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handlePII(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/pii", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	stats := body["stats"].(map[string]interface{})
+	assert.Equal(t, true, stats["available"])
+	assert.Equal(t, true, body["enabled"])
+}
+
+func TestHandleConfig(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleConfig(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/config", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	features, ok := body["features"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, features, "rate_limiting")
+	providers, ok := body["providers"].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotEmpty(t, providers)
+}
+
+func TestHandleMe_Authenticated(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleMe(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/me", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	assert.NotEmpty(t, body["email"])
+}
+
+func TestHandleMe_Unauthorized(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleMe(rec, httptest.NewRequest(http.MethodGet, "/admin/api/me", nil))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandleHealth(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleHealth(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/health", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ok")
+}
+
+func TestHandleHealth_Unavailable(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleHealth(rec, httptest.NewRequest(http.MethodGet, "/admin/api/health", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleRateLimits_WithSnapshotAndRedactedOverrides(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	h.deps.YAMLConfig.Features.RateLimiting.Overrides.PerKey = map[string]config.LimitsConfig{
+		"iw:super-secret-key-12345": {RequestsPerMinute: 10},
+	}
+	h.deps.YAMLConfig.Features.RateLimiting.Overrides.PerUser = map[string]config.LimitsConfig{
+		"user@example.com": {TokensPerMinute: 5000},
+	}
+
+	rec := httptest.NewRecorder()
+	h.handleRateLimits(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/rate-limits", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp RateLimitsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "memory", resp.Backend)
+	require.NotNil(t, resp.Snapshot)
+	require.Contains(t, resp.Overrides.PerKey, "key:••••2345")
+	require.Contains(t, resp.Overrides.PerUser, "user:••••.com")
+}
+
+func TestHandleListKeys(t *testing.T) {
+	h, store := testDashboardHandler(t)
+	_, err := store.CreateKey(context.Background(), "openai", "sk-test", "desc", 0, nil, nil)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	h.handleListKeys(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/keys", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var keys []map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&keys))
+	require.Len(t, keys, 1)
+	assert.Equal(t, "openai", keys[0]["provider"])
+}
+
+func TestHandleGetKey(t *testing.T) {
+	h, store := testDashboardHandler(t)
+	key, err := store.CreateKey(context.Background(), "anthropic", "sk-ant", "k1", 0, nil, nil)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/keys/"+key.PK, nil)
+	req = mux.SetURLVars(req, map[string]string{"key": key.PK})
+	h.handleGetKey(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	assert.Equal(t, key.PK, body["key"])
+	assert.Equal(t, maskedActualKey, body["actual_key"])
+}
+
+func TestHandleGetKey_NotFound(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/keys/missing", nil)
+	missingKey := apikeys.KeyPrefix + "0000000000000000000000000000000000000000000000000000000000000000"
+	req = mux.SetURLVars(req, map[string]string{"key": missingKey})
+	h.handleGetKey(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleDeleteKey(t *testing.T) {
+	h, store := testDashboardHandler(t)
+	key, err := store.CreateKey(context.Background(), "openai", "sk-del", "del", 0, nil, nil)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := authenticatedRequest(t, h, http.MethodDelete, "/admin/api/keys/"+key.PK, nil)
+	req = mux.SetURLVars(req, map[string]string{"key": key.PK})
+	h.handleDeleteKey(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	_, err = store.GetKeyRecord(context.Background(), key.PK)
+	require.Error(t, err)
+}
+
+func TestCorsMiddleware_OptionsPreflight(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	h.deps.YAMLConfig.Features.AdminDashboard.DevCORSOrigin = "http://localhost:5173"
+
+	nextCalled := false
+	mw := h.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/admin/api/me", nil)
+	mw.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, nextCalled)
+	assert.Equal(t, "http://localhost:5173", rec.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestRegisterRoutes_ServesDashboardAPI(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
+
+	costRec := coststats.NewRecorder()
+	usageRec := usagestats.NewRecorder()
+	piiRec := pii.NewRecorder()
+
+	yamlCfg := config.GetDefaultYAMLConfig()
+	yamlCfg.Features.AdminDashboard.DevBypassLogin = true
+
+	r := mux.NewRouter()
+	RegisterRoutes(r, Deps{
+		Logger:       testLogger(),
+		YAMLConfig:   yamlCfg,
+		CostSummary:  costRec.Snapshot,
+		UsageSummary: usageRec.Snapshot,
+		PIISummary:   piiRec.Snapshot,
+		HealthFunc: func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		},
+	})
+
+	loginRec := httptest.NewRecorder()
+	loginBody, _ := json.Marshal(map[string]string{"redirect": "http://localhost:9002/admin/"})
+	loginReq := httptest.NewRequest(http.MethodPost, "/admin/auth/dev-login", bytes.NewReader(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(loginRec, loginReq)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	costHTTPRec := httptest.NewRecorder()
+	costReq := httptest.NewRequest(http.MethodGet, "/admin/api/cost", nil)
+	for _, c := range loginRec.Result().Cookies() {
+		costReq.AddCookie(c)
+	}
+	r.ServeHTTP(costHTTPRec, costReq)
+	require.Equal(t, http.StatusOK, costHTTPRec.Code)
+}

--- a/internal/admin/scope_redact_test.go
+++ b/internal/admin/scope_redact_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRedactScopeKey(t *testing.T) {
@@ -27,6 +29,33 @@ func TestRedactScopeKey(t *testing.T) {
 			assert.Equal(t, tc.want, RedactScopeKey(tc.in))
 		})
 	}
+}
+
+func TestSanitizeLimitsSnapshot_RedactsScopes(t *testing.T) {
+	snap := ratelimit.LimitsSnapshot{
+		Minute: &ratelimit.WindowSnapshot{
+			Counters: map[string]ratelimit.CounterSnapshot{
+				"key:iw:abcdefghijklmnop": {Requests: 2, Tokens: 10},
+				"global":                  {Requests: 1},
+			},
+		},
+	}
+	sanitizeLimitsSnapshot(&snap)
+	require.Contains(t, snap.Minute.Counters, "key:••••mnop")
+	require.Contains(t, snap.Minute.Counters, "global")
+}
+
+func TestSanitizeRateLimitOverrides_RedactsKeys(t *testing.T) {
+	out := sanitizeRateLimitOverrides(config.RateLimitOverrides{
+		PerKey: map[string]config.LimitsConfig{
+			"iw:long-secret-value": {RequestsPerMinute: 5},
+		},
+		PerUser: map[string]config.LimitsConfig{
+			"alice@example.com": {TokensPerDay: 1000},
+		},
+	})
+	require.Contains(t, out.PerKey, "key:••••alue")
+	require.Contains(t, out.PerUser, "user:••••.com")
 }
 
 func TestMergeRedactedCounters_CollapsesSameSuffix(t *testing.T) {

--- a/internal/adminrollup/aggregate.go
+++ b/internal/adminrollup/aggregate.go
@@ -136,9 +136,20 @@ func buildDimRows(h map[string]float64, fields []string) map[string]map[string]f
 	return out
 }
 
-func costDataFromAggregates(totals map[string]float64, byProvider, byKey map[string]float64) map[string]interface{} {
+func flattenCostByKey(h map[string]float64) map[string]float64 {
+	out := make(map[string]float64)
+	for k, v := range h {
+		member, field, ok := parseDimMemberField(k)
+		if !ok || field != "spend_usd" {
+			continue
+		}
+		out[member] = v
+	}
+	return out
+}
+
+func costDataFromAggregates(totals map[string]float64, byProvider, byKey map[string]float64, caps TopNCaps) map[string]interface{} {
 	provRows := buildDimRows(byProvider, nil)
-	keyRows := buildDimRows(byKey, nil)
 
 	byProviderOut := make([]map[string]interface{}, 0, len(provRows))
 	for name, fields := range provRows {
@@ -154,13 +165,26 @@ func costDataFromAggregates(totals map[string]float64, byProvider, byKey map[str
 		return a > b
 	})
 
-	byKeyOut := make([]map[string]interface{}, 0, len(keyRows))
-	for keyID, fields := range keyRows {
-		row := map[string]interface{}{"key_id": keyID}
-		for f, v := range fields {
-			row[f] = v
+	keyRows := buildDimRows(byKey, nil)
+	topKeys, otherSpend := topNWithOther(flattenCostByKey(byKey), caps.ByKey)
+	byKeyOut := make([]map[string]interface{}, 0, len(topKeys)+1)
+	for _, p := range topKeys {
+		fields := keyRows[p.Name]
+		row := map[string]interface{}{"key_id": p.Name}
+		if fields != nil {
+			for f, v := range fields {
+				row[f] = v
+			}
+		} else {
+			row["spend_usd"] = p.Val
 		}
 		byKeyOut = append(byKeyOut, row)
+	}
+	if otherSpend > 0 {
+		byKeyOut = append(byKeyOut, map[string]interface{}{
+			"key_id":    "other_key",
+			"spend_usd": otherSpend,
+		})
 	}
 
 	data := map[string]interface{}{

--- a/internal/adminrollup/aggregate.go
+++ b/internal/adminrollup/aggregate.go
@@ -1,0 +1,292 @@
+package adminrollup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+func todayBase(metric, day string) string {
+	return fmt.Sprintf("%s%s:today:%s", keyPrefix, metric, day)
+}
+
+func totalsKey(metric, day string) string {
+	return todayBase(metric, day) + ":totals"
+}
+
+func dimKey(metric, day, dim string) string {
+	return todayBase(metric, day) + ":" + dim
+}
+
+var rollupApplyScript = redis.NewScript(`
+local base = KEYS[1]
+local ttl = tonumber(ARGV[1])
+local totals = cjson.decode(ARGV[2])
+local dims = cjson.decode(ARGV[3])
+
+local totalsKey = base .. ":totals"
+for field, delta in pairs(totals) do
+  redis.call("HINCRBYFLOAT", totalsKey, field, delta)
+end
+if next(totals) ~= nil then
+  redis.call("EXPIRE", totalsKey, ttl)
+end
+
+for dim, members in pairs(dims) do
+  local dimKey = base .. ":" .. dim
+  for member, delta in pairs(members) do
+    redis.call("HINCRBYFLOAT", dimKey, member, delta)
+  end
+  if next(members) ~= nil then
+    redis.call("EXPIRE", dimKey, ttl)
+  end
+end
+return 1
+`)
+
+func applyDeltaRedis(ctx context.Context, rdb *redis.Client, metric, day string, d Delta, ttl time.Duration) error {
+	if d.empty() {
+		return nil
+	}
+	totalsJSON, err := json.Marshal(d.Totals)
+	if err != nil {
+		return err
+	}
+	dimsJSON, err := json.Marshal(d.Dimensions)
+	if err != nil {
+		return err
+	}
+	sec := int(ttl.Seconds())
+	if sec <= 0 {
+		sec = int(todayTTL.Seconds())
+	}
+	return rollupApplyScript.Run(ctx, rdb, []string{todayBase(metric, day)}, sec, string(totalsJSON), string(dimsJSON)).Err()
+}
+
+func hgetallFloat(m map[string]string) map[string]float64 {
+	out := make(map[string]float64, len(m))
+	for k, v := range m {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			out[k] = f
+		}
+	}
+	return out
+}
+
+type nameVal struct {
+	Name string  `json:"name"`
+	Val  float64 `json:"count"`
+}
+
+func topNWithOther(h map[string]float64, n int) (top []nameVal, other float64) {
+	pairs := make([]nameVal, 0, len(h))
+	for k, v := range h {
+		pairs = append(pairs, nameVal{Name: k, Val: v})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].Val != pairs[j].Val {
+			return pairs[i].Val > pairs[j].Val
+		}
+		return pairs[i].Name < pairs[j].Name
+	})
+	if n <= 0 || len(pairs) <= n {
+		return pairs, 0
+	}
+	for _, p := range pairs[n:] {
+		other += p.Val
+	}
+	return pairs[:n], other
+}
+
+// DimMemberField builds a hash field key for multi-metric dimension members.
+func DimMemberField(member, field string) string {
+	return member + "|" + field
+}
+
+func dimMemberField(member, field string) string {
+	return DimMemberField(member, field)
+}
+
+func parseDimMemberField(key string) (member, field string, ok bool) {
+	for i := 0; i < len(key); i++ {
+		if key[i] == '|' {
+			return key[:i], key[i+1:], true
+		}
+	}
+	return "", "", false
+}
+
+func buildDimRows(h map[string]float64, fields []string) map[string]map[string]float64 {
+	out := make(map[string]map[string]float64)
+	for k, v := range h {
+		member, field, ok := parseDimMemberField(k)
+		if !ok {
+			continue
+		}
+		if out[member] == nil {
+			out[member] = make(map[string]float64)
+		}
+		out[member][field] = v
+	}
+	return out
+}
+
+func costDataFromAggregates(totals map[string]float64, byProvider, byKey map[string]float64) map[string]interface{} {
+	provRows := buildDimRows(byProvider, nil)
+	keyRows := buildDimRows(byKey, nil)
+
+	byProviderOut := make([]map[string]interface{}, 0, len(provRows))
+	for name, fields := range provRows {
+		row := map[string]interface{}{"name": name}
+		for f, v := range fields {
+			row[f] = v
+		}
+		byProviderOut = append(byProviderOut, row)
+	}
+	sort.Slice(byProviderOut, func(i, j int) bool {
+		a, _ := byProviderOut[i]["spend_usd"].(float64)
+		b, _ := byProviderOut[j]["spend_usd"].(float64)
+		return a > b
+	})
+
+	byKeyOut := make([]map[string]interface{}, 0, len(keyRows))
+	for keyID, fields := range keyRows {
+		row := map[string]interface{}{"key_id": keyID}
+		for f, v := range fields {
+			row[f] = v
+		}
+		byKeyOut = append(byKeyOut, row)
+	}
+
+	data := map[string]interface{}{
+		"spend_today_usd":        totals["spend_usd"],
+		"input_spend_today_usd":  totals["input_spend_usd"],
+		"output_spend_today_usd": totals["output_spend_usd"],
+		"requests_today":         int64(totals["requests"]),
+		"input_tokens_today":     int64(totals["input_tokens"]),
+		"output_tokens_today":    int64(totals["output_tokens"]),
+		"by_provider":            byProviderOut,
+		"by_key":                 byKeyOut,
+	}
+	return data
+}
+
+func usageDataFromAggregates(totals map[string]float64, byModel, byProvider, byKey, byUser map[string]float64, caps TopNCaps) map[string]interface{} {
+	data := map[string]interface{}{
+		"requests_today": int64(totals["requests"]),
+		"tokens_today":   int64(totals["tokens"]),
+	}
+	if len(byModel) > 0 {
+		data["by_model"] = scopeMapFromDim(byModel)
+	}
+	if len(byProvider) > 0 {
+		data["by_provider"] = scopeMapFromDim(byProvider)
+	}
+	if len(byKey) > 0 {
+		top, other := topNWithOther(flattenScopeDim(byKey), caps.ByKey)
+		data["by_key"] = scopeMapFromNames(top, other, "key")
+	}
+	if len(byUser) > 0 {
+		top, other := topNWithOther(flattenScopeDim(byUser), caps.ByUser)
+		data["by_user"] = scopeMapFromNames(top, other, "user")
+	}
+	return data
+}
+
+func flattenScopeDim(h map[string]float64) map[string]float64 {
+	out := make(map[string]float64)
+	for k, v := range h {
+		member, field, ok := parseDimMemberField(k)
+		if !ok || field != "tokens" {
+			continue
+		}
+		out[member] = v
+	}
+	return out
+}
+
+func scopeMapFromDim(h map[string]float64) map[string]map[string]float64 {
+	rows := buildDimRows(h, nil)
+	out := make(map[string]map[string]float64, len(rows))
+	for member, fields := range rows {
+		m := make(map[string]float64, len(fields))
+		for f, v := range fields {
+			m[f] = v
+		}
+		out[member] = m
+	}
+	return out
+}
+
+func scopeMapFromNames(top []nameVal, other float64, kind string) map[string]map[string]float64 {
+	out := make(map[string]map[string]float64, len(top)+1)
+	for _, p := range top {
+		out[p.Name] = map[string]float64{"tokens": p.Val}
+	}
+	if other > 0 {
+		out["other_"+kind] = map[string]float64{"tokens": other}
+	}
+	return out
+}
+
+func piiDataFromAggregates(totals map[string]float64, byEntity, byProvider, byKey map[string]float64, caps TopNCaps) map[string]interface{} {
+	scanned := totals["requests_scanned"]
+	withPII := totals["requests_with_pii"]
+	failOpen := totals["fail_open"]
+	failClosed := totals["fail_closed"]
+	oversize := totals["oversize"]
+	clean := scanned - failOpen - failClosed - oversize
+	var rate float64
+	if clean > 0 {
+		rate = withPII / clean
+	}
+
+	byEntityOut := make([]nameVal, 0, len(byEntity))
+	for k, v := range byEntity {
+		byEntityOut = append(byEntityOut, nameVal{Name: k, Val: v})
+	}
+	sort.Slice(byEntityOut, func(i, j int) bool {
+		return byEntityOut[i].Val > byEntityOut[j].Val
+	})
+
+	byProvOut := make([]nameVal, 0, len(byProvider))
+	for k, v := range byProvider {
+		byProvOut = append(byProvOut, nameVal{Name: k, Val: v})
+	}
+	sort.Slice(byProvOut, func(i, j int) bool {
+		return byProvOut[i].Val > byProvOut[j].Val
+	})
+
+	topKeys, otherKeys := topNWithOther(byKey, caps.ByKey)
+	topKeysOut := make([]nameVal, len(topKeys))
+	copy(topKeysOut, topKeys)
+	if otherKeys > 0 {
+		topKeysOut = append(topKeysOut, nameVal{Name: "other_key", Val: otherKeys})
+	}
+
+	return map[string]interface{}{
+		"requests_scanned":  int64(scanned),
+		"requests_with_pii": int64(withPII),
+		"entities_total":    int64(totals["entities_total"]),
+		"detection_rate":    rate,
+		"fail_open":         int64(failOpen),
+		"fail_closed":       int64(failClosed),
+		"oversize":          int64(oversize),
+		"by_entity":         kvFromNameVals(byEntityOut),
+		"by_provider":       kvFromNameVals(byProvOut),
+		"top_keys":          kvFromNameVals(topKeysOut),
+	}
+}
+
+func kvFromNameVals(vals []nameVal) []map[string]interface{} {
+	out := make([]map[string]interface{}, len(vals))
+	for i, v := range vals {
+		out[i] = map[string]interface{}{"name": v.Name, "count": int64(v.Val)}
+	}
+	return out
+}

--- a/internal/adminrollup/aggregate_test.go
+++ b/internal/adminrollup/aggregate_test.go
@@ -67,8 +67,8 @@ func TestMergeTodayUsageAggregates(t *testing.T) {
 		Totals: map[string]float64{"requests": 10, "tokens": 1000},
 		Dimensions: map[string]map[string]float64{
 			"by_model": {
-				DimMemberField("gpt-4", "requests"): 6,
-				DimMemberField("gpt-4", "tokens"):   600,
+				DimMemberField("gpt-4", "requests"):  6,
+				DimMemberField("gpt-4", "tokens"):    600,
 				DimMemberField("claude", "requests"): 4,
 				DimMemberField("claude", "tokens"):   400,
 			},

--- a/internal/adminrollup/aggregate_test.go
+++ b/internal/adminrollup/aggregate_test.go
@@ -1,0 +1,243 @@
+package adminrollup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopNWithOther(t *testing.T) {
+	t.Run("uncapped returns all sorted by value", func(t *testing.T) {
+		top, other := topNWithOther(map[string]float64{
+			"b": 10,
+			"a": 20,
+			"c": 5,
+		}, 0)
+		require.InDelta(t, 0, other, 0.001)
+		require.Len(t, top, 3)
+		require.Equal(t, "a", top[0].Name)
+		require.InDelta(t, 20, top[0].Val, 0.001)
+		require.Equal(t, "b", top[1].Name)
+		require.Equal(t, "c", top[2].Name)
+	})
+
+	t.Run("caps with other bucket", func(t *testing.T) {
+		top, other := topNWithOther(map[string]float64{
+			"high":   100,
+			"mid":    50,
+			"low":    10,
+			"tiny":   1,
+			"smidge": 1,
+		}, 2)
+		require.Len(t, top, 2)
+		require.Equal(t, "high", top[0].Name)
+		require.Equal(t, "mid", top[1].Name)
+		require.InDelta(t, 12, other, 0.001) // low + tiny + smidge
+	})
+
+	t.Run("tie breaks by name", func(t *testing.T) {
+		top, other := topNWithOther(map[string]float64{
+			"z-key": 5,
+			"a-key": 5,
+		}, 0)
+		require.InDelta(t, 0, other, 0.001)
+		require.Equal(t, "a-key", top[0].Name)
+		require.Equal(t, "z-key", top[1].Name)
+	})
+}
+
+func TestDimMemberFieldRoundTrip(t *testing.T) {
+	key := DimMemberField("gpt-4", "tokens")
+	member, field, ok := parseDimMemberField(key)
+	require.True(t, ok)
+	require.Equal(t, "gpt-4", member)
+	require.Equal(t, "tokens", field)
+}
+
+func TestMergeTodayUsageAggregates(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := "2026-06-12"
+	caps := TopNCaps{ByKey: 2, ByUser: 2}
+
+	p := NewPersister(store, MetricUsage)
+	p.QueueDelta(day, Delta{
+		Totals: map[string]float64{"requests": 10, "tokens": 1000},
+		Dimensions: map[string]map[string]float64{
+			"by_model": {
+				DimMemberField("gpt-4", "requests"): 6,
+				DimMemberField("gpt-4", "tokens"):   600,
+				DimMemberField("claude", "requests"): 4,
+				DimMemberField("claude", "tokens"):   400,
+			},
+			"by_key": {
+				DimMemberField("key-a", "tokens"): 500,
+				DimMemberField("key-b", "tokens"): 300,
+				DimMemberField("key-c", "tokens"): 200,
+			},
+			"by_user": {
+				DimMemberField("user-1", "tokens"): 700,
+				DimMemberField("user-2", "tokens"): 200,
+				DimMemberField("user-3", "tokens"): 100,
+			},
+		},
+	})
+	p.FlushNow()
+
+	snap := map[string]interface{}{"available": true}
+	store.MergeToday(ctx, MetricUsage, day, snap, caps)
+
+	require.Equal(t, int64(10), snap["requests_today"])
+	require.Equal(t, int64(1000), snap["tokens_today"])
+
+	byModel, ok := snap["by_model"].(map[string]map[string]float64)
+	require.True(t, ok)
+	require.InDelta(t, 600, byModel["gpt-4"]["tokens"], 0.001)
+	require.InDelta(t, 400, byModel["claude"]["tokens"], 0.001)
+
+	byKey, ok := snap["by_key"].(map[string]map[string]float64)
+	require.True(t, ok)
+	require.InDelta(t, 500, byKey["key-a"]["tokens"], 0.001)
+	require.InDelta(t, 300, byKey["key-b"]["tokens"], 0.001)
+	require.InDelta(t, 200, byKey["other_key"]["tokens"], 0.001)
+	require.NotContains(t, byKey, "key-c")
+
+	byUser, ok := snap["by_user"].(map[string]map[string]float64)
+	require.True(t, ok)
+	require.InDelta(t, 700, byUser["user-1"]["tokens"], 0.001)
+	require.InDelta(t, 200, byUser["user-2"]["tokens"], 0.001)
+	require.InDelta(t, 100, byUser["other_user"]["tokens"], 0.001)
+}
+
+func TestMergeTodayPIIAggregates(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := "2026-06-12"
+	caps := TopNCaps{ByKey: 2}
+
+	p := NewPersister(store, MetricPII)
+	p.QueueDelta(day, Delta{
+		Totals: map[string]float64{
+			"requests_scanned":  100,
+			"requests_with_pii": 25,
+			"entities_total":    40,
+			"fail_open":         5,
+			"fail_closed":       3,
+			"oversize":          2,
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_entity": {
+				"EMAIL_ADDRESS": 20,
+				"US_SSN":        15,
+			},
+			"by_provider": {
+				"openai": 18,
+				"gemini": 7,
+			},
+			"by_key": {
+				"key-a": 30,
+				"key-b": 20,
+				"key-c": 10,
+			},
+		},
+	})
+	p.FlushNow()
+
+	snap := map[string]interface{}{"available": true}
+	store.MergeToday(ctx, MetricPII, day, snap, caps)
+
+	require.Equal(t, int64(100), snap["requests_scanned"])
+	require.Equal(t, int64(25), snap["requests_with_pii"])
+	require.Equal(t, int64(40), snap["entities_total"])
+	// clean = 100 - 5 - 3 - 2 = 90; rate = 25/90
+	require.InDelta(t, 25.0/90.0, snap["detection_rate"].(float64), 0.001)
+
+	byEntity, ok := snap["by_entity"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, byEntity, 2)
+	require.Equal(t, "EMAIL_ADDRESS", byEntity[0]["name"])
+	require.Equal(t, int64(20), byEntity[0]["count"])
+
+	topKeys, ok := snap["top_keys"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, topKeys, 3) // top 2 + other_key bucket
+	names := []string{
+		topKeys[0]["name"].(string),
+		topKeys[1]["name"].(string),
+		topKeys[2]["name"].(string),
+	}
+	require.Contains(t, names, "key-a")
+	require.Contains(t, names, "key-b")
+	require.Contains(t, names, "other_key")
+}
+
+func TestMemoryBackendApplyDeltaMergeToday(t *testing.T) {
+	store, err := NewStore(Config{
+		Enabled:       true,
+		Backend:       BackendMemory,
+		RetentionDays: 7,
+		HistoryDays:   3,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	day := "2026-06-12"
+	require.NoError(t, store.ApplyDelta(ctx, MetricCost, day, Delta{
+		Totals: map[string]float64{"spend_usd": 4.2, "requests": 9},
+	}))
+
+	snap := map[string]interface{}{}
+	store.MergeToday(ctx, MetricCost, day, snap, TopNCaps{ByKey: 100})
+	require.InDelta(t, 4.2, snap["spend_today_usd"].(float64), 0.001)
+	require.Equal(t, int64(9), snap["requests_today"])
+}
+
+func TestArchiveDailyFromAggregates(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+	caps := TopNCaps{ByKey: 100}
+
+	p := NewPersister(store, MetricUsage)
+	p.QueueDelta(day, Delta{
+		Totals: map[string]float64{"requests": 5, "tokens": 500},
+	})
+	p.FlushNow()
+
+	require.NoError(t, store.ArchiveDailyFromAggregates(ctx, MetricUsage, day, caps))
+
+	history, err := store.LoadHistory(ctx, MetricUsage)
+	require.NoError(t, err)
+	var archived map[string]interface{}
+	for _, row := range history {
+		if row.Day == day {
+			archived = row.Data
+			break
+		}
+	}
+	require.NotNil(t, archived)
+	require.InDelta(t, 5, archived["requests_today"], 0.001)
+	require.InDelta(t, 500, archived["tokens_today"], 0.001)
+
+	totals, err := store.loadHash(ctx, totalsKey(MetricUsage, day))
+	require.NoError(t, err)
+	require.Empty(t, totals, "today hash keys should be removed after archive")
+}
+
+func TestTryElectArchiverMemoryBackend(t *testing.T) {
+	store, err := NewStore(Config{
+		Enabled:       true,
+		Backend:       BackendMemory,
+		RetentionDays: 7,
+		HistoryDays:   3,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	require.True(t, store.TryElectArchiver(ctx, MetricCost, "2026-06-12", "instance-a"))
+	require.False(t, store.TryElectArchiver(ctx, MetricCost, "2026-06-12", "instance-b"))
+}

--- a/internal/adminrollup/aggregate_test.go
+++ b/internal/adminrollup/aggregate_test.go
@@ -227,6 +227,76 @@ func TestArchiveDailyFromAggregates(t *testing.T) {
 	require.Empty(t, totals, "today hash keys should be removed after archive")
 }
 
+func TestMergeTodayCostWithByKey(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+
+	p := NewPersister(store, MetricCost)
+	p.QueueDelta(day, Delta{
+		Totals: map[string]float64{
+			"spend_usd": 2.0,
+			"requests":  1,
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_key": {
+				DimMemberField("iw:abc", "spend_usd"): 2.0,
+				DimMemberField("iw:abc", "requests"):  1,
+			},
+			"by_provider": {
+				DimMemberField("openai", "spend_usd"): 2.0,
+				DimMemberField("openai", "requests"):  1,
+			},
+		},
+	})
+	p.FlushNow()
+
+	snap := map[string]interface{}{}
+	store.MergeToday(ctx, MetricCost, day, snap, TopNCaps{ByKey: 100})
+	byKey, ok := snap["by_key"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, byKey, 1)
+	require.Equal(t, "iw:abc", byKey[0]["key_id"])
+}
+
+func TestParseDimMemberFieldInvalid(t *testing.T) {
+	_, _, ok := parseDimMemberField("no-separator")
+	require.False(t, ok)
+}
+
+func TestFlattenScopeDimSkipsNonTokenFields(t *testing.T) {
+	out := flattenScopeDim(map[string]float64{
+		"scope|requests": 5,
+		"scope|tokens":   99,
+		"plain":          1,
+	})
+	require.Len(t, out, 1)
+	require.InDelta(t, 99, out["scope"], 0.001)
+}
+
+func TestUsageMergeTodayIncludesByProvider(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+
+	p := NewPersister(store, MetricUsage)
+	p.QueueDelta(day, Delta{
+		Totals: map[string]float64{"requests": 1, "tokens": 10},
+		Dimensions: map[string]map[string]float64{
+			"by_provider": {
+				DimMemberField("anthropic", "tokens"): 10,
+			},
+		},
+	})
+	p.FlushNow()
+
+	snap := map[string]interface{}{}
+	store.MergeToday(ctx, MetricUsage, day, snap, TopNCaps{})
+	byProv, ok := snap["by_provider"].(map[string]map[string]float64)
+	require.True(t, ok)
+	require.InDelta(t, 10, byProv["anthropic"]["tokens"], 0.001)
+}
+
 func TestTryElectArchiverMemoryBackend(t *testing.T) {
 	store, err := NewStore(Config{
 		Enabled:       true,

--- a/internal/adminrollup/backend.go
+++ b/internal/adminrollup/backend.go
@@ -27,6 +27,9 @@ type backend interface {
 	// mget returns one entry per requested key, in order; a nil entry means
 	// the key is absent (or expired).
 	mget(ctx context.Context, keys []string) ([]*string, error)
+	applyDelta(ctx context.Context, metric, day string, d Delta, ttl time.Duration) error
+	hgetall(ctx context.Context, key string) (map[string]float64, error)
+	trySetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error)
 	close() error
 	kind() string
 }
@@ -75,6 +78,22 @@ func (b *redisBackend) del(ctx context.Context, key string) error {
 	return b.rdb.Del(ctx, key).Err()
 }
 
+func (b *redisBackend) applyDelta(ctx context.Context, metric, day string, d Delta, ttl time.Duration) error {
+	return applyDeltaRedis(ctx, b.rdb, metric, day, d, ttl)
+}
+
+func (b *redisBackend) hgetall(ctx context.Context, key string) (map[string]float64, error) {
+	m, err := b.rdb.HGetAll(ctx, key).Result()
+	if err != nil {
+		return nil, err
+	}
+	return hgetallFloat(m), nil
+}
+
+func (b *redisBackend) trySetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	return b.rdb.SetNX(ctx, key, value, ttl).Result()
+}
+
 func (b *redisBackend) mget(ctx context.Context, keys []string) ([]*string, error) {
 	if len(keys) == 0 {
 		return nil, nil
@@ -103,16 +122,78 @@ type memEntry struct {
 	expiresAt time.Time // zero == no expiry
 }
 
+type memHash map[string]float64
+
 // memoryBackend is a process-local store with lazy TTL expiry. It gives local
 // dev and tests the full rollup feature (daily_history) without a running
 // Redis; it intentionally does not survive process restarts.
 type memoryBackend struct {
 	mu   sync.Mutex
 	data map[string]memEntry
+	hash map[string]memHash
 }
 
 func newMemoryBackend() *memoryBackend {
-	return &memoryBackend{data: make(map[string]memEntry)}
+	return &memoryBackend{
+		data: make(map[string]memEntry),
+		hash: make(map[string]memHash),
+	}
+}
+
+func (b *memoryBackend) applyDelta(_ context.Context, metric, day string, d Delta, ttl time.Duration) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	exp := time.Time{}
+	if ttl > 0 {
+		exp = time.Now().Add(ttl)
+	}
+	applyToHash := func(key string, fields map[string]float64) {
+		if len(fields) == 0 {
+			return
+		}
+		h := b.hash[key]
+		if h == nil {
+			h = make(memHash)
+			b.hash[key] = h
+		}
+		for f, v := range fields {
+			h[f] += v
+		}
+		b.data[key] = memEntry{value: "hash", expiresAt: exp}
+	}
+	applyToHash(totalsKey(metric, day), d.Totals)
+	for dim, members := range d.Dimensions {
+		applyToHash(dimKey(metric, day, dim), members)
+	}
+	return nil
+}
+
+func (b *memoryBackend) hgetall(_ context.Context, key string) (map[string]float64, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	h := b.hash[key]
+	if h == nil {
+		return nil, nil
+	}
+	out := make(map[string]float64, len(h))
+	for k, v := range h {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (b *memoryBackend) trySetNX(_ context.Context, key, value string, ttl time.Duration) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.data[key]; ok {
+		return false, nil
+	}
+	entry := memEntry{value: value}
+	if ttl > 0 {
+		entry.expiresAt = time.Now().Add(ttl)
+	}
+	b.data[key] = entry
+	return true, nil
 }
 
 func (b *memoryBackend) set(_ context.Context, key string, value []byte, ttl time.Duration) error {

--- a/internal/adminrollup/backend_test.go
+++ b/internal/adminrollup/backend_test.go
@@ -1,0 +1,33 @@
+package adminrollup
+
+import (
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBackendErrors(t *testing.T) {
+	_, err := newBackend(Config{Backend: "bogus"})
+	require.Error(t, err)
+
+	_, err = newBackend(Config{Backend: BackendRedis})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "redis config is missing")
+}
+
+func TestNewBackendInfersMemoryWhenNoRedis(t *testing.T) {
+	be, err := newBackend(Config{Enabled: true})
+	require.NoError(t, err)
+	require.Equal(t, BackendMemory, be.kind())
+}
+
+func TestNewBackendInfersRedisFromAddress(t *testing.T) {
+	// No live Redis required: invalid address fails at ping, not at selection.
+	_, err := newBackend(Config{
+		Backend: "",
+		Redis:   &config.RedisConfig{Address: "127.0.0.1:1", DBSet: true},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "redis ping")
+}

--- a/internal/adminrollup/binding.go
+++ b/internal/adminrollup/binding.go
@@ -10,6 +10,12 @@ import (
 // a slow rollup store can never stall an admin API request.
 const mergeHistoryTimeout = 2 * time.Second
 
+// archiveTimeout bounds the Redis read+write+delete done when archiving a
+// completed UTC day's hash aggregates. It is larger than mergeHistoryTimeout
+// because the archive does more work (build today data, write the daily JSON,
+// delete the per-dimension hashes) and runs off the request path on rollover.
+const archiveTimeout = 5 * time.Second
+
 // RecorderBinding is an embeddable helper that gives metric recorders
 // (coststats, usagestats, pii) the shared Redis rollup lifecycle: attach a
 // store/persister once at startup, queue today's snapshot, archive a completed
@@ -71,9 +77,33 @@ func (b *RecorderBinding) ArchiveDayFromAggregates(metric, day string, caps TopN
 	if s == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), mergeHistoryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), archiveTimeout)
 	defer cancel()
-	_ = s.ArchiveDailyFromAggregates(ctx, metric, day, caps)
+	if err := s.ArchiveDailyFromAggregates(ctx, metric, day, caps); err != nil {
+		s.logger.Warn("admin rollup: archive from aggregates failed", "metric", metric, "day", day, "error", err)
+	}
+}
+
+// ArchiveDayFromAggregatesElected archives hash-backed today data, but only the
+// instance that wins the per-day archiver election performs the archive+delete.
+// This prevents multiple sidecars from racing the same archive (and the
+// delete-then-recreate hazard where one writer removes today's hashes while
+// another is still flushing a debounced delta into them). Callers should still
+// FlushRollup() first so their own pending deltas land before the winner
+// snapshots the completed day. No-op if unbound.
+func (b *RecorderBinding) ArchiveDayFromAggregatesElected(metric, day string, caps TopNCaps) {
+	s, _ := b.deps()
+	if s == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), archiveTimeout)
+	defer cancel()
+	if !s.TryElectArchiver(ctx, metric, day, archiverHolderID()) {
+		return
+	}
+	if err := s.ArchiveDailyFromAggregates(ctx, metric, day, caps); err != nil {
+		s.logger.Warn("admin rollup: elected archive failed", "metric", metric, "day", day, "error", err)
+	}
 }
 
 // MergeToday overlays fleet-wide today totals from Redis (no-op if unbound).

--- a/internal/adminrollup/binding.go
+++ b/internal/adminrollup/binding.go
@@ -50,12 +50,41 @@ func (b *RecorderBinding) QueueToday(day string, data map[string]interface{}) {
 	}
 }
 
+// QueueDelta schedules a debounced atomic merge of today's delta (no-op if unbound).
+func (b *RecorderBinding) QueueDelta(day string, d Delta) {
+	if _, p := b.deps(); p != nil {
+		p.QueueDelta(day, d)
+	}
+}
+
 // ArchiveDay writes a completed day's data to the daily key immediately
 // (no-op if unbound). Used on UTC day rollover.
 func (b *RecorderBinding) ArchiveDay(day string, data map[string]interface{}) {
 	if _, p := b.deps(); p != nil {
 		p.ArchiveImmediately(day, data)
 	}
+}
+
+// ArchiveDayFromAggregates archives hash-backed today data (no-op if unbound).
+func (b *RecorderBinding) ArchiveDayFromAggregates(metric, day string, caps TopNCaps) {
+	s, _ := b.deps()
+	if s == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), mergeHistoryTimeout)
+	defer cancel()
+	_ = s.ArchiveDailyFromAggregates(ctx, metric, day, caps)
+}
+
+// MergeToday overlays fleet-wide today totals from Redis (no-op if unbound).
+func (b *RecorderBinding) MergeToday(metric, day string, snap map[string]interface{}, caps TopNCaps) {
+	s, _ := b.deps()
+	if s == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), mergeHistoryTimeout)
+	defer cancel()
+	s.MergeToday(ctx, metric, day, snap, caps)
 }
 
 // MergeHistory folds persisted daily history into a live snapshot under a

--- a/internal/adminrollup/binding_test.go
+++ b/internal/adminrollup/binding_test.go
@@ -51,7 +51,7 @@ func TestRecorderBindingArchiveAndMergeHistory(t *testing.T) {
 	require.Equal(t, "2026-06-10", rows[0]["day"])
 }
 
-func TestRecorderBindingQueueTodayFlush(t *testing.T) {
+func TestRecorderBindingQueueDeltaFlush(t *testing.T) {
 	mr, err := miniredis.Run()
 	require.NoError(t, err)
 	t.Cleanup(mr.Close)
@@ -69,14 +69,12 @@ func TestRecorderBindingQueueTodayFlush(t *testing.T) {
 	var b RecorderBinding
 	b.BindRollup(store, persister)
 
-	// QueueToday is debounced; FlushRollup forces the pending write out now.
-	b.QueueToday("2026-06-11", map[string]interface{}{
-		"requests_today": int64(3),
-		"tokens_today":   int64(300),
+	// QueueDelta is debounced; FlushRollup forces the pending write out now.
+	b.QueueDelta("2026-06-11", Delta{
+		Totals: map[string]float64{"requests": 3, "tokens": 300},
 	})
 	b.FlushRollup()
 
-	// The debounced "today" key should now exist in Redis.
-	require.True(t, mr.DB(6).Exists(todayKey(MetricUsage, "2026-06-11")),
-		"FlushRollup should have persisted the pending today key")
+	require.True(t, mr.DB(6).Exists(totalsKey(MetricUsage, "2026-06-11")),
+		"FlushRollup should have persisted hash-backed today totals")
 }

--- a/internal/adminrollup/binding_test.go
+++ b/internal/adminrollup/binding_test.go
@@ -1,7 +1,9 @@
 package adminrollup
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/alicebob/miniredis/v2"
@@ -77,4 +79,32 @@ func TestRecorderBindingQueueDeltaFlush(t *testing.T) {
 
 	require.True(t, mr.DB(6).Exists(totalsKey(MetricUsage, "2026-06-11")),
 		"FlushRollup should have persisted hash-backed today totals")
+}
+
+func TestRecorderBindingMergeTodayAndArchiveFromAggregates(t *testing.T) {
+	store := testStore(t)
+	persister := NewPersister(store, MetricUsage)
+	var b RecorderBinding
+	b.BindRollup(store, persister)
+
+	day := time.Now().UTC().Format("2006-01-02")
+	b.QueueDelta(day, Delta{Totals: map[string]float64{"requests": 4, "tokens": 40}})
+	b.FlushRollup()
+
+	snap := map[string]interface{}{"available": true}
+	b.MergeToday(MetricUsage, day, snap, TopNCaps{ByKey: 100})
+	require.Equal(t, int64(4), snap["requests_today"])
+	require.Equal(t, int64(40), snap["tokens_today"])
+
+	b.ArchiveDayFromAggregates(MetricUsage, day, TopNCaps{ByKey: 100})
+	history, err := store.LoadHistory(context.Background(), MetricUsage)
+	require.NoError(t, err)
+	var archived bool
+	for _, row := range history {
+		if row.Day == day {
+			archived = true
+			require.InDelta(t, 4, row.Data["requests_today"], 0.001)
+		}
+	}
+	require.True(t, archived)
 }

--- a/internal/adminrollup/circuit.go
+++ b/internal/adminrollup/circuit.go
@@ -2,6 +2,7 @@ package adminrollup
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/circuit"
@@ -155,6 +156,10 @@ func RunCircuitArchiver(
 			now := time.Now().UTC()
 			day := now.Format("2006-01-02")
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if !store.TryElectArchiver(ctx, MetricCircuit, day, archiverHolderID()) {
+				cancel()
+				continue
+			}
 			snap := SnapshotCircuit(ctx, cbStore, providers, rollupThreshold, rollupWindowSec)
 			cancel()
 
@@ -170,4 +175,11 @@ func RunCircuitArchiver(
 			persister.QueueToday(day, peak.payload())
 		}
 	}
+}
+
+func archiverHolderID() string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return "llm-proxy"
 }

--- a/internal/adminrollup/circuit_test.go
+++ b/internal/adminrollup/circuit_test.go
@@ -2,7 +2,14 @@ package adminrollup
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/circuit"
+	"github.com/stretchr/testify/require"
 )
 
 func snap(provs map[string]interface{}) map[string]interface{} {
@@ -107,4 +114,129 @@ func TestSnapshotCircuitNilStore(t *testing.T) {
 	if provs := out["providers"].(map[string]interface{}); len(provs) != 0 {
 		t.Fatalf("nil store providers = %+v, want empty", provs)
 	}
+}
+
+func TestSnapshotCircuitMemoryStore(t *testing.T) {
+	cfg := circuit.Config{
+		Enabled:          true,
+		Backend:          "memory",
+		FailureThreshold: 2,
+		WindowSeconds:    60,
+		CooldownSeconds:  30,
+	}.Defaults()
+	store := circuit.NewMemoryStore(cfg)
+	ctx := context.Background()
+	_, _, err := store.RecordTerminalFailure(ctx, "openai")
+	require.NoError(t, err)
+	_, _, err = store.RecordTerminalFailure(ctx, "openai")
+	require.NoError(t, err)
+
+	out := SnapshotCircuit(ctx, store, []string{"openai", "anthropic"}, 2, 300)
+	require.Equal(t, 2, out["total_failures"])
+	provs := out["providers"].(map[string]interface{})
+	openai := provs["openai"].(map[string]interface{})
+	require.Equal(t, 2, openai["failures"])
+	require.Equal(t, "open", openai["state"])
+	require.Contains(t, openai, "rollup_open")
+}
+
+func TestSnapshotCircuitSkipsGetStatsErrors(t *testing.T) {
+	store := &fakeCircuitStore{statsErr: errors.New("redis down")}
+	out := SnapshotCircuit(context.Background(), store, []string{"openai"}, 0, 0)
+	require.Equal(t, 0, out["total_failures"])
+	require.Empty(t, out["providers"].(map[string]interface{}))
+}
+
+func TestArchiverHolderIDNonEmpty(t *testing.T) {
+	require.NotEmpty(t, archiverHolderID())
+}
+
+func TestTryElectArchiverRedisBackend(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+	require.Equal(t, BackendRedis, store.Backend())
+	require.True(t, store.TryElectArchiver(ctx, MetricCircuit, day, "writer-a"))
+	require.False(t, store.TryElectArchiver(ctx, MetricCircuit, day, "writer-b"))
+}
+
+func TestRunCircuitArchiverExitsOnStop(t *testing.T) {
+	store := testStore(t)
+	persister := NewPersister(store, MetricCircuit)
+	cb := circuit.NewMemoryStore(circuit.Config{Enabled: true, Backend: "memory"}.Defaults())
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		RunCircuitArchiver(store, persister, cb, []string{"openai"}, 0, 0, stop)
+		close(done)
+	}()
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunCircuitArchiver did not exit after stop closed")
+	}
+}
+
+func TestRunCircuitArchiverNilDepsReturnImmediately(t *testing.T) {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		RunCircuitArchiver(nil, nil, nil, nil, 0, 0, stop)
+		close(done)
+	}()
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("nil-deps archiver did not return")
+	}
+}
+
+type fakeCircuitStore struct {
+	statsErr error
+}
+
+func (f *fakeCircuitStore) GetState(context.Context, string) (circuit.State, error) {
+	return circuit.StateClosed, nil
+}
+func (f *fakeCircuitStore) RecordTerminalFailure(context.Context, string) (circuit.State, bool, error) {
+	return circuit.StateClosed, false, nil
+}
+func (f *fakeCircuitStore) RecordSuccess(context.Context, string) error { return nil }
+func (f *fakeCircuitStore) RecordProbeFailed(context.Context, string) error {
+	return nil
+}
+func (f *fakeCircuitStore) GetStats(context.Context, string) (*circuit.ProviderStats, error) {
+	return nil, f.statsErr
+}
+
+var _ circuit.Store = (*fakeCircuitStore)(nil)
+
+func TestCircuitArchiverElectsSingleWriter(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+
+	var wg sync.WaitGroup
+	winners := make(chan bool, 4)
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			winners <- store.TryElectArchiver(ctx, MetricCircuit, day, fmt.Sprintf("instance-%d", id))
+		}(i)
+	}
+	wg.Wait()
+	close(winners)
+
+	trueCount := 0
+	for w := range winners {
+		if w {
+			trueCount++
+		}
+	}
+	require.Equal(t, 1, trueCount)
 }

--- a/internal/adminrollup/delta.go
+++ b/internal/adminrollup/delta.go
@@ -1,0 +1,26 @@
+package adminrollup
+
+// Delta is one instance's additive contribution since its last flush.
+type Delta struct {
+	Totals     map[string]float64
+	Dimensions map[string]map[string]float64 // dim name -> member -> delta
+}
+
+func (d Delta) empty() bool {
+	if len(d.Totals) > 0 {
+		return false
+	}
+	for _, m := range d.Dimensions {
+		if len(m) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// TopNCaps limits high-cardinality dimension rows on read. Zero or negative
+// means uncapped (exact).
+type TopNCaps struct {
+	ByKey  int
+	ByUser int
+}

--- a/internal/adminrollup/delta_test.go
+++ b/internal/adminrollup/delta_test.go
@@ -1,0 +1,65 @@
+package adminrollup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDeltaMultiWriterSums(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := "2026-06-12"
+
+	p1 := NewPersister(store, MetricCost)
+	p2 := NewPersister(store, MetricCost)
+
+	p1.QueueDelta(day, Delta{
+		Totals: map[string]float64{
+			"spend_usd": 1.0,
+			"requests":  3,
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_provider": {"openai|spend_usd": 1.0, "openai|requests": 3},
+		},
+	})
+	p2.QueueDelta(day, Delta{
+		Totals: map[string]float64{
+			"spend_usd": 2.5,
+			"requests":  4,
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_provider": {"openai|spend_usd": 2.5, "openai|requests": 4},
+		},
+	})
+	p1.FlushNow()
+	p2.FlushNow()
+
+	snap := map[string]interface{}{"available": true}
+	store.MergeToday(ctx, MetricCost, day, snap, TopNCaps{ByKey: 100})
+
+	require.InDelta(t, 3.5, snap["spend_today_usd"].(float64), 0.001)
+	require.Equal(t, int64(7), snap["requests_today"])
+	byProv, ok := snap["by_provider"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, byProv, 1)
+	require.InDelta(t, 3.5, byProv[0]["spend_usd"].(float64), 0.001)
+	require.InDelta(t, 7, byProv[0]["requests"].(float64), 0.001)
+}
+
+func TestPersisterMergesPendingDeltas(t *testing.T) {
+	store := testStore(t)
+	p := NewPersister(store, MetricUsage)
+	day := "2026-06-12"
+
+	p.QueueDelta(day, Delta{Totals: map[string]float64{"requests": 2, "tokens": 100}})
+	p.QueueDelta(day, Delta{Totals: map[string]float64{"requests": 3, "tokens": 50}})
+	p.FlushNow()
+
+	ctx := context.Background()
+	totals, err := store.loadHash(ctx, totalsKey(MetricUsage, day))
+	require.NoError(t, err)
+	require.InDelta(t, 5, totals["requests"], 0.001)
+	require.InDelta(t, 150, totals["tokens"], 0.001)
+}

--- a/internal/adminrollup/delta_test.go
+++ b/internal/adminrollup/delta_test.go
@@ -63,3 +63,19 @@ func TestPersisterMergesPendingDeltas(t *testing.T) {
 	require.InDelta(t, 5, totals["requests"], 0.001)
 	require.InDelta(t, 150, totals["tokens"], 0.001)
 }
+
+func TestDeltaEmpty(t *testing.T) {
+	require.True(t, (Delta{}).empty())
+	require.True(t, Delta{Totals: map[string]float64{}, Dimensions: map[string]map[string]float64{}}.empty())
+	require.False(t, Delta{Totals: map[string]float64{"x": 1}}.empty())
+	require.False(t, Delta{Dimensions: map[string]map[string]float64{"d": {"m": 1}}}.empty())
+}
+
+func TestApplyDeltaEmptyNoOp(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.ApplyDelta(ctx, MetricCost, "2026-06-12", Delta{}))
+	totals, err := store.loadHash(ctx, totalsKey(MetricCost, "2026-06-12"))
+	require.NoError(t, err)
+	require.Empty(t, totals)
+}

--- a/internal/adminrollup/persist.go
+++ b/internal/adminrollup/persist.go
@@ -13,9 +13,11 @@ type Persister struct {
 	store  *Store
 	metric string
 
-	mu      sync.Mutex
-	timers  map[string]*time.Timer
-	pending map[string]map[string]interface{}
+	mu           sync.Mutex
+	timers       map[string]*time.Timer
+	pending      map[string]map[string]interface{}
+	deltaTimers  map[string]*time.Timer
+	deltaPending map[string]Delta
 }
 
 // NewPersister returns a persister for one metric family (cost, pii, …).
@@ -24,14 +26,16 @@ func NewPersister(store *Store, metric string) *Persister {
 		return nil
 	}
 	return &Persister{
-		store:   store,
-		metric:  metric,
-		timers:  make(map[string]*time.Timer),
-		pending: make(map[string]map[string]interface{}),
+		store:        store,
+		metric:       metric,
+		timers:       make(map[string]*time.Timer),
+		pending:      make(map[string]map[string]interface{}),
+		deltaTimers:  make(map[string]*time.Timer),
+		deltaPending: make(map[string]Delta),
 	}
 }
 
-// QueueToday schedules a debounced write of today's snapshot.
+// QueueToday schedules a debounced write of today's snapshot (legacy JSON path).
 func (p *Persister) QueueToday(day string, data map[string]interface{}) {
 	if p == nil || p.store == nil || data == nil {
 		return
@@ -45,6 +49,48 @@ func (p *Persister) QueueToday(day string, data map[string]interface{}) {
 	p.timers[day] = time.AfterFunc(persistDebounce, func() {
 		p.flushDay(day)
 	})
+}
+
+// QueueDelta schedules a debounced atomic merge of today's additive delta.
+func (p *Persister) QueueDelta(day string, d Delta) {
+	if p == nil || p.store == nil || d.empty() {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.deltaPending == nil {
+		p.deltaPending = make(map[string]Delta)
+	}
+	acc := p.deltaPending[day]
+	acc = mergeDelta(acc, d)
+	p.deltaPending[day] = acc
+	if t, ok := p.deltaTimers[day]; ok {
+		t.Stop()
+	}
+	p.deltaTimers[day] = time.AfterFunc(persistDebounce, func() {
+		p.flushDeltaDay(day)
+	})
+}
+
+func mergeDelta(acc, d Delta) Delta {
+	if acc.Totals == nil {
+		acc.Totals = make(map[string]float64)
+	}
+	for k, v := range d.Totals {
+		acc.Totals[k] += v
+	}
+	if acc.Dimensions == nil {
+		acc.Dimensions = make(map[string]map[string]float64)
+	}
+	for dim, members := range d.Dimensions {
+		if acc.Dimensions[dim] == nil {
+			acc.Dimensions[dim] = make(map[string]float64)
+		}
+		for m, v := range members {
+			acc.Dimensions[dim][m] += v
+		}
+	}
+	return acc
 }
 
 // ArchiveImmediately writes the completed day to the daily key (day rollover).
@@ -64,6 +110,22 @@ func (p *Persister) ArchiveImmediately(day string, data map[string]interface{}) 
 	defer cancel()
 	if err := p.store.ArchiveDaily(ctx, p.metric, day, data); err != nil {
 		p.store.logger.Warn("admin rollup: archive failed", "metric", p.metric, "day", day, "error", err)
+	}
+}
+
+func (p *Persister) flushDeltaDay(day string) {
+	p.mu.Lock()
+	d := p.deltaPending[day]
+	delete(p.deltaPending, day)
+	delete(p.deltaTimers, day)
+	p.mu.Unlock()
+	if d.empty() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.store.ApplyDelta(ctx, p.metric, day, d); err != nil {
+		p.store.logger.Warn("admin rollup: apply delta failed", "metric", p.metric, "day", day, "error", err)
 	}
 }
 
@@ -89,12 +151,21 @@ func (p *Persister) FlushNow() {
 		return
 	}
 	p.mu.Lock()
-	days := make([]string, 0, len(p.pending))
+	days := make([]string, 0, len(p.pending)+len(p.deltaPending))
 	for d := range p.pending {
 		days = append(days, d)
 	}
+	for d := range p.deltaPending {
+		days = append(days, d)
+	}
 	p.mu.Unlock()
+	seen := make(map[string]struct{}, len(days))
 	for _, d := range days {
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		p.flushDeltaDay(d)
 		p.flushDay(d)
 	}
 }

--- a/internal/adminrollup/persist_test.go
+++ b/internal/adminrollup/persist_test.go
@@ -1,0 +1,56 @@
+package adminrollup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueTodayLegacyFlush(t *testing.T) {
+	store := testStore(t)
+	p := NewPersister(store, MetricCost)
+	day := time.Now().UTC().Format("2006-01-02")
+
+	p.QueueToday(day, map[string]interface{}{
+		"spend_today_usd": 3.14,
+		"requests_today":  int64(2),
+	})
+	p.FlushNow()
+
+	ctx := context.Background()
+	history, err := store.LoadHistory(ctx, MetricCost)
+	require.NoError(t, err)
+
+	var found bool
+	for _, row := range history {
+		if row.Day == day {
+			found = true
+			require.InDelta(t, 3.14, row.Data["spend_today_usd"], 0.001)
+			break
+		}
+	}
+	require.True(t, found, "legacy SaveToday should persist JSON today blob readable by LoadHistory")
+}
+
+func TestArchiveImmediatelyFlushesPendingToday(t *testing.T) {
+	store := testStore(t)
+	p := NewPersister(store, MetricPII)
+	day := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+
+	p.QueueToday(day, map[string]interface{}{"requests_scanned": int64(9)})
+	p.ArchiveImmediately(day, map[string]interface{}{"requests_scanned": int64(9)})
+
+	ctx := context.Background()
+	history, err := store.LoadHistory(ctx, MetricPII)
+	require.NoError(t, err)
+	var archived bool
+	for _, row := range history {
+		if row.Day == day {
+			archived = true
+			require.InDelta(t, 9, row.Data["requests_scanned"], 0.001)
+		}
+	}
+	require.True(t, archived)
+}

--- a/internal/adminrollup/store.go
+++ b/internal/adminrollup/store.go
@@ -126,6 +126,93 @@ func todayKey(metric, day string) string {
 	return fmt.Sprintf("%s%s:today:%s", keyPrefix, metric, day)
 }
 
+// ApplyDelta atomically folds an instance delta into today's hash aggregates.
+func (s *Store) ApplyDelta(ctx context.Context, metric, day string, d Delta) error {
+	if s == nil || d.empty() {
+		return nil
+	}
+	return s.be.applyDelta(ctx, metric, day, d, todayTTL)
+}
+
+// TryElectArchiver returns true when this instance wins a short-lived lock to
+// write circuit daily peaks (one writer per metric/day).
+func (s *Store) TryElectArchiver(ctx context.Context, metric, day, holder string) bool {
+	if s == nil {
+		return false
+	}
+	key := fmt.Sprintf("%s%s:archiver:%s", keyPrefix, metric, day)
+	ok, err := s.be.trySetNX(ctx, key, holder, 26*time.Hour)
+	return err == nil && ok
+}
+
+func (s *Store) loadHash(ctx context.Context, key string) (map[string]float64, error) {
+	if s == nil {
+		return nil, nil
+	}
+	return s.be.hgetall(ctx, key)
+}
+
+func (s *Store) buildTodayData(ctx context.Context, metric, day string, caps TopNCaps) (map[string]interface{}, bool) {
+	totals, err := s.loadHash(ctx, totalsKey(metric, day))
+	if err != nil || len(totals) == 0 {
+		return nil, false
+	}
+	switch metric {
+	case MetricCost:
+		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))
+		byKey, _ := s.loadHash(ctx, dimKey(metric, day, "by_key"))
+		return costDataFromAggregates(totals, byProv, byKey), true
+	case MetricUsage:
+		byModel, _ := s.loadHash(ctx, dimKey(metric, day, "by_model"))
+		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))
+		byKey, _ := s.loadHash(ctx, dimKey(metric, day, "by_key"))
+		byUser, _ := s.loadHash(ctx, dimKey(metric, day, "by_user"))
+		return usageDataFromAggregates(totals, byModel, byProv, byKey, byUser, caps), true
+	case MetricPII:
+		byEntity, _ := s.loadHash(ctx, dimKey(metric, day, "by_entity"))
+		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))
+		byKey, _ := s.loadHash(ctx, dimKey(metric, day, "by_key"))
+		return piiDataFromAggregates(totals, byEntity, byProv, byKey, caps), true
+	default:
+		return nil, false
+	}
+}
+
+// MergeToday overlays fleet-wide today totals from Redis onto a live snapshot.
+func (s *Store) MergeToday(ctx context.Context, metric, day string, snap map[string]interface{}, caps TopNCaps) {
+	if s == nil || snap == nil {
+		return
+	}
+	data, ok := s.buildTodayData(ctx, metric, day, caps)
+	if !ok {
+		return
+	}
+	for k, v := range data {
+		snap[k] = v
+	}
+}
+
+// ArchiveDailyFromAggregates copies completed hash aggregates to the daily JSON
+// key and removes today's hash keys.
+func (s *Store) ArchiveDailyFromAggregates(ctx context.Context, metric, day string, caps TopNCaps) error {
+	if s == nil {
+		return nil
+	}
+	data, ok := s.buildTodayData(ctx, metric, day, caps)
+	if !ok {
+		return nil
+	}
+	if err := s.ArchiveDaily(ctx, metric, day, data); err != nil {
+		return err
+	}
+	_ = s.be.del(ctx, totalsKey(metric, day))
+	for _, dim := range []string{"by_provider", "by_key", "by_model", "by_user", "by_entity"} {
+		_ = s.be.del(ctx, dimKey(metric, day, dim))
+	}
+	_ = s.be.del(ctx, todayKey(metric, day))
+	return nil
+}
+
 // SaveToday writes the in-progress UTC day blob with a bounded TTL so an
 // orphaned today key (restart across midnight) self-expires; a live day is
 // rewritten long before todayTTL elapses.
@@ -173,14 +260,19 @@ func (s *Store) LoadHistory(ctx context.Context, metric string) ([]DayRecord, er
 	}
 	days = append(days, today)
 
+	byDay := make(map[string]DayRecord)
 	keys := make([]string, 0, len(days)*2)
 	keyDays := make([]string, 0, len(days)*2)
 	for _, d := range days {
 		keys = append(keys, dailyKey(metric, d))
 		keyDays = append(keyDays, d)
 		if d == today {
-			keys = append(keys, todayKey(metric, d))
-			keyDays = append(keyDays, d)
+			if agg, ok := s.buildTodayData(ctx, metric, d, TopNCaps{ByKey: 100, ByUser: 100}); ok {
+				byDay[d] = DayRecord{Day: d, Data: agg}
+			} else {
+				keys = append(keys, todayKey(metric, d))
+				keyDays = append(keyDays, d)
+			}
 		}
 	}
 
@@ -189,7 +281,6 @@ func (s *Store) LoadHistory(ctx context.Context, metric string) ([]DayRecord, er
 		return nil, err
 	}
 
-	byDay := make(map[string]DayRecord)
 	for i, raw := range vals {
 		if raw == nil {
 			continue

--- a/internal/adminrollup/store.go
+++ b/internal/adminrollup/store.go
@@ -161,7 +161,7 @@ func (s *Store) buildTodayData(ctx context.Context, metric, day string, caps Top
 	case MetricCost:
 		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))
 		byKey, _ := s.loadHash(ctx, dimKey(metric, day, "by_key"))
-		return costDataFromAggregates(totals, byProv, byKey), true
+		return costDataFromAggregates(totals, byProv, byKey, caps), true
 	case MetricUsage:
 		byModel, _ := s.loadHash(ctx, dimKey(metric, day, "by_model"))
 		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))

--- a/internal/coststats/stats.go
+++ b/internal/coststats/stats.go
@@ -96,9 +96,15 @@ func (r *Recorder) maybeRollDay(now time.Time) {
 		return
 	}
 	oldDay := r.dayKey
-	r.FlushRollup()
-	r.ArchiveDayFromAggregates(adminrollup.MetricCost, oldDay, costRollupCaps)
 	r.dayKey = day
+	// Flush pending debounced deltas synchronously (persister mutex only — does
+	// not take r.mu) so this instance's last old-day deltas land in Redis
+	// before the archive goroutine snapshots. Only the archive runs async so a
+	// UTC rollover never blocks concurrent RecordRequest on r.mu for seconds.
+	r.FlushRollup()
+	go func() {
+		r.ArchiveDayFromAggregatesElected(adminrollup.MetricCost, oldDay, costRollupCaps)
+	}()
 	r.flushed = costFlushed{}
 	r.spendTodayUSD = 0
 	r.inputSpendTodayUSD = 0

--- a/internal/coststats/stats.go
+++ b/internal/coststats/stats.go
@@ -62,12 +62,22 @@ type Recorder struct {
 	byKey      map[string]*keySpend
 	byProvider map[string]*providerSpend
 	recent     []recentEntry
+	flushed    costFlushed
 
 	// Shared Redis rollup lifecycle (BindRollup/FlushRollup/QueueToday/
 	// ArchiveDay/MergeHistory). Promoted methods satisfy the recorder's
 	// public BindRollup/FlushRollup API.
 	adminrollup.RecorderBinding
 }
+
+type costFlushed struct {
+	spendUSD, inputSpendUSD, outputSpendUSD float64
+	requests, inputTokens, outputTokens     int64
+	byProvider                              map[string]providerSpend
+	byKey                                   map[string]keySpend
+}
+
+var costRollupCaps = adminrollup.TopNCaps{ByKey: 100}
 
 // NewRecorder returns a ready-to-use Recorder scoped to the current UTC day.
 func NewRecorder() *Recorder {
@@ -85,8 +95,11 @@ func (r *Recorder) maybeRollDay(now time.Time) {
 	if r.dayKey == day {
 		return
 	}
-	r.ArchiveDay(r.dayKey, r.rollupDataLocked())
+	oldDay := r.dayKey
+	r.FlushRollup()
+	r.ArchiveDayFromAggregates(adminrollup.MetricCost, oldDay, costRollupCaps)
 	r.dayKey = day
+	r.flushed = costFlushed{}
 	r.spendTodayUSD = 0
 	r.inputSpendTodayUSD = 0
 	r.outputSpendTodayUSD = 0
@@ -184,10 +197,79 @@ func (r *Recorder) RecordRequest(
 	}
 
 	dayKey := r.dayKey
-	rollup := r.rollupDataLocked()
+	delta := r.costDeltaLocked()
+	r.advanceCostFlushedLocked()
 	r.mu.Unlock()
 
-	r.QueueToday(dayKey, rollup)
+	r.QueueDelta(dayKey, delta)
+}
+
+func (r *Recorder) costDeltaLocked() adminrollup.Delta {
+	d := adminrollup.Delta{
+		Totals: map[string]float64{
+			"spend_usd":        r.spendTodayUSD - r.flushed.spendUSD,
+			"input_spend_usd":  r.inputSpendTodayUSD - r.flushed.inputSpendUSD,
+			"output_spend_usd": r.outputSpendTodayUSD - r.flushed.outputSpendUSD,
+			"requests":         float64(r.requestsToday - r.flushed.requests),
+			"input_tokens":     float64(r.inputTokensToday - r.flushed.inputTokens),
+			"output_tokens":    float64(r.outputTokensToday - r.flushed.outputTokens),
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_provider": {},
+			"by_key":      {},
+		},
+	}
+	for name, ps := range r.byProvider {
+		prev := r.flushed.byProvider[name]
+		addDim(d.Dimensions["by_provider"], name, "spend_usd", ps.SpendUSD-prev.SpendUSD)
+		addDim(d.Dimensions["by_provider"], name, "input_spend_usd", ps.InputSpendUSD-prev.InputSpendUSD)
+		addDim(d.Dimensions["by_provider"], name, "output_spend_usd", ps.OutputSpendUSD-prev.OutputSpendUSD)
+		addDim(d.Dimensions["by_provider"], name, "requests", float64(ps.Requests-prev.Requests))
+		addDim(d.Dimensions["by_provider"], name, "input_tokens", float64(ps.InputTokens-prev.InputTokens))
+		addDim(d.Dimensions["by_provider"], name, "output_tokens", float64(ps.OutputTokens-prev.OutputTokens))
+	}
+	for scope, ks := range r.byKey {
+		prev := r.flushed.byKey[scope]
+		member := scope
+		if ks.KeyID != "" {
+			member = ks.KeyID
+		}
+		addDim(d.Dimensions["by_key"], member, "spend_usd", ks.SpendUSD-prev.SpendUSD)
+		addDim(d.Dimensions["by_key"], member, "input_spend_usd", ks.InputSpendUSD-prev.InputSpendUSD)
+		addDim(d.Dimensions["by_key"], member, "output_spend_usd", ks.OutputSpendUSD-prev.OutputSpendUSD)
+		addDim(d.Dimensions["by_key"], member, "requests", float64(ks.Requests-prev.Requests))
+		addDim(d.Dimensions["by_key"], member, "input_tokens", float64(ks.InputTokens-prev.InputTokens))
+		addDim(d.Dimensions["by_key"], member, "output_tokens", float64(ks.OutputTokens-prev.OutputTokens))
+	}
+	return d
+}
+
+func addDim(m map[string]float64, member, field string, v float64) {
+	if v == 0 {
+		return
+	}
+	m[adminrollup.DimMemberField(member, field)] = v
+}
+
+func (r *Recorder) advanceCostFlushedLocked() {
+	if r.flushed.byProvider == nil {
+		r.flushed.byProvider = make(map[string]providerSpend)
+	}
+	if r.flushed.byKey == nil {
+		r.flushed.byKey = make(map[string]keySpend)
+	}
+	r.flushed.spendUSD = r.spendTodayUSD
+	r.flushed.inputSpendUSD = r.inputSpendTodayUSD
+	r.flushed.outputSpendUSD = r.outputSpendTodayUSD
+	r.flushed.requests = r.requestsToday
+	r.flushed.inputTokens = r.inputTokensToday
+	r.flushed.outputTokens = r.outputTokensToday
+	for name, ps := range r.byProvider {
+		r.flushed.byProvider[name] = *ps
+	}
+	for scope, ks := range r.byKey {
+		r.flushed.byKey[scope] = *ks
+	}
 }
 
 func spendList(m map[string]*keySpend) []keySpend {
@@ -230,9 +312,10 @@ func (r *Recorder) Snapshot() map[string]interface{} {
 		recent[len(r.recent)-1-i] = e
 	}
 
+	dayKey := r.dayKey
 	snap := map[string]interface{}{
 		"available":              true,
-		"day":                    r.dayKey,
+		"day":                    dayKey,
 		"started_at":             r.startedAt.Unix(),
 		"spend_today_usd":        r.spendTodayUSD,
 		"input_spend_today_usd":  r.inputSpendTodayUSD,
@@ -246,6 +329,7 @@ func (r *Recorder) Snapshot() map[string]interface{} {
 	}
 	r.mu.RUnlock()
 
+	r.MergeToday(adminrollup.MetricCost, dayKey, snap, costRollupCaps)
 	r.MergeHistory(adminrollup.MetricCost, snap)
 	return snap
 }

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -47,10 +47,16 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 			}
 
 			scope := ratelimit.ScopeKeys{Provider: prov.GetName(), Model: model, APIKey: apiKey, UserID: userID}
-			res, err := limiter.CheckAndReserve(r.Context(), newReservationID(), scope, estTokens, time.Now())
+			reservationID := newReservationID()
+			res, err := limiter.CheckAndReserve(r.Context(), reservationID, scope, estTokens, time.Now())
 			if err != nil {
-				log.Printf("ratelimit: error reserving: %v", err)
-				http.Error(w, "rate limit error", http.StatusInternalServerError)
+				// Fail OPEN on limiter/backend (e.g. Redis) errors. A transient
+				// Redis blip must not turn into a wholesale 500 for every LLM
+				// request — that is strictly worse than briefly not enforcing a
+				// limit. This mirrors the circuit breaker, which also fails open
+				// (GetState returns closed) when its store is unreachable.
+				log.Printf("ratelimit: backend error, failing open: %v", err)
+				next.ServeHTTP(w, r)
 				return
 			}
 			if !res.Allowed {
@@ -75,23 +81,82 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 				prov.GetName(), model, userID, prefix(apiKey), estTokens)
 
 			// Proceed to next middleware/handler; TokenParsingMiddleware later
-			// in the chain will set X-LLM-Total-Tokens if available.
-			next.ServeHTTP(w, r)
+			// in the chain will set X-LLM-Total-Tokens if available. Wrap the
+			// writer so we can observe the final status code and undo the
+			// reservation when the upstream hard-fails (see below).
+			sw := &statusCapturingWriter{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(sw, r)
 
 			// Reconcile using input token metadata set by token parsing middleware headers if present
 			actualInput := headerToInt(w.Header().Get("X-LLM-Input-Tokens"))
 			if actualInput > 0 {
 				delta := actualInput - estTokens
-				if err := limiter.Adjust(r.Context(), "", scope, delta, time.Now()); err != nil {
+				if err := limiter.Adjust(r.Context(), reservationID, scope, delta, time.Now()); err != nil {
 					log.Printf("ratelimit: adjust error: %v", err)
 				} else if delta != 0 {
 					log.Printf("ratelimit: adjust (input) provider=%s model=%s user=%s key_prefix=%s delta_input_tokens=%d",
 						prov.GetName(), model, userID, prefix(apiKey), delta)
 				}
+			} else if sw.status >= 500 {
+				// Hard upstream failure (5xx) after we already reserved capacity.
+				// The request consumed no real LLM quota, so release the full
+				// reservation (1 request + estTokens) rather than letting it sit
+				// in the window until the TTL expires and silently throttle the
+				// caller. We intentionally only do this for 5xx: 4xx is a real
+				// (client-caused) attempt that should count, and 2xx without an
+				// input-token header is a streaming/parsed success that the
+				// Adjust branch above (or estimation) already accounts for.
+				if err := limiter.Cancel(r.Context(), reservationID, scope, estTokens, time.Now()); err != nil {
+					log.Printf("ratelimit: cancel error: %v", err)
+				} else {
+					log.Printf("ratelimit: cancel (upstream %d) provider=%s model=%s user=%s key_prefix=%s est_tokens=%d",
+						sw.status, prov.GetName(), model, userID, prefix(apiKey), estTokens)
+				}
 			}
 		})
 	}
 }
+
+// statusCapturingWriter records the response status code so the rate-limit
+// middleware can decide whether to release a reservation after the handler
+// runs. It transparently forwards http.Flusher (required by
+// StreamingMiddleware, which type-asserts http.Flusher to flush SSE chunks)
+// and exposes Unwrap for http.ResponseController compatibility, so wrapping
+// here never degrades streaming or other writer capabilities.
+type statusCapturingWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (w *statusCapturingWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusCapturingWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		// Mirror net/http: the first Write implies a 200 if WriteHeader was
+		// never called, so a successful body write isn't misread as a failure.
+		w.status = http.StatusOK
+		w.wroteHeader = true
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush forwards to the underlying writer when it supports flushing so
+// streaming responses keep working through this wrapper.
+func (w *statusCapturingWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap exposes the wrapped writer for http.ResponseController.
+func (w *statusCapturingWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
 
 func fmtInt(v int) string { return strconv.FormatInt(int64(v), 10) }
 

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -296,24 +296,31 @@ func (erroringLimiter) Cancel(ctx context.Context, id string, scope ratelimit.Sc
 	return nil
 }
 
-// TestRateLimitingMiddleware_CheckAndReserveError_Returns500 verifies that a
-// limiter outage during reservation surfaces as HTTP 500 rather than failing
-// open or panicking.  The inner handler must not run.
-func TestRateLimitingMiddleware_CheckAndReserveError_Returns500(t *testing.T) {
+// TestRateLimitingMiddleware_CheckAndReserveError_FailsOpen verifies that a
+// limiter outage during reservation fails OPEN: the request is allowed through
+// to the handler rather than surfacing as a wholesale HTTP 500. A transient
+// Redis blip must not take down all LLM traffic, mirroring the circuit
+// breaker's fail-open behavior when its store is unreachable.
+func TestRateLimitingMiddleware_CheckAndReserveError_FailsOpen(t *testing.T) {
 	cfg := makeCfg()
 	pm := providers.NewProviderManager()
 	pm.RegisterProvider(&fakeProvider{})
 
+	handlerRan := false
 	h := RateLimitingMiddleware(pm, cfg, erroringLimiter{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler must not be called when limiter errors")
+		handlerRan = true
+		w.WriteHeader(http.StatusOK)
 	}))
 
 	req := httptest.NewRequest("POST", "/openai/v1/chat/completions", bytes.NewReader([]byte(`{}`)))
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("limiter error must surface as 500; got %d", rr.Code)
+	if !handlerRan {
+		t.Fatal("handler must run when limiter errors (fail open)")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("limiter error must fail open with handler status; got %d", rr.Code)
 	}
 }
 
@@ -359,6 +366,78 @@ func TestRateLimitingMiddleware_AdjustError_LoggedButRequestSucceeds(t *testing.
 	}
 	if !strings.Contains(logOut, "ratelimit: adjust error") {
 		t.Errorf("Adjust error must be logged; got %s", logOut)
+	}
+}
+
+// cancelRecordingLimiter allows reservations and records whether Cancel was
+// called, with the estTokens it received. Used to verify the middleware
+// releases a reservation when the upstream hard-fails.
+type cancelRecordingLimiter struct {
+	cancelCalled bool
+	cancelTokens int
+}
+
+func (l *cancelRecordingLimiter) CheckAndReserve(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, now time.Time) (ratelimit.ReservationResult, error) {
+	return ratelimit.ReservationResult{Allowed: true, ReservationID: id}, nil
+}
+
+func (l *cancelRecordingLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, now time.Time) error {
+	return nil
+}
+
+func (l *cancelRecordingLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, now time.Time) error {
+	l.cancelCalled = true
+	l.cancelTokens = estTokens
+	return nil
+}
+
+// TestRateLimitingMiddleware_CancelsReservationOnUpstream5xx asserts that when
+// the handler responds 5xx (and no input-token header is set), the middleware
+// releases the reservation so a failed upstream call doesn't permanently
+// consume the caller's request/token quota for the window.
+func TestRateLimitingMiddleware_CancelsReservationOnUpstream5xx(t *testing.T) {
+	cfg := makeCfg()
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(&fakeProvider{})
+
+	lim := &cancelRecordingLimiter{}
+	chain := RateLimitingMiddleware(pm, cfg, lim)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+
+	req := httptest.NewRequest("POST", "/openai/v1/chat/completions", bytes.NewReader([]byte(`{"model":"gpt-4o","messages":[]}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	chain.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("expected upstream status 502 to pass through; got %d", rr.Code)
+	}
+	if !lim.cancelCalled {
+		t.Fatal("Cancel must be called to release the reservation on a 5xx upstream")
+	}
+}
+
+// TestRateLimitingMiddleware_DoesNotCancelOnSuccess asserts that a successful
+// (2xx) response does NOT release the reservation — the request really
+// happened and must count against the limit.
+func TestRateLimitingMiddleware_DoesNotCancelOnSuccess(t *testing.T) {
+	cfg := makeCfg()
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(&fakeProvider{})
+
+	lim := &cancelRecordingLimiter{}
+	chain := RateLimitingMiddleware(pm, cfg, lim)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/openai/v1/chat/completions", bytes.NewReader([]byte(`{"model":"gpt-4o","messages":[]}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	chain.ServeHTTP(rr, req)
+
+	if lim.cancelCalled {
+		t.Fatal("Cancel must NOT be called on a successful (2xx) response")
 	}
 }
 

--- a/internal/pii/stats.go
+++ b/internal/pii/stats.go
@@ -50,12 +50,21 @@ type Recorder struct {
 	byProvider map[string]int64
 	byKey      map[string]int64
 
-	recent []recentEntry
+	recent  []recentEntry
+	flushed piiFlushed
 
 	// Shared Redis rollup lifecycle; promoted methods satisfy the recorder's
 	// public BindRollup/FlushRollup API.
 	adminrollup.RecorderBinding
 }
+
+type piiFlushed struct {
+	requestsScanned, requestsWithPII, entitiesTotal int64
+	failOpen, failClosed, oversize                  int64
+	byEntity, byProvider, byKey                     map[string]int64
+}
+
+var piiRollupCaps = adminrollup.TopNCaps{ByKey: 100}
 
 // NewRecorder returns a ready-to-use Recorder.
 func NewRecorder() *Recorder {
@@ -74,8 +83,11 @@ func (r *Recorder) maybeRollDay(now time.Time) {
 	if r.dayKey == day {
 		return
 	}
-	r.ArchiveDay(r.dayKey, r.rollupDataLocked())
+	oldDay := r.dayKey
+	r.FlushRollup()
+	r.ArchiveDayFromAggregates(adminrollup.MetricPII, oldDay, piiRollupCaps)
 	r.dayKey = day
+	r.flushed = piiFlushed{}
 	r.requestsScanned = 0
 	r.requestsWithPII = 0
 	r.entitiesTotal = 0
@@ -203,10 +215,60 @@ func (r *Recorder) RecordRedaction(
 	}
 
 	dayKey := r.dayKey
-	rollup := r.rollupDataLocked()
+	delta := r.piiDeltaLocked()
+	r.advancePIIFlushedLocked()
 	r.mu.Unlock()
 
-	r.QueueToday(dayKey, rollup)
+	r.QueueDelta(dayKey, delta)
+}
+
+func (r *Recorder) piiDeltaLocked() adminrollup.Delta {
+	d := adminrollup.Delta{
+		Totals: map[string]float64{
+			"requests_scanned":  float64(r.requestsScanned - r.flushed.requestsScanned),
+			"requests_with_pii": float64(r.requestsWithPII - r.flushed.requestsWithPII),
+			"entities_total":    float64(r.entitiesTotal - r.flushed.entitiesTotal),
+			"fail_open":         float64(r.failOpen - r.flushed.failOpen),
+			"fail_closed":       float64(r.failClosed - r.flushed.failClosed),
+			"oversize":          float64(r.oversize - r.flushed.oversize),
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_entity":   intMapDelta(r.byEntity, r.flushed.byEntity),
+			"by_provider": intMapDelta(r.byProvider, r.flushed.byProvider),
+			"by_key":      intMapDelta(r.byKey, r.flushed.byKey),
+		},
+	}
+	return d
+}
+
+func intMapDelta(cur, prev map[string]int64) map[string]float64 {
+	out := make(map[string]float64)
+	for k, v := range cur {
+		if dv := float64(v - prev[k]); dv != 0 {
+			out[k] = dv
+		}
+	}
+	return out
+}
+
+func (r *Recorder) advancePIIFlushedLocked() {
+	r.flushed.requestsScanned = r.requestsScanned
+	r.flushed.requestsWithPII = r.requestsWithPII
+	r.flushed.entitiesTotal = r.entitiesTotal
+	r.flushed.failOpen = r.failOpen
+	r.flushed.failClosed = r.failClosed
+	r.flushed.oversize = r.oversize
+	r.flushed.byEntity = copyIntMap(r.byEntity)
+	r.flushed.byProvider = copyIntMap(r.byProvider)
+	r.flushed.byKey = copyIntMap(r.byKey)
+}
+
+func copyIntMap(m map[string]int64) map[string]int64 {
+	out := make(map[string]int64, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 // Snapshot returns a JSON-serialisable view of the current aggregates for
@@ -224,9 +286,10 @@ func (r *Recorder) Snapshot() map[string]interface{} {
 
 	_, detectionRate := r.detectionRateLocked()
 
+	dayKey := r.dayKey
 	snap := map[string]interface{}{
 		"available":         true,
-		"day":               r.dayKey,
+		"day":               dayKey,
 		"started_at":        r.startedAt.Unix(),
 		"requests_scanned":  r.requestsScanned,
 		"requests_with_pii": r.requestsWithPII,
@@ -242,6 +305,7 @@ func (r *Recorder) Snapshot() map[string]interface{} {
 	}
 	r.mu.RUnlock()
 
+	r.MergeToday(adminrollup.MetricPII, dayKey, snap, piiRollupCaps)
 	r.MergeHistory(adminrollup.MetricPII, snap)
 	return snap
 }

--- a/internal/pii/stats.go
+++ b/internal/pii/stats.go
@@ -84,9 +84,11 @@ func (r *Recorder) maybeRollDay(now time.Time) {
 		return
 	}
 	oldDay := r.dayKey
-	r.FlushRollup()
-	r.ArchiveDayFromAggregates(adminrollup.MetricPII, oldDay, piiRollupCaps)
 	r.dayKey = day
+	r.FlushRollup()
+	go func() {
+		r.ArchiveDayFromAggregatesElected(adminrollup.MetricPII, oldDay, piiRollupCaps)
+	}()
 	r.flushed = piiFlushed{}
 	r.requestsScanned = 0
 	r.requestsWithPII = 0

--- a/internal/ratelimit/factory_test.go
+++ b/internal/ratelimit/factory_test.go
@@ -49,10 +49,12 @@ func TestFactory_RedisBackend(t *testing.T) {
 	assert.NotNil(t, rl)
 }
 
-func TestFactory_UnknownBackend_ReturnsNil(t *testing.T) {
+func TestFactory_UnknownBackend_ReturnsError(t *testing.T) {
 	cfg := baseCfg()
 	cfg.Features.RateLimiting.Backend = "unknown"
 	rl, err := Factory(cfg)
-	require.NoError(t, err)
+	// An unknown backend with rate limiting enabled is a misconfiguration and
+	// must fail fast rather than silently disabling enforcement.
+	require.Error(t, err)
 	assert.Nil(t, rl)
 }

--- a/internal/ratelimit/redis.go
+++ b/internal/ratelimit/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -195,10 +196,15 @@ func secToMinuteEnd(t time.Time) int {
 }
 
 func secToDayEnd(t time.Time) int {
+	// Use the UTC calendar day so the rate-limit "day" window aligns with the
+	// admin rollups and the in-memory limiter (which truncate on UTC). Using
+	// the local TZ here meant the daily window and its TTL could roll at a
+	// different instant than the rest of the system if the process TZ drifted
+	// from UTC.
+	t = t.UTC()
 	y, m, d := t.Date()
-	loc := t.Location()
-	end := time.Date(y, m, d, 23, 59, 59, int(time.Second-time.Nanosecond), loc)
-	return int(time.Until(end).Seconds()) + 1
+	end := time.Date(y, m, d, 23, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
+	return int(end.Sub(t).Seconds()) + 1
 }
 
 var luaCheckAndReserve = redis.NewScript(`
@@ -302,6 +308,67 @@ for i = 0, pairsCount - 1 do
 end
 return {1}
 `)
+
+// snapshotTimeout bounds the Redis SCAN+HGETALL done for the admin dashboard
+// so a slow/large keyspace can never stall the admin API request.
+const snapshotTimeout = 2 * time.Second
+
+// Snapshot implements Snapshotter for the Redis backend so the admin dashboard
+// shows live fleet-wide counters (not just configured limits). It SCANs the
+// rl:min:* and rl:day:* hashes on the rate-limit DB and reports each scope's
+// current req/tok. Best-effort: on any Redis error it returns the configured
+// limits with empty counters rather than failing the admin request.
+func (r *redisLimiter) Snapshot(now time.Time) LimitsSnapshot {
+	rl := r.cfg.Features.RateLimiting
+	snap := LimitsSnapshot{
+		Enabled:   rl.Enabled,
+		Backend:   "redis",
+		Limits:    rl.Limits,
+		Overrides: rl.Overrides,
+		Minute: &WindowSnapshot{
+			WindowStart: now.UTC().Truncate(time.Minute).Format(time.RFC3339),
+			Counters:    map[string]CounterSnapshot{},
+		},
+		Day: &WindowSnapshot{
+			WindowStart: now.UTC().Truncate(24 * time.Hour).Format(time.RFC3339),
+			Counters:    map[string]CounterSnapshot{},
+		},
+	}
+	if r.rdb == nil {
+		return snap
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), snapshotTimeout)
+	defer cancel()
+	r.scanCounters(ctx, "rl:min:", snap.Minute.Counters)
+	r.scanCounters(ctx, "rl:day:", snap.Day.Counters)
+	return snap
+}
+
+// scanCounters loads every "<prefix><scope>" hash into out keyed by the bare
+// scope string (matching the memory limiter's counter keys, e.g. "global",
+// "user:alice"). Errors abort the scan and leave out partially populated.
+func (r *redisLimiter) scanCounters(ctx context.Context, prefix string, out map[string]CounterSnapshot) {
+	var cursor uint64
+	for {
+		keys, next, err := r.rdb.Scan(ctx, cursor, prefix+"*", 200).Result()
+		if err != nil {
+			return
+		}
+		for _, k := range keys {
+			h, err := r.rdb.HGetAll(ctx, k).Result()
+			if err != nil {
+				return
+			}
+			req, _ := strconv.Atoi(h["req"])
+			tok, _ := strconv.Atoi(h["tok"])
+			out[strings.TrimPrefix(k, prefix)] = CounterSnapshot{Requests: req, Tokens: tok}
+		}
+		cursor = next
+		if cursor == 0 {
+			return
+		}
+	}
+}
 
 func (r *redisLimiter) CheckAndReserve(ctx context.Context, id string, scope ScopeKeys, estTokens int, now time.Time) (ReservationResult, error) {
 	scopeKeys := r.scopeKeys(scope)

--- a/internal/ratelimit/redis_test.go
+++ b/internal/ratelimit/redis_test.go
@@ -214,6 +214,31 @@ func TestRedisLimiter_DynamicPerKeyOverride(t *testing.T) {
 	assert.False(t, res.Allowed)
 }
 
+func TestRedisLimiter_SnapshotReportsLiveCounters(t *testing.T) {
+	cfg := baseCfg()
+	lim, _ := newRedisLimiterForTest(t, cfg)
+
+	snapshotter, ok := lim.(Snapshotter)
+	require.True(t, ok, "redis limiter must implement Snapshotter")
+
+	scope := ScopeKeys{Provider: "openai", Model: "gpt-4o", UserID: "snapuser"}
+	now := time.Now()
+	res, err := lim.CheckAndReserve(context.Background(), "1", scope, 17, now)
+	require.NoError(t, err)
+	require.True(t, res.Allowed)
+
+	snap := snapshotter.Snapshot(now)
+	assert.Equal(t, "redis", snap.Backend)
+	require.NotNil(t, snap.Minute)
+
+	got := snap.Minute.Counters["user:snapuser"]
+	assert.Equal(t, 1, got.Requests)
+	assert.Equal(t, 17, got.Tokens)
+
+	global := snap.Minute.Counters["global"]
+	assert.Equal(t, 1, global.Requests)
+}
+
 func TestNewRedisLimiter_NilRedisConfigErrors(t *testing.T) {
 	cfg := config.GetDefaultYAMLConfig()
 	cfg.Features.RateLimiting.Enabled = true

--- a/internal/ratelimit/types.go
+++ b/internal/ratelimit/types.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/config"
@@ -113,5 +114,8 @@ func Factory(cfg *config.YAMLConfig) (RateLimiter, error) {
 		// Redis implementation added separately
 		return NewRedisLimiter(cfg)
 	}
-	return nil, nil
+	// An unknown backend with rate limiting enabled is a misconfiguration: a
+	// typo like "reddis" previously returned (nil, nil) and silently disabled
+	// enforcement. Fail fast at startup instead.
+	return nil, fmt.Errorf("unknown rate limiting backend %q (expected \"memory\" or \"redis\")", backend)
 }

--- a/internal/usagestats/stats.go
+++ b/internal/usagestats/stats.go
@@ -62,9 +62,11 @@ func (r *Recorder) maybeRollDay(now time.Time) {
 		return
 	}
 	oldDay := r.dayKey
-	r.FlushRollup()
-	r.ArchiveDayFromAggregates(adminrollup.MetricUsage, oldDay, usageRollupCaps)
 	r.dayKey = day
+	r.FlushRollup()
+	go func() {
+		r.ArchiveDayFromAggregatesElected(adminrollup.MetricUsage, oldDay, usageRollupCaps)
+	}()
 	r.flushed = usageFlushed{}
 	r.global = scopeUsage{}
 	r.byModel = make(map[string]*scopeUsage)

--- a/internal/usagestats/stats.go
+++ b/internal/usagestats/stats.go
@@ -26,11 +26,22 @@ type Recorder struct {
 	byProv  map[string]*scopeUsage
 	byKey   map[string]*scopeUsage
 	byUser  map[string]*scopeUsage
+	flushed usageFlushed
 
 	// Shared Redis rollup lifecycle; promoted methods satisfy the recorder's
 	// public BindRollup/FlushRollup API.
 	adminrollup.RecorderBinding
 }
+
+type usageFlushed struct {
+	global  scopeUsage
+	byModel map[string]scopeUsage
+	byProv  map[string]scopeUsage
+	byKey   map[string]scopeUsage
+	byUser  map[string]scopeUsage
+}
+
+var usageRollupCaps = adminrollup.TopNCaps{ByKey: 100, ByUser: 100}
 
 // NewRecorder returns a recorder for the current UTC day.
 func NewRecorder() *Recorder {
@@ -50,8 +61,11 @@ func (r *Recorder) maybeRollDay(now time.Time) {
 	if r.dayKey == day {
 		return
 	}
-	r.ArchiveDay(r.dayKey, r.rollupDataLocked())
+	oldDay := r.dayKey
+	r.FlushRollup()
+	r.ArchiveDayFromAggregates(adminrollup.MetricUsage, oldDay, usageRollupCaps)
 	r.dayKey = day
+	r.flushed = usageFlushed{}
 	r.global = scopeUsage{}
 	r.byModel = make(map[string]*scopeUsage)
 	r.byProv = make(map[string]*scopeUsage)
@@ -101,10 +115,69 @@ func (r *Recorder) RecordRequest(provider, model, keyID, userID string, inputTok
 		r.add(r.byUser, scopeKey("user", userID), tokens)
 	}
 	dayKey := r.dayKey
-	rollup := r.rollupDataLocked()
+	delta := r.usageDeltaLocked()
+	r.advanceUsageFlushedLocked()
 	r.mu.Unlock()
 
-	r.QueueToday(dayKey, rollup)
+	r.QueueDelta(dayKey, delta)
+}
+
+func (r *Recorder) usageDeltaLocked() adminrollup.Delta {
+	d := adminrollup.Delta{
+		Totals: map[string]float64{
+			"requests": float64(r.global.Requests - r.flushed.global.Requests),
+			"tokens":   float64(r.global.Tokens - r.flushed.global.Tokens),
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_model":    usageScopeDelta(r.byModel, r.flushed.byModel),
+			"by_provider": usageScopeDelta(r.byProv, r.flushed.byProv),
+			"by_key":      usageScopeDelta(r.byKey, r.flushed.byKey),
+			"by_user":     usageScopeDelta(r.byUser, r.flushed.byUser),
+		},
+	}
+	return d
+}
+
+func usageScopeDelta(cur map[string]*scopeUsage, prev map[string]scopeUsage) map[string]float64 {
+	out := make(map[string]float64)
+	for key, u := range cur {
+		p := prev[key]
+		if dr := float64(u.Requests - p.Requests); dr != 0 {
+			out[adminrollup.DimMemberField(key, "requests")] = dr
+		}
+		if dt := float64(u.Tokens - p.Tokens); dt != 0 {
+			out[adminrollup.DimMemberField(key, "tokens")] = dt
+		}
+	}
+	return out
+}
+
+func (r *Recorder) advanceUsageFlushedLocked() {
+	if r.flushed.byModel == nil {
+		r.flushed.byModel = make(map[string]scopeUsage)
+	}
+	if r.flushed.byProv == nil {
+		r.flushed.byProv = make(map[string]scopeUsage)
+	}
+	if r.flushed.byKey == nil {
+		r.flushed.byKey = make(map[string]scopeUsage)
+	}
+	if r.flushed.byUser == nil {
+		r.flushed.byUser = make(map[string]scopeUsage)
+	}
+	r.flushed.global = r.global
+	for k, v := range r.byModel {
+		r.flushed.byModel[k] = *v
+	}
+	for k, v := range r.byProv {
+		r.flushed.byProv[k] = *v
+	}
+	for k, v := range r.byKey {
+		r.flushed.byKey[k] = *v
+	}
+	for k, v := range r.byUser {
+		r.flushed.byUser[k] = *v
+	}
 }
 
 func scopeMap(m map[string]*scopeUsage) map[string]scopeUsage {
@@ -180,9 +253,10 @@ func (r *Recorder) Snapshot() map[string]interface{} {
 		return map[string]interface{}{"available": false}
 	}
 	r.mu.RLock()
+	dayKey := r.dayKey
 	snap := map[string]interface{}{
 		"available":      true,
-		"day":            r.dayKey,
+		"day":            dayKey,
 		"started_at":     r.startedAt.Unix(),
 		"requests_today": r.global.Requests,
 		"tokens_today":   r.global.Tokens,
@@ -192,6 +266,7 @@ func (r *Recorder) Snapshot() map[string]interface{} {
 	}
 	r.mu.RUnlock()
 
+	r.MergeToday(adminrollup.MetricUsage, dayKey, snap, usageRollupCaps)
 	r.MergeHistory(adminrollup.MetricUsage, snap)
 	return snap
 }


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

Makes admin dashboard rollups safe for multi-instance / multi-sidecar fleets by switching cost, usage, and PII recorders from last-writer-wins JSON snapshots to debounced atomic Redis hash deltas (`HINCRBYFLOAT` via Lua). Also wires production rate limiting to the shared Redis URL (DB 4) with `enabled: false`.

**Depends on:** infrastructure PR provisioning `/llm-proxy/redis_url` and injecting `REDIS_URL` into ECS tasks. Apply infra first, then deploy this app change.

## Rollup changes

- New `Delta` type + `aggregate.go` Lua script for atomic merges
- `Persister.QueueDelta` debounces and merges per-instance deltas before flush
- `Store.MergeToday` reads hash-backed aggregates for fleet-wide admin snapshots
- `coststats`, `usagestats`, `pii` recorders track flushed watermarks and emit deltas on each event
- Top-100 caps on `by_key` / `by_user` at read time with exact `other_*` buckets; `by_model` uncapped

## Config

- `configs/production.yml` — `features.rate_limiting` redis block on `${REDIS_URL}` db 4, `enabled: false`
- Circuit breaker (db 5) and rollups (db 6) unchanged

## Tests

- `TestApplyDeltaMultiWriterSums` — two persisters sum, not last-writer-wins
- `make check`, `make test`, `go run ./cmd/config-validator/` all pass