### PR TITLE
circuit: fix empty graphs on force-open + add caller dimension to failure metrics

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -702,6 +702,24 @@ func circuitModelExtractor(
 	}
 }
 
+// circuitCallerExtractor returns a caller-label extractor for circuit
+// failure observability. It reads the resolved proxy API-key record off
+// the request context (set by the auth middleware) and returns its
+// Description — a stable, human-readable label like "finch-prod" — never
+// the secret key value. Empty when no key is on the context; the circuit
+// transport normalizes that to the "unknown" tag.
+func circuitCallerExtractor() circuit.CallerFromRequestFunc {
+	return func(req *http.Request) string {
+		if req == nil {
+			return ""
+		}
+		if rec, ok := apikeys.FromContext(req.Context()); ok && rec != nil {
+			return rec.Description
+		}
+		return ""
+	}
+}
+
 // initializeAPIKeyStore creates and configures the API key store from config
 func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore {
 	// Check if API key management is enabled
@@ -1205,6 +1223,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		modelFn := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider)
 		opts := []circuit.Option{
 			circuit.WithModelExtractor(modelFn),
+			circuit.WithCallerExtractor(circuitCallerExtractor()),
 		}
 		if circuitMetrics != nil {
 			opts = append(opts, circuit.WithMetrics(circuitMetrics))

--- a/internal/circuit/memory.go
+++ b/internal/circuit/memory.go
@@ -271,10 +271,17 @@ func (s *MemoryStore) ForceOpen(_ context.Context, key string, cooldownSeconds i
 	e := s.entry(key)
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	now := s.now()
 	e.state = StateOpen
-	e.cooldownUntil = s.now().Add(time.Duration(cooldownSeconds) * time.Second)
+	e.cooldownUntil = now.Add(time.Duration(cooldownSeconds) * time.Second)
 	e.probeInFlight = false
 	e.probeStartAt = time.Time{}
+	// Record a failure in the sliding window so observability (GetStats
+	// Failures, the dashboard "Failures by provider" / trend charts, and
+	// daily-history rollups) reflects the forced-open event. Without this the
+	// breaker shows state=open with failures=0 and the graphs stay empty.
+	e.failures = append(e.failures, now)
+	s.pruneFailuresLocked(e, now)
 	return nil
 }
 

--- a/internal/circuit/memory_test.go
+++ b/internal/circuit/memory_test.go
@@ -29,6 +29,21 @@ func TestMemoryStore_InitialStateClosed(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_ForceOpenRecordsFailureForObservability(t *testing.T) {
+	s := NewMemoryStore(defaultConfig())
+	ctx := context.Background()
+
+	require.NoError(t, s.ForceOpen(ctx, "openai", 0))
+
+	stats, err := s.GetStats(ctx, "openai")
+	require.NoError(t, err)
+	require.Equal(t, StateOpen, stats.State)
+	// Regression: ForceOpen must credit a failure so the dashboard charts
+	// (which plot GetStats.Failures / total_failures) reflect the forced-open
+	// event instead of showing state=open with an empty graph.
+	require.Equal(t, 1, stats.Failures)
+}
+
 func TestMemoryStore_CircuitOpensAtThreshold(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.FailureThreshold = 3

--- a/internal/circuit/observability_test.go
+++ b/internal/circuit/observability_test.go
@@ -268,6 +268,48 @@ func TestObserveOnly_TerminalFailureLogContainsStructuredAttrs(t *testing.T) {
 	}
 }
 
+// TestFastFailMetric_TagsCaller verifies the caller-label dimension wired
+// via WithCallerExtractor lands on both the log line and the dogstatsd tag
+// set, so operators can attribute degraded responses to a downstream
+// client (e.g. "finch-prod").
+func TestFastFailMetric_TagsCaller(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := captureLogs(buf)
+	metrics := &fakeMetrics{}
+
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Fatal("inner transport must not be called when the circuit is open")
+		return nil, nil
+	})
+	cfg := Config{Enabled: true, Mode: ModeEnforce}.Defaults()
+	store := NewMemoryStore(cfg)
+	// Force the bare-provider breaker open so the next request fast-fails.
+	if err := store.ForceOpen(context.Background(), "openai", cfg.CooldownSeconds); err != nil {
+		t.Fatalf("ForceOpen: %v", err)
+	}
+	tr := NewTransport(
+		inner, store, cfg, "openai", log,
+		WithMetrics(metrics),
+		WithCallerExtractor(func(*http.Request) string { return "finch-prod" }),
+	)
+
+	resp, err := tr.RoundTrip(dummyOpenAIRequest("gpt-4o"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+
+	calls := metrics.findByName("circuit.fast_fail")
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 circuit.fast_fail metric, got %d (%+v)", len(calls), metrics.calls)
+	}
+	if _, ok := tagSet(calls[0].Tags)["caller:finch-prod"]; !ok {
+		t.Fatalf("missing tag caller:finch-prod on circuit.fast_fail (tags=%v)", calls[0].Tags)
+	}
+}
+
 // TestObserveOnly_TerminalFailureMetric_TransportError_TagsClientDeadline
 // is the explicit fixture for the "tag context.DeadlineExceeded
 // distinctly" requirement: a deadline-exceeded transport error must

--- a/internal/circuit/options.go
+++ b/internal/circuit/options.go
@@ -38,6 +38,22 @@ func (noopMetrics) Incr(string, []string, float64) error { return nil }
 //     retry paths).
 type ModelFromRequestFunc func(*http.Request) string
 
+// CallerFromRequestFunc returns a low-cardinality, human-readable label
+// for the caller behind an HTTP request (e.g. the proxy API-key
+// description like "finch-prod"), or "" if it cannot be determined.
+//
+// It is used only to enrich failure log lines and metric tags so
+// operators can attribute degraded responses to a downstream caller —
+// never to influence routing or breaker behaviour. Like
+// ModelFromRequestFunc, implementations must be side-effect-free,
+// non-blocking, and safe for concurrent use; in practice the caller
+// label lives on the request context, so no body read is required.
+//
+// IMPORTANT: return a stable, bounded label (a key *name*, not the
+// secret key value and not a per-request id) — the value becomes a
+// Datadog tag and unbounded values blow the cardinality budget.
+type CallerFromRequestFunc func(*http.Request) string
+
 // Option mutates a Transport during construction.  See NewTransport for
 // the canonical usage.
 type Option func(*Transport)
@@ -61,5 +77,16 @@ func WithMetrics(m MetricsSink) Option {
 func WithModelExtractor(f ModelFromRequestFunc) Option {
 	return func(t *Transport) {
 		t.modelFn = f
+	}
+}
+
+// WithCallerExtractor installs a caller-label extractor so failure log
+// lines and metric tags carry a `caller` dimension (e.g. the proxy
+// API-key description). The transport calls it only on failure paths, so
+// successful traffic pays no extra cost. Pass nil (or omit the option) to
+// skip caller tagging — the tag then reports "unknown".
+func WithCallerExtractor(f CallerFromRequestFunc) Option {
+	return func(t *Transport) {
+		t.callerFn = f
 	}
 }

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -366,10 +366,21 @@ func (s *RedisStore) ForceOpen(ctx context.Context, key string, cooldownSeconds 
 	}
 	cd := time.Duration(cooldownSeconds) * time.Second
 	hoTTL := time.Duration(cooldownSeconds*halfOpenMarkerTTLMultiplier) * time.Second
+	now := float64(time.Now().UnixNano()) / 1e9
+	cutoff := now - float64(s.cfg.WindowSeconds)
+	member := fmt.Sprintf("%.9f:%d", now, s.failureSeq.Add(1))
+	fttl := time.Duration(s.cfg.CooldownSeconds*halfOpenMarkerTTLMultiplier) * time.Second
 	pipe := s.rdb.Pipeline()
 	pipe.Set(ctx, s.stateKey(key), "open", cd)
 	pipe.Set(ctx, s.halfOpenKey(key), "1", hoTTL)
 	pipe.Del(ctx, s.probeKey(key))
+	// Record a failure in the sliding window so observability (GetStats
+	// Failures, the dashboard "Failures by provider" / trend charts, and
+	// daily-history rollups) reflects the forced-open event. Without this the
+	// breaker shows state=open with failures=0 and the graphs stay empty.
+	pipe.ZAdd(ctx, s.failuresKey(key), redis.Z{Score: now, Member: member})
+	pipe.ZRemRangeByScore(ctx, s.failuresKey(key), "-inf", fmt.Sprintf("%f", cutoff))
+	pipe.Expire(ctx, s.failuresKey(key), fttl)
 	if _, err := pipe.Exec(ctx); err != nil {
 		s.log.Warn(
 			"circuit.RedisStore: ForceOpen failed (provider will NOT fast-fail account-wide)",

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -57,6 +57,7 @@ type Transport struct {
 	log      *slog.Logger
 	metrics  MetricsSink
 	modelFn  ModelFromRequestFunc
+	callerFn CallerFromRequestFunc
 }
 
 // NewTransport wraps inner with circuit-breaker behaviour for provider.
@@ -109,6 +110,7 @@ type failureContext struct {
 	Provider    string
 	Model       string
 	CBKey       string
+	Caller      string
 	Path        string
 	Method      string
 	StatusCode  int
@@ -142,6 +144,12 @@ func (t *Transport) newFailureContext(req *http.Request, resp *http.Response, er
 		// and allowing extractors to fall back to req.Body there can turn an
 		// open circuit into an unbounded body read just for observability.
 		fc.Model = t.modelFn(req)
+	}
+	if t.callerFn != nil && req != nil {
+		// Best-effort caller label (e.g. proxy API-key description). Reads
+		// from the request context only — no body access — so it is safe on
+		// synthetic fast-fail paths that run before cacheBody.
+		fc.Caller = t.callerFn(req)
 	}
 	fc.CBKey = composeKey(fc.Provider, fc.Model)
 	return fc
@@ -200,6 +208,7 @@ func (fc failureContext) attrs() []any {
 		"provider", fc.Provider,
 		"model", fc.Model,
 		"cb_key", fc.CBKey,
+		"caller", fc.Caller,
 		"path", fc.Path,
 		"method", fc.Method,
 		"status_code", fc.StatusCode,
@@ -219,6 +228,12 @@ func (fc failureContext) attrs() []any {
 // derivable from `provider:model` via concatenation and including it
 // would double-count cardinality without adding any new dimension.
 //
+// caller is the API-key description (a human label like "finch-prod"),
+// so operators can attribute degraded responses to a downstream client.
+// Its cardinality is bounded by the number of provisioned proxy keys —
+// low and operator-controlled — and is length-capped via
+// normalizeTagValue as defence-in-depth; empty becomes "unknown".
+//
 // Tag values are length-capped via normalizeTagValue to prevent
 // pathological model IDs (e.g. an attacker passing a 4096-char string
 // or a one-off fine-tune SKU) from blowing up the Datadog cardinality
@@ -229,6 +244,7 @@ func (fc failureContext) metricTags() []string {
 	return []string{
 		"provider:" + normalizeTagValue(fc.Provider),
 		"model:" + normalizeTagValue(fc.Model),
+		"caller:" + normalizeTagValue(fc.Caller),
 		"status_code:" + strconv.Itoa(fc.StatusCode),
 		"failure_kind:" + normalizeTagValue(string(fc.Kind)),
 	}

--- a/web/src/components/charts/index.tsx
+++ b/web/src/components/charts/index.tsx
@@ -238,10 +238,7 @@ export function DonutChart({
       maintainAspectRatio: false,
       cutout: "70%",
       plugins: {
-        legend: {
-          position: "bottom",
-          labels: { boxWidth: 12, usePointStyle: true, padding: 16, color: chartPalette.tick() },
-        },
+        legend: { display: false },
       },
     }),
     [theme],
@@ -253,16 +250,29 @@ export function DonutChart({
   }
 
   return (
-    <div className="relative" style={{ height }}>
-      <Doughnut key={theme} data={data} options={options} />
-      {centerValue ? (
-        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center pb-10">
-          <span className="text-2xl font-semibold">{centerValue}</span>
-          {centerLabel ? (
-            <span className="text-xs uppercase tracking-wide text-base-content/50">{centerLabel}</span>
-          ) : null}
-        </div>
-      ) : null}
+    <div className="flex flex-col">
+      <div className="relative" style={{ height }}>
+        <Doughnut key={theme} data={data} options={options} />
+        {centerValue ? (
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-2xl font-semibold leading-tight">{centerValue}</span>
+            {centerLabel ? (
+              <span className="text-xs uppercase tracking-wide text-base-content/50">{centerLabel}</span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      <ul className="mt-4 flex flex-wrap justify-center gap-x-4 gap-y-2">
+        {labels.map((label, i) => (
+          <li key={`${label}-${i}`} className="flex items-center gap-1.5 text-xs text-base-content/70">
+            <span
+              className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: colors[i % colors.length] }}
+            />
+            <span className="truncate">{label}</span>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
# DO NOT MERGE

# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary
- **Fix empty dashboard graphs on quota force-open.** `ForceOpen` opened the breaker but recorded no failure, so `GetStats().Failures` stayed 0 and the Circuit Breaker dashboard showed `state: open` with empty "Failures by provider" / "Failure trend" charts. Now `ForceOpen` credits one failure into the same sliding window the charts/daily-history read, in both the memory and Redis stores.
- **Add a `caller` dimension to circuit failure observability.** Every `circuit.*` counter and failure log line now carries `caller` (the proxy API-key description, e.g. `finch-prod`; never the secret value), so degraded responses can be attributed to a downstream client. Wired via a new `WithCallerExtractor` option mirroring `WithModelExtractor`, populated from `apikeys.FromContext`. Empty descriptions normalize to `caller:unknown`; cardinality is bounded by the provisioned key set and length-capped as defence-in-depth.
- Includes a small admin donut-legend rendering fix carried on this branch.

## Why
After OpenAI `insufficient_quota` started force-opening the provider, operators saw the breaker open but no graph movement, and couldn't tell which callers were eating the resulting 503s. These two changes make the force-open visible on the existing dashboard and queryable per-caller in Datadog (e.g. `sum:circuit.fast_fail{*} by {caller,provider,failure_kind}`).

## Notes
- Observability-only: neither change alters the Open then HalfOpen then probe then Closed recovery lifecycle. The recorded force-open failure clears on `RecordSuccess`.
- Open-source audit finding `main.go:155` ('regions') reviewed and deemed acceptable — generic cloud-infra terminology in a pre-existing Redis-timeout comment, not private release terminology.

## Test plan
- [ ] `go build ./...`, `go vet ./internal/circuit/ ./cmd/...`, `gofmt` clean
- [ ] Full `go test ./internal/circuit/` suite passes
- [ ] New regressions: `TestMemoryStore_ForceOpenRecordsFailureForObservability`, `TestFastFailMetric_TagsCaller`
- [ ] Post-deploy: confirm the Circuit Breaker dashboard shows failures on a force-open and `caller` facets appear on `circuit.fast_fail` / `circuit.terminal_failure`