### PR TITLE
feat(provision): auto-mint upstream API keys

### DIFF
--- a/cmd/llm-proxy-keys/main.go
+++ b/cmd/llm-proxy-keys/main.go
@@ -20,6 +20,11 @@ const (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "pool" {
+		runPoolCommand(os.Args[2:])
+		return
+	}
+
 	// Command-line flags
 	var (
 		configDir     = flag.String("config-dir", "configs", "Path to configuration directory")
@@ -47,6 +52,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  Delete key:      -delete=iw:xxx\n")
 		fmt.Fprintf(os.Stderr, "  Disable key:     -disable=iw:xxx\n")
 		fmt.Fprintf(os.Stderr, "  Enable key:      -enable=iw:xxx\n\n")
+		fmt.Fprintf(os.Stderr, "Pool commands:\n")
+		fmt.Fprintf(os.Stderr, "  pool add:        pool add --provider anthropic --key sk-ant-api03-...\n")
+		fmt.Fprintf(os.Stderr, "  pool status:     pool status --provider anthropic\n\n")
 		fmt.Fprintf(os.Stderr, "Flags:\n")
 		flag.PrintDefaults()
 	}

--- a/cmd/llm-proxy-keys/pool.go
+++ b/cmd/llm-proxy-keys/pool.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Instawork/llm-proxy/internal/provision"
+	redis "github.com/redis/go-redis/v9"
+)
+
+func runPoolCommand(args []string) {
+	fs := flag.NewFlagSet("pool", flag.ExitOnError)
+	configDir := fs.String("config-dir", "configs", "Path to configuration directory")
+	environment := fs.String("env", "dev", "Environment (dev, staging, production)")
+	provider := fs.String("provider", "", "Provider name (anthropic)")
+	key := fs.String("key", "", "Upstream API key to add to the pool")
+	listKey := fs.String("pool-key", "", "Redis list key override")
+
+	if len(args) == 0 {
+		printPoolUsage()
+		os.Exit(1)
+	}
+	subcmd := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		os.Exit(1)
+	}
+
+	if *provider != "anthropic" && *provider != "" {
+		fmt.Fprintf(os.Stderr, "only anthropic pool operations are supported\n")
+		os.Exit(1)
+	}
+	if *provider == "" {
+		*provider = "anthropic"
+	}
+
+	yamlConfig, err := loadConfig(*configDir, *environment)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	poolRedisKey := yamlConfig.Features.APIKeyManagement.Provisioning.Anthropic.PoolRedisKey
+	if *listKey != "" {
+		poolRedisKey = *listKey
+	}
+	if poolRedisKey == "" {
+		poolRedisKey = "llm:provision:anthropic:available"
+	}
+
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" && yamlConfig.Features.CircuitBreaker.Redis != nil {
+		redisURL = os.ExpandEnv(yamlConfig.Features.CircuitBreaker.Redis.URL)
+	}
+	if redisURL == "" {
+		fmt.Fprintf(os.Stderr, "REDIS_URL is required for pool operations\n")
+		os.Exit(1)
+	}
+
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "redis url: %v\n", err)
+		os.Exit(1)
+	}
+	rdb := redis.NewClient(opts)
+	ctx := context.Background()
+
+	switch subcmd {
+	case "add":
+		if strings.TrimSpace(*key) == "" {
+			fmt.Fprintf(os.Stderr, "pool add requires --key\n")
+			os.Exit(1)
+		}
+		if err := provision.PoolAdd(ctx, rdb, poolRedisKey, *key); err != nil {
+			fmt.Fprintf(os.Stderr, "pool add: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Added key to %s\n", poolRedisKey)
+	case "status":
+		n, err := provision.PoolLen(ctx, rdb, poolRedisKey)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "pool status: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("anthropic pool %s: %d available\n", poolRedisKey, n)
+	default:
+		printPoolUsage()
+		os.Exit(1)
+	}
+}
+
+func printPoolUsage() {
+	fmt.Fprintf(os.Stderr, "Usage:\n")
+	fmt.Fprintf(os.Stderr, "  %s pool add --provider anthropic --key sk-ant-api03-...\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s pool status --provider anthropic\n", os.Args[0])
+}

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/middleware"
 	"github.com/Instawork/llm-proxy/internal/pii"
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/provision"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/Instawork/llm-proxy/internal/ratelimitstats"
 	"github.com/Instawork/llm-proxy/internal/redact"
@@ -105,6 +106,7 @@ var globalCostStatsRecorder *coststats.Recorder
 var (
 	globalAPIKeyStore          providers.APIKeyStore
 	globalAPIKeyStoreInitError error
+	globalKeyProvisioner       *provision.Manager
 )
 
 // Global rate limiter instance
@@ -1202,6 +1204,17 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	// Initialize API key store if enabled
 	globalAPIKeyStore = initializeAPIKeyStore(yamlConfig)
 
+	provRT := provision.RuntimeFromYAML(yamlConfig.Features.APIKeyManagement.Provisioning)
+	keyProvisioner, provErr := provision.NewManagerFromRuntime(provRT, logger)
+	if provErr != nil {
+		logger.Error("Key provisioning disabled: setup failed", "error", provErr)
+	} else {
+		globalKeyProvisioner = keyProvisioner
+		if keyProvisioner.Enabled() {
+			logger.Info("Key provisioning: ENABLED")
+		}
+	}
+
 	// Initialize rate limiter if enabled
 	if yamlConfig.Features.RateLimiting.Enabled {
 		lim, err := ratelimit.Factory(yamlConfig)
@@ -1441,6 +1454,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			UsageSummary:     usageSummaryFunc(),
 			RateLimitSummary: rateLimitSummaryFunc(),
 			CircuitActivity:  circuitActivitySummaryFunc(),
+			KeyProvisioner:   globalKeyProvisioner,
 		})
 		logger.Info("Admin dashboard: ENABLED")
 	}

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -28,12 +28,11 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys-dev"
     region: "us-west-2"
-    # New keys are minted as "iw_<random>"; legacy "iw:" keys still validate.
+    # New keys are minted as "iw-<random>"; legacy "iw_" and "iw:" keys still validate.
     key_prefix: "iw"
-    # Dev only — auto-creates the DynamoDB table against whatever AWS
-    # creds are active. Staging/production must leave this false and
-    # pre-provision the table via Terraform.
     auto_create_table: true
+    provisioning:
+      enabled: false
   circuit_breaker:
     enabled: true
     backend: "redis"

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -31,8 +31,19 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys"
     region: "us-west-2"
-    # New keys are minted as "iw_<random>"; legacy "iw:" keys still validate.
+    # New keys are minted as "iw-<random>"; legacy "iw_" and "iw:" keys still validate.
     key_prefix: "iw"
+    provisioning:
+      enabled: true
+      openai:
+        enabled: true
+        project_id: "${LLM_PROXY_OPENAI_PROJECT_ID}"
+      gemini:
+        enabled: true
+        gcp_project_id: "${LLM_PROXY_GCP_PROJECT_ID}"
+      anthropic:
+        enabled: true
+        pool_redis_key: "llm:provision:anthropic:available"
   # Circuit breaker: enforce mode.  Retries transient failures (up to
   # max_transient_retries), fast-fails open circuits with a synthetic 503,
   # and counts retry contributions toward the failure window.

--- a/configs/staging.yml
+++ b/configs/staging.yml
@@ -18,8 +18,10 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys-staging"
     region: "us-west-2"
-    # New keys are minted as "iw_<random>"; legacy "iw:" keys still validate.
+    # New keys are minted as "iw-<random>"; legacy "iw_" and "iw:" keys still validate.
     key_prefix: "iw"
+    provisioning:
+      enabled: false
   # Circuit breaker: enforce mode (matching production).
   circuit_breaker:
     enabled: true

--- a/internal/admin/dashboard_handlers_test.go
+++ b/internal/admin/dashboard_handlers_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
-	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/circuitstats"
+	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/coststats"
 	"github.com/Instawork/llm-proxy/internal/pii"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"

--- a/internal/admin/deps.go
+++ b/internal/admin/deps.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/provision"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 )
 
@@ -22,4 +23,5 @@ type Deps struct {
 	UsageSummary     func() map[string]interface{}
 	RateLimitSummary func() map[string]interface{}
 	CircuitActivity  func() map[string]interface{}
+	KeyProvisioner   *provision.Manager
 }

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/provision"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/gorilla/mux"
 )
@@ -110,8 +112,8 @@ func (h *handler) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
 		return
 	}
-	if req.Provider == "" || req.ActualKey == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider and actual_key are required"})
+	if req.Provider == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider is required"})
 		return
 	}
 	if err := apikeys.ValidatePIIOffBedrockPolicy(
@@ -124,14 +126,51 @@ func (h *handler) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	key, err := h.deps.APIKeyStore.CreateKey(
+	actualKey := strings.TrimSpace(req.ActualKey)
+	var meta apikeys.KeyCreateMeta
+
+	if req.AutoProvision {
+		if h.deps.KeyProvisioner == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "key provisioning is not configured"})
+			return
+		}
+		if _, ok := h.deps.KeyProvisioner.ForProvider(req.Provider); !ok {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error": "auto_provision is not available for provider " + req.Provider,
+			})
+			return
+		}
+		provName := "llm-proxy:" + provision.SanitizeName(req.Description)
+		res, err := h.deps.KeyProvisioner.Provision(r.Context(), req.Provider, provName)
+		if err != nil {
+			if errors.Is(err, provision.ErrEmptyPool) {
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+				return
+			}
+			h.deps.Logger.Error("admin: provision upstream key failed", "provider", req.Provider, "error", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "failed to provision upstream key"})
+			return
+		}
+		actualKey = res.ActualKey
+		meta = apikeys.KeyCreateMeta{
+			Provisioned:   true,
+			UpstreamKeyID: res.UpstreamID,
+			UpstreamKind:  res.UpstreamKind,
+		}
+	} else if actualKey == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "actual_key is required unless auto_provision is true"})
+		return
+	}
+
+	key, err := h.deps.APIKeyStore.CreateKeyWithMeta(
 		r.Context(),
 		req.Provider,
-		req.ActualKey,
+		actualKey,
 		req.Description,
 		req.DailyCostLimit,
 		req.Tags,
 		req.RedactPII,
+		meta,
 		apikeys.KeyRateLimits{
 			RPM: req.RateLimitRPM,
 			TPM: req.RateLimitTPM,
@@ -272,6 +311,32 @@ func (h *handler) handleDeleteKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyID := mux.Vars(r)["key"]
+	record, err := h.deps.APIKeyStore.GetKeyRecord(r.Context(), keyID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "key not found"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if record.Provisioned && h.deps.KeyProvisioner != nil {
+		if revokeErr := h.deps.KeyProvisioner.Revoke(
+			r.Context(),
+			record.Provider,
+			record.UpstreamKeyID,
+			record.UpstreamKind,
+		); revokeErr != nil {
+			h.deps.Logger.Warn("admin: upstream revoke failed",
+				"key", keyID,
+				"provider", record.Provider,
+				"upstream_id", record.UpstreamKeyID,
+				"error", revokeErr,
+			)
+		}
+	}
+
 	if err := h.deps.APIKeyStore.DeleteKey(r.Context(), keyID); err != nil {
 		if strings.Contains(err.Error(), "ConditionalCheckFailed") {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "key not found"})
@@ -282,6 +347,33 @@ func (h *handler) handleDeleteKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handler) handleProvisioning(w http.ResponseWriter, r *http.Request) {
+	if h.deps.KeyProvisioner == nil {
+		writeJSON(w, http.StatusOK, ProvisioningResponse{Enabled: false})
+		return
+	}
+	raw := h.deps.KeyProvisioner.Status(r.Context())
+	resp := ProvisioningResponse{Enabled: false}
+	if enabled, ok := raw["enabled"].(bool); ok {
+		resp.Enabled = enabled
+	}
+	if providers, ok := raw["providers"].(map[string]interface{}); ok {
+		resp.Providers = make(map[string]ProvisioningProvider, len(providers))
+		for name, entry := range providers {
+			m, _ := entry.(map[string]interface{})
+			p := ProvisioningProvider{}
+			if v, ok := m["auto_provision"].(bool); ok {
+				p.AutoProvision = v
+			}
+			if v, ok := m["pool_available"].(int); ok {
+				p.PoolAvailable = v
+			}
+			resp.Providers[name] = p
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *handler) handleConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -65,6 +65,7 @@ func RegisterRoutes(r *mux.Router, deps Deps) {
 	api.HandleFunc("/me", h.handleMe).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/keys", h.handleListKeys).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/keys", h.handleCreateKey).Methods(http.MethodPost, http.MethodOptions)
+	api.HandleFunc("/provisioning", h.handleProvisioning).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/keys/{key:.+}", h.handleGetKey).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/keys/{key:.+}", h.handleUpdateKey).Methods(http.MethodPatch, http.MethodOptions)
 	api.HandleFunc("/keys/{key:.+}", h.handleDeleteKey).Methods(http.MethodDelete, http.MethodOptions)

--- a/internal/admin/types.go
+++ b/internal/admin/types.go
@@ -36,12 +36,14 @@ type KeyResponse struct {
 	UpdatedAt      time.Time         `json:"updated_at"`
 	ExpiresAt      *time.Time        `json:"expires_at,omitempty"`
 	ActualKey      string            `json:"actual_key,omitempty"`
+	Provisioned    bool              `json:"provisioned,omitempty"`
 }
 
 // CreateKeyRequest creates a new proxy API key.
 type CreateKeyRequest struct {
 	Provider       string            `json:"provider"`
-	ActualKey      string            `json:"actual_key"`
+	ActualKey      string            `json:"actual_key,omitempty"`
+	AutoProvision  bool              `json:"auto_provision,omitempty"`
 	Description    string            `json:"description,omitempty"`
 	DailyCostLimit int64             `json:"daily_cost_limit"`
 	Tags           map[string]string `json:"tags,omitempty"`
@@ -110,6 +112,18 @@ type RateLimitsResponse struct {
 	Stats     map[string]interface{}    `json:"stats,omitempty"`
 }
 
+// ProvisioningResponse summarizes auto-provision availability for the admin UI.
+type ProvisioningResponse struct {
+	Enabled   bool                            `json:"enabled"`
+	Providers map[string]ProvisioningProvider `json:"providers,omitempty"`
+}
+
+// ProvisioningProvider describes per-provider auto-provision status.
+type ProvisioningProvider struct {
+	AutoProvision bool `json:"auto_provision"`
+	PoolAvailable int  `json:"pool_available,omitempty"`
+}
+
 func keyToResponse(k *apikeys.APIKey, includeActualKey bool) KeyResponse {
 	resp := KeyResponse{
 		Key:            k.PK,
@@ -130,5 +144,6 @@ func keyToResponse(k *apikeys.APIKey, includeActualKey bool) KeyResponse {
 	if includeActualKey {
 		resp.ActualKey = maskedActualKey
 	}
+	resp.Provisioned = k.Provisioned
 	return resp
 }

--- a/internal/apikeys/store.go
+++ b/internal/apikeys/store.go
@@ -23,12 +23,13 @@ const (
 	KeyLength = 32
 
 	// DefaultKeyPrefixBase is the default prefix base (without separator).
-	// New keys are generated as "<base>_<hex>"; both the current "<base>_"
-	// and the legacy "<base>:" separator are accepted on lookup.
+	// New keys are generated as "<base>-<hex>"; legacy "<base>_",
+	// "<base>:", and "<base>-" forms are accepted on lookup.
 	DefaultKeyPrefixBase = "iw"
 
-	keyPrefixSepNew    = "_"
-	keyPrefixSepLegacy = ":"
+	keyPrefixSepNew              = "-"
+	keyPrefixSepLegacyUnderscore = "_"
+	keyPrefixSepLegacyColon      = ":"
 )
 
 var (
@@ -36,28 +37,28 @@ var (
 	// e.g. "iw". Set once at startup via SetKeyPrefixBase.
 	keyPrefixBase = DefaultKeyPrefixBase
 
-	// KeyPrefix is the prefix used to GENERATE new keys ("<base>_").
+	// KeyPrefix is the prefix used to GENERATE new keys ("<base>-").
 	// Exported for backwards compatibility with callers/tests that build
 	// keys as KeyPrefix+"...". Do NOT use it to decide whether a string is
-	// one of our keys — that must accept the legacy ":" separator too, so
-	// use HasKeyPrefix / TrimKeyPrefix instead.
+	// one of our keys — that must accept legacy separators too, so use
+	// HasKeyPrefix / TrimKeyPrefix instead.
 	KeyPrefix = keyPrefixBase + keyPrefixSepNew
 
 	// acceptedKeyPrefixes lists every prefix recognized as one of our proxy
 	// keys, current separator first. Kept in sync by SetKeyPrefixBase.
 	acceptedKeyPrefixes = []string{
 		keyPrefixBase + keyPrefixSepNew,
-		keyPrefixBase + keyPrefixSepLegacy,
+		keyPrefixBase + keyPrefixSepLegacyUnderscore,
+		keyPrefixBase + keyPrefixSepLegacyColon,
 	}
 )
 
 // SetKeyPrefixBase configures the proxy key prefix base (e.g. "iw"). New
-// keys are then generated as "<base>_<hex>", while lookups continue to
-// accept both the current "<base>_" form and the legacy "<base>:" form for
-// keys minted before the separator change. A blank base is ignored so a
-// missing config value falls back to the default. Call once at startup
-// before serving traffic — it is not safe to call concurrently with key
-// operations.
+// keys are then generated as "<base>-<hex>", while lookups continue to
+// accept "<base>-", "<base>_", and "<base>:" for keys minted under older
+// separators. A blank base is ignored so a missing config value falls back
+// to the default. Call once at startup before serving traffic — it is not
+// safe to call concurrently with key operations.
 func SetKeyPrefixBase(base string) {
 	base = strings.TrimSpace(base)
 	if base == "" {
@@ -67,15 +68,16 @@ func SetKeyPrefixBase(base string) {
 	KeyPrefix = base + keyPrefixSepNew
 	acceptedKeyPrefixes = []string{
 		base + keyPrefixSepNew,
-		base + keyPrefixSepLegacy,
+		base + keyPrefixSepLegacyUnderscore,
+		base + keyPrefixSepLegacyColon,
 	}
 }
 
 // KeyPrefixBase returns the configured prefix base (without separator).
 func KeyPrefixBase() string { return keyPrefixBase }
 
-// HasKeyPrefix reports whether k carries a recognized proxy-key prefix —
-// either the current "<base>_" or the legacy "<base>:" form.
+// HasKeyPrefix reports whether k carries a recognized proxy-key prefix
+// (current "<base>-" or legacy "<base>_" / "<base>:").
 func HasKeyPrefix(k string) bool {
 	_, ok := matchedKeyPrefix(k)
 	return ok
@@ -172,6 +174,13 @@ type APIKey struct {
 	RateLimitTPM int `dynamodbav:"rate_limit_tpm,omitempty"` // tokens / minute
 	RateLimitRPD int `dynamodbav:"rate_limit_rpd,omitempty"` // requests / day
 	RateLimitTPD int `dynamodbav:"rate_limit_tpd,omitempty"` // tokens / day
+	// Provisioned is true when actual_key was minted by the provisioner.
+	Provisioned bool `dynamodbav:"provisioned,omitempty"`
+	// UpstreamKeyID identifies the vendor credential for revoke (service
+	// account id, GCP key name, etc.).
+	UpstreamKeyID string `dynamodbav:"upstream_key_id,omitempty"`
+	// UpstreamKind classifies the upstream credential for revoke handlers.
+	UpstreamKind string `dynamodbav:"upstream_kind,omitempty"`
 }
 
 // KeyRateLimits carries optional per-key rate-limit overrides for CreateKey.
@@ -335,8 +344,15 @@ func (s *Store) ensureTableExists(ctx context.Context) error {
 	return nil
 }
 
+// KeyCreateMeta carries optional auto-provision metadata for CreateKey.
+type KeyCreateMeta struct {
+	Provisioned   bool
+	UpstreamKeyID string
+	UpstreamKind  string
+}
+
 // GenerateKey generates a new API key using the current generation prefix
-// ("<base>_", e.g. "iw_").
+// ("<base>-", e.g. "iw-").
 func GenerateKey() (string, error) {
 	bytes := make([]byte, KeyLength)
 	if _, err := rand.Read(bytes); err != nil {
@@ -347,6 +363,11 @@ func GenerateKey() (string, error) {
 
 // CreateKey creates a new API key record.
 func (s *Store) CreateKey(ctx context.Context, provider, actualKey, description string, dailyCostLimit int64, tags map[string]string, redactPII *bool, rateLimits ...KeyRateLimits) (*APIKey, error) {
+	return s.CreateKeyWithMeta(ctx, provider, actualKey, description, dailyCostLimit, tags, redactPII, KeyCreateMeta{}, rateLimits...)
+}
+
+// CreateKeyWithMeta creates a new API key record with optional provision metadata.
+func (s *Store) CreateKeyWithMeta(ctx context.Context, provider, actualKey, description string, dailyCostLimit int64, tags map[string]string, redactPII *bool, meta KeyCreateMeta, rateLimits ...KeyRateLimits) (*APIKey, error) {
 	// Generate new key
 	newKey, err := GenerateKey()
 	if err != nil {
@@ -374,6 +395,9 @@ func (s *Store) CreateKey(ctx context.Context, provider, actualKey, description 
 		RateLimitTPM:   rl.TPM,
 		RateLimitRPD:   rl.RPD,
 		RateLimitTPD:   rl.TPD,
+		Provisioned:    meta.Provisioned,
+		UpstreamKeyID:  meta.UpstreamKeyID,
+		UpstreamKind:   meta.UpstreamKind,
 	}
 
 	// Marshal to DynamoDB attribute values

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -364,11 +364,39 @@ type APIKeyManagementConfig struct {
 	// pre-provision the table via Terraform and leave this false.
 	AutoCreateTable bool `yaml:"auto_create_table"`
 	// KeyPrefix is the prefix base (without separator, e.g. "iw") used for
-	// proxy API keys. New keys are generated as "<base>_<random>", and both
-	// the current "<base>_" and legacy "<base>:" separators are accepted on
-	// lookup. Blank falls back to apikeys.DefaultKeyPrefixBase. Overridable
-	// at runtime via the LLM_PROXY_API_KEY_PREFIX env var.
+	// proxy API keys. New keys are generated as "<base>-<random>", and
+	// "<base>-", "<base>_", and "<base>:" are accepted on lookup. Blank
+	// falls back to apikeys.DefaultKeyPrefixBase. Overridable at runtime
+	// via the LLM_PROXY_API_KEY_PREFIX env var.
 	KeyPrefix string `yaml:"key_prefix"`
+	// Provisioning configures automatic upstream key minting for the admin UI.
+	Provisioning KeyProvisioningConfig `yaml:"provisioning,omitempty"`
+}
+
+// KeyProvisioningConfig controls server-side upstream API key creation.
+type KeyProvisioningConfig struct {
+	Enabled   bool                        `yaml:"enabled"`
+	OpenAI    OpenAIProvisioningConfig    `yaml:"openai,omitempty"`
+	Gemini    GeminiProvisioningConfig    `yaml:"gemini,omitempty"`
+	Anthropic AnthropicProvisioningConfig `yaml:"anthropic,omitempty"`
+}
+
+// OpenAIProvisioningConfig mints keys via the OpenAI Admin API.
+type OpenAIProvisioningConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	ProjectID string `yaml:"project_id"`
+}
+
+// GeminiProvisioningConfig mints keys via the GCP API Keys API.
+type GeminiProvisioningConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	GCPProjectID string `yaml:"gcp_project_id"`
+}
+
+// AnthropicProvisioningConfig assigns keys from a Redis-backed pool.
+type AnthropicProvisioningConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	PoolRedisKey string `yaml:"pool_redis_key"`
 }
 
 // RateLimitingConfig represents rate limiting feature configuration

--- a/internal/provision/anthropic_pool.go
+++ b/internal/provision/anthropic_pool.go
@@ -1,0 +1,108 @@
+package provision
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+// AnthropicPool assigns pre-created Anthropic API keys from a Redis list.
+type AnthropicPool struct {
+	rdb      *redis.Client
+	listKey  string
+	adminKey string
+	client   *http.Client
+}
+
+// NewAnthropicPool returns a pool provisioner. adminKey is optional for revoke.
+func NewAnthropicPool(rdb *redis.Client, listKey, adminKey string) *AnthropicPool {
+	if listKey == "" {
+		listKey = "llm:provision:anthropic:available"
+	}
+	return &AnthropicPool{
+		rdb:      rdb,
+		listKey:  listKey,
+		adminKey: adminKey,
+		client:   &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (p *AnthropicPool) Provision(ctx context.Context, name string) (Result, error) {
+	_ = name
+	key, err := p.rdb.LPop(ctx, p.listKey).Result()
+	if err == redis.Nil || key == "" {
+		return Result{}, fmt.Errorf("%w — refill via llm-proxy-keys pool add", errEmptyPool)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		ActualKey:    key,
+		UpstreamKind: UpstreamKindAnthropicPooled,
+	}, nil
+}
+
+func (p *AnthropicPool) Revoke(ctx context.Context, upstreamID, upstreamKind string) error {
+	if upstreamKind != UpstreamKindAnthropicPooled || p.adminKey == "" || upstreamID == "" {
+		return nil
+	}
+	body, _ := json.Marshal(map[string]string{"status": "archived"})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.anthropic.com/v1/organizations/api_keys/"+upstreamID,
+		bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("x-api-key", p.adminKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("anthropic revoke: status %d: %s", resp.StatusCode, truncate(raw, 300))
+	}
+	return nil
+}
+
+func (p *AnthropicPool) PoolStatus(ctx context.Context) (int, bool) {
+	n, err := p.rdb.LLen(ctx, p.listKey).Result()
+	if err != nil {
+		return 0, true
+	}
+	return int(n), true
+}
+
+// PoolAdd pushes a key onto the Anthropic pool (ops / CLI).
+func PoolAdd(ctx context.Context, rdb *redis.Client, listKey, key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return fmt.Errorf("empty key")
+	}
+	if listKey == "" {
+		listKey = "llm:provision:anthropic:available"
+	}
+	return rdb.RPush(ctx, listKey, key).Err()
+}
+
+// PoolLen returns the number of keys available in the pool.
+func PoolLen(ctx context.Context, rdb *redis.Client, listKey string) (int64, error) {
+	if listKey == "" {
+		listKey = "llm:provision:anthropic:available"
+	}
+	return rdb.LLen(ctx, listKey).Result()
+}

--- a/internal/provision/anthropic_pool_test.go
+++ b/internal/provision/anthropic_pool_test.go
@@ -1,0 +1,69 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	redis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicPool_ProvisionEmpty(t *testing.T) {
+	t.Parallel()
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	p := NewAnthropicPool(rdb, "llm:provision:anthropic:available", "")
+
+	_, err = p.Provision(context.Background(), "test")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEmptyPool))
+}
+
+func TestAnthropicPool_ProvisionAndStatus(t *testing.T) {
+	t.Parallel()
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+
+	listKey := "llm:provision:anthropic:available"
+	mr.Lpush(listKey, "sk-ant-api03-test")
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	p := NewAnthropicPool(rdb, listKey, "")
+
+	res, err := p.Provision(context.Background(), "test")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-ant-api03-test", res.ActualKey)
+	assert.Equal(t, UpstreamKindAnthropicPooled, res.UpstreamKind)
+
+	n, ok := p.PoolStatus(context.Background())
+	assert.True(t, ok)
+	assert.Equal(t, 0, n)
+}
+
+func TestPoolAddAndLen(t *testing.T) {
+	t.Parallel()
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	ctx := context.Background()
+	listKey := "llm:provision:anthropic:available"
+
+	require.NoError(t, PoolAdd(ctx, rdb, listKey, "sk-ant-one"))
+	require.NoError(t, PoolAdd(ctx, rdb, listKey, "sk-ant-two"))
+
+	n, err := PoolLen(ctx, rdb, listKey)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+}

--- a/internal/provision/config.go
+++ b/internal/provision/config.go
@@ -1,0 +1,117 @@
+package provision
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+	redis "github.com/redis/go-redis/v9"
+)
+
+// RuntimeConfig is resolved provisioning configuration (secrets from env).
+type RuntimeConfig struct {
+	Enabled bool
+
+	OpenAIEnabled   bool
+	OpenAIAdminKey  string
+	OpenAIProjectID string
+
+	GeminiEnabled      bool
+	GCPProjectID       string
+	GCPCredentialsJSON string
+
+	AnthropicEnabled  bool
+	AnthropicAdminKey string
+	AnthropicPoolKey  string
+
+	RedisURL string
+}
+
+// RuntimeFromYAML builds runtime config from YAML + environment.
+func RuntimeFromYAML(cfg config.KeyProvisioningConfig) RuntimeConfig {
+	rt := RuntimeConfig{
+		Enabled:          cfg.Enabled,
+		OpenAIEnabled:    cfg.OpenAI.Enabled,
+		OpenAIProjectID:  os.ExpandEnv(cfg.OpenAI.ProjectID),
+		GeminiEnabled:    cfg.Gemini.Enabled,
+		GCPProjectID:     os.ExpandEnv(cfg.Gemini.GCPProjectID),
+		AnthropicEnabled: cfg.Anthropic.Enabled,
+		AnthropicPoolKey: cfg.Anthropic.PoolRedisKey,
+	}
+	if rt.AnthropicPoolKey == "" {
+		rt.AnthropicPoolKey = "llm:provision:anthropic:available"
+	}
+
+	rt.OpenAIAdminKey = os.Getenv("LLM_PROXY_OPENAI_ADMIN_KEY")
+	if v := os.Getenv("LLM_PROXY_OPENAI_PROJECT_ID"); v != "" {
+		rt.OpenAIProjectID = v
+	}
+	rt.GCPCredentialsJSON = os.Getenv("LLM_PROXY_GCP_CREDENTIALS_JSON")
+	if v := os.Getenv("LLM_PROXY_GCP_PROJECT_ID"); v != "" {
+		rt.GCPProjectID = v
+	}
+	rt.AnthropicAdminKey = os.Getenv("LLM_PROXY_ANTHROPIC_ADMIN_KEY")
+	rt.RedisURL = os.Getenv("REDIS_URL")
+
+	return rt
+}
+
+// NewManagerFromRuntime constructs a Manager from resolved runtime config.
+func NewManagerFromRuntime(rt RuntimeConfig, logger *slog.Logger) (*Manager, error) {
+	if !rt.Enabled {
+		return NewManager(nil, nil), nil
+	}
+
+	byProvider := map[string]Provisioner{}
+
+	if rt.OpenAIEnabled && rt.OpenAIAdminKey != "" && rt.OpenAIProjectID != "" {
+		byProvider["openai"] = NewOpenAI(rt.OpenAIAdminKey, rt.OpenAIProjectID, "")
+	}
+
+	if rt.GeminiEnabled && rt.GCPProjectID != "" && rt.GCPCredentialsJSON != "" {
+		g, err := NewGemini(rt.GCPProjectID, []byte(rt.GCPCredentialsJSON), "")
+		if err != nil {
+			return nil, fmt.Errorf("gemini provisioner: %w", err)
+		}
+		byProvider["gemini"] = g
+	}
+
+	if rt.AnthropicEnabled && rt.RedisURL != "" {
+		opts, err := redis.ParseURL(rt.RedisURL)
+		if err != nil {
+			return nil, fmt.Errorf("anthropic pool redis url: %w", err)
+		}
+		client := redis.NewClient(opts)
+		byProvider["anthropic"] = NewAnthropicPool(client, rt.AnthropicPoolKey, rt.AnthropicAdminKey)
+	}
+
+	return NewManager(logger, byProvider), nil
+}
+
+// SanitizeName makes a vendor-safe resource name from a description.
+func SanitizeName(description string) string {
+	description = strings.TrimSpace(description)
+	if description == "" {
+		return "llm-proxy-key"
+	}
+	var b strings.Builder
+	b.Grow(len(description))
+	for _, r := range description {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ', r == '-', r == '_', r == '.':
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "llm-proxy-key"
+	}
+	if len(out) > 64 {
+		out = out[:64]
+	}
+	return out
+}

--- a/internal/provision/gemini.go
+++ b/internal/provision/gemini.go
@@ -1,0 +1,190 @@
+package provision
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// Gemini provisions GCP API keys restricted to the Generative Language API.
+type Gemini struct {
+	projectID string
+	tokenSrc  oauth2.TokenSource
+	client    *http.Client
+	baseURL   string
+}
+
+// NewGemini returns a Gemini provisioner. baseURL is for tests only.
+func NewGemini(projectID string, credsJSON []byte, baseURL string) (*Gemini, error) {
+	ctx := context.Background()
+	creds, err := google.CredentialsFromJSON(ctx, credsJSON, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, err
+	}
+	if baseURL == "" {
+		baseURL = "https://apikeys.googleapis.com/v2"
+	}
+	return &Gemini{
+		projectID: projectID,
+		tokenSrc:  creds.TokenSource,
+		client:    &http.Client{Timeout: 90 * time.Second},
+		baseURL:   strings.TrimRight(baseURL, "/"),
+	}, nil
+}
+
+func (g *Gemini) Provision(ctx context.Context, name string) (Result, error) {
+	createBody := map[string]interface{}{
+		"displayName": SanitizeName(name),
+		"restrictions": map[string]interface{}{
+			"apiTargets": []map[string]string{
+				{"service": "generativelanguage.googleapis.com"},
+			},
+		},
+	}
+	payload, _ := json.Marshal(createBody)
+	path := fmt.Sprintf("/projects/%s/locations/global/keys", g.projectID)
+
+	opName, err := g.postJSON(ctx, path, payload)
+	if err != nil {
+		return Result{}, err
+	}
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		keyName, keyString, done, err := g.pollOperation(ctx, opName)
+		if err != nil {
+			return Result{}, err
+		}
+		if done {
+			if keyString == "" {
+				return Result{}, fmt.Errorf("gemini provision: empty keyString")
+			}
+			return Result{
+				ActualKey:    keyString,
+				UpstreamID:   keyName,
+				UpstreamKind: UpstreamKindGCPAPIKey,
+			}, nil
+		}
+		select {
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return Result{}, fmt.Errorf("gemini provision: operation timed out")
+}
+
+func (g *Gemini) Revoke(ctx context.Context, upstreamID, upstreamKind string) error {
+	if upstreamKind != UpstreamKindGCPAPIKey || upstreamID == "" {
+		return nil
+	}
+	path := "/" + strings.TrimPrefix(upstreamID, "/")
+	req, err := g.newRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("gemini revoke: status %d: %s", resp.StatusCode, truncate(raw, 300))
+	}
+	return nil
+}
+
+func (g *Gemini) PoolStatus(context.Context) (int, bool) { return 0, false }
+
+func (g *Gemini) postJSON(ctx context.Context, path string, body []byte) (string, error) {
+	req, err := g.newRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return "", err
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("gemini create: status %d: %s", resp.StatusCode, truncate(raw, 300))
+	}
+	var op struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &op); err != nil {
+		return "", err
+	}
+	if op.Name == "" {
+		return "", fmt.Errorf("gemini create: missing operation name")
+	}
+	return op.Name, nil
+}
+
+func (g *Gemini) pollOperation(ctx context.Context, opName string) (keyName, keyString string, done bool, err error) {
+	path := "/" + strings.TrimPrefix(opName, "/")
+	req, err := g.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", "", false, err
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", "", false, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", false, fmt.Errorf("gemini operation: status %d: %s", resp.StatusCode, truncate(raw, 300))
+	}
+	var op struct {
+		Done     bool `json:"done"`
+		Response struct {
+			Name      string `json:"name"`
+			KeyString string `json:"keyString"`
+		} `json:"response"`
+		Error interface{} `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &op); err != nil {
+		return "", "", false, err
+	}
+	if op.Error != nil {
+		return "", "", false, fmt.Errorf("gemini operation failed: %v", op.Error)
+	}
+	if !op.Done {
+		return "", "", false, nil
+	}
+	return op.Response.Name, op.Response.KeyString, true, nil
+}
+
+func (g *Gemini) newRequest(ctx context.Context, method, path string, body []byte) (*http.Request, error) {
+	tok, err := g.tokenSrc.Token()
+	if err != nil {
+		return nil, err
+	}
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, g.baseURL+path, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
+}

--- a/internal/provision/openai.go
+++ b/internal/provision/openai.go
@@ -1,0 +1,113 @@
+package provision
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const openAIBaseURL = "https://api.openai.com/v1"
+
+// OpenAI provisions project service accounts via the Admin API.
+type OpenAI struct {
+	adminKey  string
+	projectID string
+	baseURL   string
+	client    *http.Client
+}
+
+// NewOpenAI returns an OpenAI provisioner. baseURL is for tests only.
+func NewOpenAI(adminKey, projectID, baseURL string) *OpenAI {
+	if baseURL == "" {
+		baseURL = openAIBaseURL
+	}
+	return &OpenAI{
+		adminKey:  adminKey,
+		projectID: projectID,
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		client:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (o *OpenAI) Provision(ctx context.Context, name string) (Result, error) {
+	path := fmt.Sprintf("/organization/projects/%s/service_accounts", o.projectID)
+	body, _ := json.Marshal(map[string]string{"name": SanitizeName(name)})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+o.adminKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return Result{}, err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Result{}, fmt.Errorf("openai provision: status %d: %s", resp.StatusCode, truncate(raw, 300))
+	}
+
+	var parsed struct {
+		ID     string `json:"id"`
+		APIKey struct {
+			Value string `json:"value"`
+			ID    string `json:"id"`
+		} `json:"api_key"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return Result{}, fmt.Errorf("openai provision: decode: %w", err)
+	}
+	if parsed.APIKey.Value == "" {
+		return Result{}, fmt.Errorf("openai provision: empty api_key in response")
+	}
+	return Result{
+		ActualKey:    parsed.APIKey.Value,
+		UpstreamID:   parsed.ID,
+		UpstreamKind: UpstreamKindOpenAIServiceAccount,
+		ProviderMeta: map[string]string{"openai_key_id": parsed.APIKey.ID},
+	}, nil
+}
+
+func (o *OpenAI) Revoke(ctx context.Context, upstreamID, upstreamKind string) error {
+	if upstreamKind != UpstreamKindOpenAIServiceAccount || upstreamID == "" {
+		return nil
+	}
+	path := fmt.Sprintf("/organization/projects/%s/service_accounts/%s", o.projectID, upstreamID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, o.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+o.adminKey)
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("openai revoke: status %d: %s", resp.StatusCode, truncate(raw, 300))
+	}
+	return nil
+}
+
+func (o *OpenAI) PoolStatus(context.Context) (int, bool) { return 0, false }
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n])
+}

--- a/internal/provision/openai_test.go
+++ b/internal/provision/openai_test.go
@@ -1,0 +1,53 @@
+package provision
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAI_ProvisionAndRevoke(t *testing.T) {
+	t.Parallel()
+
+	var deleted string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/organization/projects/proj_test/service_accounts":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "sa_123",
+				"api_key": map[string]string{
+					"id":    "key_abc",
+					"value": "sk-test-secret",
+				},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/organization/projects/proj_test/service_accounts/sa_123":
+			deleted = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewOpenAI("admin-key", "proj_test", srv.URL)
+	res, err := p.Provision(context.Background(), "finch-hiring")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-secret", res.ActualKey)
+	assert.Equal(t, "sa_123", res.UpstreamID)
+	assert.Equal(t, UpstreamKindOpenAIServiceAccount, res.UpstreamKind)
+
+	err = p.Revoke(context.Background(), res.UpstreamID, res.UpstreamKind)
+	require.NoError(t, err)
+	assert.NotEmpty(t, deleted)
+}
+
+func TestSanitizeName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "llm-proxy-key", SanitizeName(""))
+	assert.Equal(t, "Finch-Hiring-Assistant", SanitizeName("Finch Hiring Assistant"))
+}

--- a/internal/provision/provisioner.go
+++ b/internal/provision/provisioner.go
@@ -1,0 +1,116 @@
+// Package provision mints upstream provider API keys for proxy key creation.
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+const (
+	UpstreamKindOpenAIServiceAccount = "openai_service_account"
+	UpstreamKindGCPAPIKey            = "gcp_api_key"
+	UpstreamKindAnthropicPooled      = "anthropic_pooled"
+)
+
+// Result is a freshly minted upstream credential.
+type Result struct {
+	ActualKey    string
+	UpstreamID   string
+	UpstreamKind string
+	ProviderMeta map[string]string
+}
+
+// Provisioner mints or assigns an upstream API key for one provider.
+type Provisioner interface {
+	Provision(ctx context.Context, name string) (Result, error)
+	Revoke(ctx context.Context, upstreamID, upstreamKind string) error
+	PoolStatus(ctx context.Context) (available int, ok bool)
+}
+
+// Manager routes provision requests by provider name.
+type Manager struct {
+	byProvider map[string]Provisioner
+	logger     *slog.Logger
+}
+
+// NewManager returns a manager with the given per-provider provisioners.
+func NewManager(logger *slog.Logger, byProvider map[string]Provisioner) *Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if byProvider == nil {
+		byProvider = map[string]Provisioner{}
+	}
+	return &Manager{byProvider: byProvider, logger: logger}
+}
+
+// Enabled reports whether any provider provisioner is configured.
+func (m *Manager) Enabled() bool {
+	return m != nil && len(m.byProvider) > 0
+}
+
+// ForProvider returns the provisioner for a provider, if configured.
+func (m *Manager) ForProvider(provider string) (Provisioner, bool) {
+	if m == nil {
+		return nil, false
+	}
+	p, ok := m.byProvider[provider]
+	return p, ok
+}
+
+// Provision mints an upstream key for the given provider.
+func (m *Manager) Provision(ctx context.Context, provider, name string) (Result, error) {
+	p, ok := m.ForProvider(provider)
+	if !ok {
+		return Result{}, fmt.Errorf("provisioning not configured for provider %q", provider)
+	}
+	res, err := p.Provision(ctx, name)
+	if err != nil {
+		return Result{}, err
+	}
+	if m.logger != nil {
+		m.logger.Info("provision: upstream key minted",
+			"provider", provider,
+			"name", name,
+			"upstream_kind", res.UpstreamKind,
+			"upstream_id", res.UpstreamID,
+		)
+	}
+	return res, nil
+}
+
+// Revoke best-effort revokes an upstream credential.
+func (m *Manager) Revoke(ctx context.Context, provider, upstreamID, upstreamKind string) error {
+	p, ok := m.ForProvider(provider)
+	if !ok {
+		return nil
+	}
+	return p.Revoke(ctx, upstreamID, upstreamKind)
+}
+
+// Status returns provisioning availability per provider for the admin API.
+func (m *Manager) Status(ctx context.Context) map[string]interface{} {
+	out := map[string]interface{}{
+		"enabled": m != nil && m.Enabled(),
+	}
+	if m == nil {
+		return out
+	}
+	providers := make(map[string]interface{}, len(m.byProvider))
+	for name, p := range m.byProvider {
+		entry := map[string]interface{}{"auto_provision": true}
+		if n, ok := p.PoolStatus(ctx); ok {
+			entry["pool_available"] = n
+		}
+		providers[name] = entry
+	}
+	out["providers"] = providers
+	return out
+}
+
+var errEmptyPool = errors.New("anthropic key pool is empty")
+
+// ErrEmptyPool is returned when the Anthropic Redis pool has no keys left.
+var ErrEmptyPool = errEmptyPool

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -10,8 +10,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <script type="module" crossorigin src="/admin/assets/index-x_ZhsMKE.js"></script>
-  <link rel="stylesheet" crossorigin href="/admin/assets/index-CvjezLIW.css">
+  <script type="module" crossorigin src="/admin/assets/index-DHAhObCy.js"></script>
+  <link rel="stylesheet" crossorigin href="/admin/assets/index-i8diTV-m.css">
 </head>
 
 <body>

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -10,6 +10,7 @@ import type {
   HealthResponse,
   CircuitActivityResponse,
   PIIResponse,
+  ProvisioningStatus,
   Provider,
   RateLimitsResponse,
   ShareCreateResponse,
@@ -30,6 +31,7 @@ export const queryKeys = {
   cost: ["admin", "cost"] as const,
   usage: ["admin", "usage"] as const,
   pii: ["admin", "pii"] as const,
+  provisioning: ["admin", "provisioning"] as const,
 };
 
 export function useMe() {
@@ -81,6 +83,13 @@ export function useCircuitActivity() {
     queryFn: () => apiFetch<CircuitActivityResponse>("/admin/api/circuit-activity"),
     refetchInterval,
     refetchIntervalInBackground: true,
+  });
+}
+
+export function useProvisioning() {
+  return useQuery({
+    queryKey: queryKeys.provisioning,
+    queryFn: () => apiFetch<ProvisioningStatus>("/admin/api/provisioning"),
   });
 }
 

--- a/web/src/pages/keys/index.tsx
+++ b/web/src/pages/keys/index.tsx
@@ -20,6 +20,7 @@ import {
   useDeleteKey,
   useKeys,
   useMe,
+  useProvisioning,
   useUpdateKey,
 } from "../../hooks/queries";
 import type {
@@ -123,11 +124,13 @@ export default function KeysPage() {
   const [deleteTarget, setDeleteTarget] = useState<APIKey | null>(null);
   const [editingKey, setEditingKey] = useState<APIKey | null>(null);
   const [form, setForm] = useState<KeyFormState>(defaultForm);
+  const [manualKeyEntry, setManualKeyEntry] = useState(false);
   const [shareResult, setShareResult] = useState<ShareCreateResponse | null>(null);
   const [sharingKey, setSharingKey] = useState<string | null>(null);
 
   const filter = providerFilter || undefined;
   const { data: keys = [], isLoading, error } = useKeys(filter);
+  const { data: provisioning } = useProvisioning();
   const createKey = useCreateKey();
   const updateKey = useUpdateKey();
   const deleteKey = useDeleteKey();
@@ -151,6 +154,16 @@ export default function KeysPage() {
     return ["bedrock"] as Provider[];
   }, [piiOffRequiresBedrock]);
 
+  const providerAutoProvision = Boolean(
+    provisioning?.enabled && provisioning.providers?.[form.provider]?.auto_provision,
+  );
+  const anthropicPoolAvailable = provisioning?.providers?.anthropic?.pool_available;
+  const showAnthropicPoolWarning =
+    form.provider === "anthropic" &&
+    providerAutoProvision &&
+    typeof anthropicPoolAvailable === "number" &&
+    anthropicPoolAvailable < 5;
+
   const onShare = async (record: APIKey) => {
     setSharingKey(record.key);
     try {
@@ -166,6 +179,7 @@ export default function KeysPage() {
   const openCreate = () => {
     setEditingKey(null);
     setForm(defaultForm);
+    setManualKeyEntry(false);
     setModalOpen(true);
   };
 
@@ -190,6 +204,7 @@ export default function KeysPage() {
     setModalOpen(false);
     setEditingKey(null);
     setForm(defaultForm);
+    setManualKeyEntry(false);
   };
 
   const onSubmit = async (event: FormEvent) => {
@@ -211,19 +226,24 @@ export default function KeysPage() {
         });
         push("Key updated", "success");
       } else {
-        if (!form.actual_key.trim()) {
+        const useAutoProvision = providerAutoProvision && !manualKeyEntry;
+        if (!useAutoProvision && !form.actual_key.trim()) {
           push("Provider API key is required", "error");
           return;
         }
         const body: CreateAPIKeyRequest = {
           provider: form.provider,
-          actual_key: form.actual_key,
           description: form.description,
           daily_cost_limit: dailyCostLimit,
           enabled: form.enabled,
           redact_pii: redactPii,
           ...rateLimitsFromForm(form),
         };
+        if (useAutoProvision) {
+          body.auto_provision = true;
+        } else {
+          body.actual_key = form.actual_key;
+        }
         await createKey.mutateAsync(body);
         push("Key created", "success");
       }
@@ -401,7 +421,45 @@ export default function KeysPage() {
                 ) : null}
               </label>
 
-              {!editingKey ? (
+              {!editingKey && providerAutoProvision && !manualKeyEntry ? (
+                <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm text-base-content/80">
+                  Upstream key will be created automatically for {form.provider}.
+                </div>
+              ) : null}
+
+              {showAnthropicPoolWarning ? (
+                <div className="alert alert-warning py-2 text-sm">
+                  Anthropic pool is low ({anthropicPoolAvailable} remaining). Contact ops to refill
+                  the pool.
+                </div>
+              ) : null}
+
+              {!editingKey && providerAutoProvision ? (
+                <details
+                  className="rounded-lg border border-base-300 px-3 py-2"
+                  open={manualKeyEntry}
+                  onToggle={(event) => setManualKeyEntry(event.currentTarget.open)}
+                >
+                  <summary className="cursor-pointer text-sm font-medium">
+                    Advanced: paste provider key
+                  </summary>
+                  <label className="form-control mt-3 w-full">
+                    <span className="label-text">Provider API key</span>
+                    <input
+                      type="password"
+                      autoComplete="new-password"
+                      className="input input-bordered w-full font-mono"
+                      placeholder="sk-..."
+                      value={form.actual_key}
+                      onChange={(event) =>
+                        setForm((current) => ({ ...current, actual_key: event.target.value }))
+                      }
+                    />
+                  </label>
+                </details>
+              ) : null}
+
+              {!editingKey && !providerAutoProvision ? (
                 <label className="form-control w-full">
                   <span className="label-text">Provider API key</span>
                   <input

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -24,11 +24,23 @@ export interface APIKey {
   created_at: string;
   updated_at: string;
   expires_at?: string | null;
+  provisioned?: boolean;
+}
+
+export interface ProvisioningProviderStatus {
+  auto_provision: boolean;
+  pool_available?: number;
+}
+
+export interface ProvisioningStatus {
+  enabled: boolean;
+  providers?: Partial<Record<Provider, ProvisioningProviderStatus>>;
 }
 
 export interface CreateAPIKeyRequest {
   provider: Provider;
-  actual_key: string;
+  actual_key?: string;
+  auto_provision?: boolean;
   description?: string;
   daily_cost_limit?: number;
   enabled?: boolean;


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

- Adds `internal/provision` to mint OpenAI service accounts, GCP Gemini API keys, and Anthropic keys from a Redis pool
- Admin API supports `auto_provision` on key create, `GET /admin/api/provisioning`, and best-effort upstream revoke on delete
- New proxy keys generate as `iw-<hex>` (legacy `iw_` / `iw:` still accepted); admin UI hides the paste field when auto-provision is enabled
- Adds `llm-proxy-keys pool add|status` for Anthropic pool refill

## Test plan

- [x] `go test ./internal/provision/... ./internal/admin/... ./internal/apikeys/...`
- [x] `make check` (fmt, vet)
- [x] `cd web && npm run check && npm run build`
- [x] OSS audit on changed files
- [ ] Enable provisioning in staging with real admin credentials and create a key per provider
- [ ] Refill Anthropic pool via `llm-proxy-keys pool add` and verify low-pool UI warning

## Ops prerequisites

1. Populate new SSM params (see infrastructure `secrets.example.yml`)
2. Pre-seed Anthropic pool before enabling `provisioning.enabled: true` in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic API key provisioning for OpenAI, Gemini, and Anthropic providers during key creation
  * CLI tool for managing Anthropic API key pools (add, status subcommands)
  * Admin dashboard displays provisioning status and per-provider pool availability
  * Web UI supports automatic key provisioning as an alternative to manual entry

* **Configuration**
  * Updated key naming format to use hyphens (iw-<random>) with backward compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->