### PR TITLE
fix(admin): restore circuit breaker dashboard metrics and range-aware history

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -928,6 +928,9 @@ func initAdminRollups(yamlConfig *config.YAMLConfig) {
 	if globalRateLimitStatsRecorder != nil {
 		globalRateLimitStatsRecorder.BindRollup(store, adminrollup.NewPersister(store, adminrollup.MetricRateLimit))
 	}
+	if globalCircuitStatsRecorder != nil {
+		globalCircuitStatsRecorder.BindRollup(store, adminrollup.NewPersister(store, adminrollup.MetricCircuitActivity))
+	}
 	if globalCircuitStore != nil {
 		globalAdminRollupStop = make(chan struct{})
 		go adminrollup.RunCircuitArchiver(
@@ -964,7 +967,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 		perProvider := make(map[string]interface{}, len(circuitBreakerProviders))
 		totalFailures := 0
 		for _, name := range circuitBreakerProviders {
-			stats, err := globalCircuitStore.GetStats(r.Context(), name)
+			stats, err := circuit.ProviderStatsFor(r.Context(), globalCircuitStore, name)
 			if err != nil {
 				// /health is unauthenticated, so we MUST NOT leak the
 				// raw error string (it can contain Redis URLs, host
@@ -1587,6 +1590,9 @@ func gracefulShutdown(server *http.Server) {
 	}
 	if globalRateLimitStatsRecorder != nil {
 		globalRateLimitStatsRecorder.FlushRollup()
+	}
+	if globalCircuitStatsRecorder != nil {
+		globalCircuitStatsRecorder.FlushRollup()
 	}
 	if globalHistorySink != nil {
 		logger.Info("🔄 Flushing history sink...")

--- a/internal/adminrollup/aggregate.go
+++ b/internal/adminrollup/aggregate.go
@@ -61,6 +61,9 @@ func applyDeltaRedis(ctx context.Context, rdb *redis.Client, metric, day string,
 	if err != nil {
 		return err
 	}
+	if len(dimsJSON) == 0 || string(dimsJSON) == "null" {
+		dimsJSON = []byte("{}")
+	}
 	sec := int(ttl.Seconds())
 	if sec <= 0 {
 		sec = int(todayTTL.Seconds())
@@ -313,4 +316,20 @@ func kvFromNameVals(vals []nameVal) []map[string]interface{} {
 		out[i] = map[string]interface{}{"name": v.Name, "count": int64(v.Val)}
 	}
 	return out
+}
+
+func circuitActivityDataFromAggregates(totals map[string]float64, byProvider map[string]float64) map[string]interface{} {
+	byProvOut := make(map[string]int64, len(byProvider))
+	for k, v := range byProvider {
+		byProvOut[k] = int64(v)
+	}
+	return map[string]interface{}{
+		"checks_total":     int64(totals["checks_total"]),
+		"blocked_open":     int64(totals["blocked_open"]),
+		"probes_started":   int64(totals["probes_started"]),
+		"probes_succeeded": int64(totals["probes_succeeded"]),
+		"probes_failed":    int64(totals["probes_failed"]),
+		"circuits_opened":  int64(totals["circuits_opened"]),
+		"by_provider":      byProvOut,
+	}
 }

--- a/internal/adminrollup/circuit.go
+++ b/internal/adminrollup/circuit.go
@@ -104,7 +104,7 @@ func SnapshotCircuit(
 	providerOut := make(map[string]interface{}, len(providers))
 	total := 0
 	for _, name := range providers {
-		stats, err := store.GetStats(ctx, name)
+		stats, err := circuit.ProviderStatsFor(ctx, store, name)
 		if err != nil {
 			continue
 		}

--- a/internal/adminrollup/circuit_activity_test.go
+++ b/internal/adminrollup/circuit_activity_test.go
@@ -1,0 +1,32 @@
+package adminrollup
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeTodayCircuitActivity(t *testing.T) {
+	store := testStore(t)
+	ctx := t.Context()
+	day := time.Now().UTC().Format("2006-01-02")
+
+	err := store.ApplyDelta(ctx, MetricCircuitActivity, day, Delta{
+		Totals: map[string]float64{
+			"checks_total": 5,
+			"blocked_open": 2,
+		},
+	})
+	require.NoError(t, err)
+
+	snap := map[string]interface{}{
+		"checks_total": int64(1),
+		"blocked_open": int64(0),
+	}
+	store.MergeToday(ctx, MetricCircuitActivity, day, snap, TopNCaps{})
+
+	assert.Equal(t, int64(5), snap["checks_total"])
+	assert.Equal(t, int64(2), snap["blocked_open"])
+}

--- a/internal/adminrollup/store.go
+++ b/internal/adminrollup/store.go
@@ -19,11 +19,12 @@ import (
 )
 
 const (
-	MetricCost      = "cost"
-	MetricPII       = "pii"
-	MetricUsage     = "usage"
-	MetricCircuit   = "circuit"
-	MetricRateLimit = "ratelimit"
+	MetricCost            = "cost"
+	MetricPII             = "pii"
+	MetricUsage           = "usage"
+	MetricCircuit         = "circuit"
+	MetricCircuitActivity = "circuit_activity"
+	MetricRateLimit       = "ratelimit"
 
 	keyPrefix = "llm:admin:"
 
@@ -174,6 +175,9 @@ func (s *Store) buildTodayData(ctx context.Context, metric, day string, caps Top
 		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))
 		byKey, _ := s.loadHash(ctx, dimKey(metric, day, "by_key"))
 		return piiDataFromAggregates(totals, byEntity, byProv, byKey, caps), true
+	case MetricCircuitActivity:
+		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))
+		return circuitActivityDataFromAggregates(totals, byProv), true
 	default:
 		return nil, false
 	}

--- a/internal/circuit/memory.go
+++ b/internal/circuit/memory.go
@@ -330,6 +330,35 @@ func (s *MemoryStore) GetStats(_ context.Context, key string) (*ProviderStats, e
 	return stats, nil
 }
 
+// GetProviderStats aggregates failures and worst-case state across every
+// per-model key for provider (see ProviderStatsFor).
+func (s *MemoryStore) GetProviderStats(_ context.Context, provider string) (*ProviderStats, error) {
+	now := s.now()
+	stats := &ProviderStats{State: StateClosed}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for key, e := range s.entries {
+		if !providerKeyMatches(key, provider) {
+			continue
+		}
+		e.mu.Lock()
+		s.pruneFailuresLocked(e, now)
+		stats.Failures += len(e.failures)
+		state := s.stateUnlocked(e)
+		stats.State = worseState(stats.State, state)
+		if state == StateOpen && !e.cooldownUntil.IsZero() {
+			t := e.cooldownUntil
+			if stats.CooldownUntil == nil || t.Before(*stats.CooldownUntil) {
+				stats.CooldownUntil = &t
+			}
+		}
+		e.mu.Unlock()
+	}
+	return stats, nil
+}
+
 // pruneRollupLocked removes rollup events older than the window cutoff.
 // Caller must hold r.mu.
 //

--- a/internal/circuit/memory_test.go
+++ b/internal/circuit/memory_test.go
@@ -195,6 +195,25 @@ func TestMemoryStore_GetStats(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_GetProviderStats_AggregatesPerModelKeys(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.WindowSeconds = 60
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	s.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")          //nolint:errcheck
+	s.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")          //nolint:errcheck
+	s.RecordTerminalFailure(ctx, "gemini:gemini-1-flash-preview")    //nolint:errcheck
+
+	bare, err := s.GetStats(ctx, "gemini")
+	require.NoError(t, err)
+	require.Equal(t, 0, bare.Failures)
+
+	agg, err := s.GetProviderStats(ctx, "gemini")
+	require.NoError(t, err)
+	require.Equal(t, 3, agg.Failures)
+}
+
 func TestMemoryStore_GetStatsPrunesExpiredFailures(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.WindowSeconds = 1

--- a/internal/circuit/memory_test.go
+++ b/internal/circuit/memory_test.go
@@ -201,9 +201,9 @@ func TestMemoryStore_GetProviderStats_AggregatesPerModelKeys(t *testing.T) {
 	s := NewMemoryStore(cfg)
 	ctx := context.Background()
 
-	s.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")          //nolint:errcheck
-	s.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")          //nolint:errcheck
-	s.RecordTerminalFailure(ctx, "gemini:gemini-1-flash-preview")    //nolint:errcheck
+	s.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")       //nolint:errcheck
+	s.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")       //nolint:errcheck
+	s.RecordTerminalFailure(ctx, "gemini:gemini-1-flash-preview") //nolint:errcheck
 
 	bare, err := s.GetStats(ctx, "gemini")
 	require.NoError(t, err)

--- a/internal/circuit/provider_stats.go
+++ b/internal/circuit/provider_stats.go
@@ -1,0 +1,45 @@
+package circuit
+
+import (
+	"context"
+	"strings"
+)
+
+// providerStatsAggregator is implemented by Store backends that can roll up
+// per-model breaker keys for dashboard display.
+type providerStatsAggregator interface {
+	GetProviderStats(ctx context.Context, provider string) (*ProviderStats, error)
+}
+
+// ProviderStatsFor returns observability stats for a provider name. When the
+// store supports aggregation, failures and state across all `<provider>:<model>`
+// keys (plus the bare `<provider>` fallback key) are folded into one snapshot.
+// Otherwise it falls back to GetStats(provider).
+func ProviderStatsFor(ctx context.Context, store Store, provider string) (*ProviderStats, error) {
+	if agg, ok := store.(providerStatsAggregator); ok {
+		return agg.GetProviderStats(ctx, provider)
+	}
+	return store.GetStats(ctx, provider)
+}
+
+func providerKeyMatches(key, provider string) bool {
+	return key == provider || strings.HasPrefix(key, provider+":")
+}
+
+func worseState(a, b State) State {
+	if stateRank(a) >= stateRank(b) {
+		return a
+	}
+	return b
+}
+
+func stateRank(s State) int {
+	switch s {
+	case StateOpen:
+		return 2
+	case StateHalfOpen:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/circuit/provider_stats_test.go
+++ b/internal/circuit/provider_stats_test.go
@@ -1,0 +1,47 @@
+package circuit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderStatsFor_FallsBackToGetStats(t *testing.T) {
+	store := &fakeProviderStatsStore{
+		providerStats: &ProviderStats{Failures: 9, State: StateOpen},
+		keyStats:      &ProviderStats{Failures: 1, State: StateClosed},
+	}
+
+	got, err := ProviderStatsFor(context.Background(), store, "openai")
+	require.NoError(t, err)
+	require.Equal(t, 9, got.Failures)
+	require.Equal(t, StateOpen, got.State)
+}
+
+type fakeProviderStatsStore struct {
+	providerStats *ProviderStats
+	keyStats      *ProviderStats
+}
+
+func (f *fakeProviderStatsStore) GetState(context.Context, string) (State, error) {
+	return StateClosed, nil
+}
+func (f *fakeProviderStatsStore) RecordTerminalFailure(context.Context, string) (State, bool, error) {
+	return StateClosed, false, nil
+}
+func (f *fakeProviderStatsStore) RecordSuccess(context.Context, string) error { return nil }
+func (f *fakeProviderStatsStore) RecordProbeFailed(context.Context, string) error {
+	return nil
+}
+func (f *fakeProviderStatsStore) ForceOpen(context.Context, string, int) error {
+	return nil
+}
+func (f *fakeProviderStatsStore) GetStats(context.Context, string) (*ProviderStats, error) {
+	return f.keyStats, nil
+}
+func (f *fakeProviderStatsStore) GetProviderStats(context.Context, string) (*ProviderStats, error) {
+	return f.providerStats, nil
+}
+
+var _ Store = (*fakeProviderStatsStore)(nil)

--- a/internal/circuit/provider_stats_test.go
+++ b/internal/circuit/provider_stats_test.go
@@ -27,6 +27,7 @@ type fakeProviderStatsStore struct {
 func (f *fakeProviderStatsStore) GetState(context.Context, string) (State, error) {
 	return StateClosed, nil
 }
+
 func (f *fakeProviderStatsStore) RecordTerminalFailure(context.Context, string) (State, bool, error) {
 	return StateClosed, false, nil
 }
@@ -34,12 +35,15 @@ func (f *fakeProviderStatsStore) RecordSuccess(context.Context, string) error { 
 func (f *fakeProviderStatsStore) RecordProbeFailed(context.Context, string) error {
 	return nil
 }
+
 func (f *fakeProviderStatsStore) ForceOpen(context.Context, string, int) error {
 	return nil
 }
+
 func (f *fakeProviderStatsStore) GetStats(context.Context, string) (*ProviderStats, error) {
 	return f.keyStats, nil
 }
+
 func (f *fakeProviderStatsStore) GetProviderStats(context.Context, string) (*ProviderStats, error) {
 	return f.providerStats, nil
 }

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -426,6 +427,53 @@ func (s *RedisStore) GetStats(ctx context.Context, key string) (*ProviderStats, 
 		}
 	}
 
+	return stats, nil
+}
+
+// GetProviderStats aggregates failures and worst-case state across every
+// per-model key for provider (see ProviderStatsFor).
+func (s *RedisStore) GetProviderStats(ctx context.Context, provider string) (*ProviderStats, error) {
+	now := float64(time.Now().UnixNano()) / 1e9
+	cutoff := fmt.Sprintf("%f", now-float64(s.cfg.WindowSeconds))
+	stats := &ProviderStats{State: StateClosed}
+
+	match := redisKeyFailures + provider + "*"
+	var cursor uint64
+	for {
+		keys, next, err := s.rdb.Scan(ctx, cursor, match, 128).Result()
+		if err != nil {
+			return nil, err
+		}
+		for _, fkey := range keys {
+			cbKey := strings.TrimPrefix(fkey, redisKeyFailures)
+			if !providerKeyMatches(cbKey, provider) {
+				continue
+			}
+			count, err := s.rdb.ZCount(ctx, fkey, cutoff, "+inf").Result()
+			if err != nil {
+				continue
+			}
+			stats.Failures += int(count)
+
+			state, err := s.GetState(ctx, cbKey)
+			if err != nil {
+				continue
+			}
+			stats.State = worseState(stats.State, state)
+			if state == StateOpen {
+				if dur, err := s.rdb.TTL(ctx, s.stateKey(cbKey)).Result(); err == nil && dur > 0 {
+					t := time.Now().Add(dur)
+					if stats.CooldownUntil == nil || t.Before(*stats.CooldownUntil) {
+						stats.CooldownUntil = &t
+					}
+				}
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
 	return stats, nil
 }
 

--- a/internal/circuit/redis_behavior_test.go
+++ b/internal/circuit/redis_behavior_test.go
@@ -74,6 +74,31 @@ func TestRedisStore_RecordTerminalFailure_CountsSameScoreFailures(t *testing.T) 
 	}
 }
 
+func TestRedisStore_GetProviderStats_AggregatesPerModelKeys(t *testing.T) {
+	cfg := Config{
+		FailureThreshold: 5,
+		WindowSeconds:    60,
+		CooldownSeconds:  300,
+	}.Defaults()
+	store, _ := newRedisStoreForBehaviorTest(t, cfg)
+	ctx := context.Background()
+
+	_, _, err := store.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")
+	require.NoError(t, err)
+	_, _, err = store.RecordTerminalFailure(ctx, "gemini:gemini-2.5-flash")
+	require.NoError(t, err)
+	_, _, err = store.RecordTerminalFailure(ctx, "gemini:gemini-1-flash-preview")
+	require.NoError(t, err)
+
+	bare, err := store.GetStats(ctx, "gemini")
+	require.NoError(t, err)
+	require.Equal(t, 0, bare.Failures)
+
+	agg, err := store.GetProviderStats(ctx, "gemini")
+	require.NoError(t, err)
+	require.Equal(t, 3, agg.Failures)
+}
+
 func TestRedisStore_StateTransitionsFromOpenToHalfOpenThenClosedAfterIdle(t *testing.T) {
 	cfg := Config{
 		FailureThreshold: 1,

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -639,6 +639,10 @@ func (t *Transport) runObserveOnly(req *http.Request) (*http.Response, error) {
 
 	key := t.keyFor(req)
 
+	if t.activity != nil {
+		t.activity.RecordCheck()
+	}
+
 	// Log what ModeEnforce *would* have done given the current state, but
 	// always let the real request through.
 	if state, err := t.store.GetState(ctx, key); err == nil && state == StateOpen {
@@ -782,6 +786,10 @@ func (t *Transport) runBypass(req *http.Request, reason string) (*http.Response,
 
 	key := t.keyFor(req)
 	upstreamReq := stripBypassMarkers(req)
+
+	if t.activity != nil {
+		t.activity.RecordCheck()
+	}
 
 	// Tag the metric with the normalised reason so operators can audit
 	// how the bypass safety valve is being used WITHOUT the

--- a/internal/circuitstats/redis.go
+++ b/internal/circuitstats/redis.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"strconv"
-	"strings"
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
@@ -19,8 +18,9 @@ const (
 	redisOpTimeout = 500 * time.Millisecond
 )
 
-// recordEventScript atomically bumps a counter, optional per-provider tally,
-// appends a JSON event, trims the list, and sets started_at once.
+// recordEventScript appends a JSON event and trims the list. Counter totals
+// live in admin rollups; this script keeps legacy counter fields best-effort
+// for operators inspecting the circuit-breaker Redis DB directly.
 var recordEventScript = redis.NewScript(`
 local counters = KEYS[1]
 local events = KEYS[2]
@@ -40,8 +40,8 @@ redis.call('HSETNX', counters, 'started_at', started_at)
 return 1
 `)
 
-// NewRedisRecorder returns a recorder that shares activity across tasks via
-// Redis (same DB as the circuit breaker). The client is not closed by the
+// NewRedisRecorder returns a recorder that mirrors recent events across tasks
+// via Redis (same DB as the circuit breaker). The client is not closed by the
 // recorder — the circuit store owns it.
 func NewRedisRecorder(client *redis.Client, log *slog.Logger) *Recorder {
 	if log == nil {
@@ -49,6 +49,7 @@ func NewRedisRecorder(client *redis.Client, log *slog.Logger) *Recorder {
 	}
 	return &Recorder{
 		startedAt:  time.Now().UTC(),
+		dayKey:     time.Now().UTC().Format("2006-01-02"),
 		byProvider: make(map[string]int64),
 		rdb:        client,
 		log:        log,
@@ -96,37 +97,22 @@ func (r *Recorder) incrRedisCheckAsync() {
 	}()
 }
 
-func (r *Recorder) snapshotRedis() map[string]interface{} {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+func (r *Recorder) mergeRedisRecentEvents(snap map[string]interface{}) {
+	if !r.redisEnabled() || snap == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
 	defer cancel()
 
-	pipe := r.rdb.Pipeline()
-	countersCmd := pipe.HGetAll(ctx, redisCountersKey)
-	eventsCmd := pipe.LRange(ctx, redisEventsKey, 0, MaxRecentEvents-1)
-	if _, err := pipe.Exec(ctx); err != nil {
+	rawEvents, err := r.rdb.LRange(ctx, redisEventsKey, 0, MaxRecentEvents-1).Result()
+	if err != nil {
 		if r.log != nil {
-			r.log.Warn("circuitstats: redis snapshot failed", "error", err)
+			r.log.Warn("circuitstats: redis recent events read failed", "error", err)
 		}
-		return r.snapshotMemory()
+		return
 	}
-
-	counters, err := countersCmd.Result()
-	if err != nil {
-		return r.snapshotMemory()
-	}
-	rawEvents, err := eventsCmd.Result()
-	if err != nil {
-		return r.snapshotMemory()
-	}
-
-	byProvider := make(map[string]int64)
-	for field, val := range counters {
-		if strings.HasPrefix(field, redisProviderPFX) {
-			provider := strings.TrimPrefix(field, redisProviderPFX)
-			if n, parseErr := strconv.ParseInt(val, 10, 64); parseErr == nil {
-				byProvider[provider] = n
-			}
-		}
+	if len(rawEvents) == 0 {
+		return
 	}
 
 	recent := make([]activityEvent, 0, len(rawEvents))
@@ -136,28 +122,5 @@ func (r *Recorder) snapshotRedis() map[string]interface{} {
 			recent = append(recent, e)
 		}
 	}
-
-	startedAt := parseCounter(counters["started_at"])
-	if startedAt == 0 {
-		startedAt = r.startedAt.Unix()
-	}
-
-	return map[string]interface{}{
-		"available":        true,
-		"backend":          "redis",
-		"started_at":       startedAt,
-		"checks_total":     parseCounter(counters["checks_total"]),
-		"blocked_open":     parseCounter(counters["blocked_open"]),
-		"probes_started":   parseCounter(counters["probes_started"]),
-		"probes_succeeded": parseCounter(counters["probes_succeeded"]),
-		"probes_failed":    parseCounter(counters["probes_failed"]),
-		"circuits_opened":  parseCounter(counters["circuits_opened"]),
-		"by_provider":      byProvider,
-		"recent_events":    recent,
-	}
-}
-
-func parseCounter(s string) int64 {
-	n, _ := strconv.ParseInt(s, 10, 64)
-	return n
+	snap["recent_events"] = recent
 }

--- a/internal/circuitstats/redis_test.go
+++ b/internal/circuitstats/redis_test.go
@@ -58,7 +58,7 @@ func TestRedisRecorder_RecordCheck(t *testing.T) {
 	assert.Equal(t, int64(2), snap["checks_total"])
 }
 
-func TestRedisRecorder_SharedAcrossRecorders(t *testing.T) {
+func TestRedisRecorder_SharedRecentEventsAcrossRecorders(t *testing.T) {
 	r1, mr := newRedisRecorderForTest(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = client.Close() })
@@ -68,7 +68,6 @@ func TestRedisRecorder_SharedAcrossRecorders(t *testing.T) {
 	r2.RecordProbeClosed("gemini", "gemini", 200)
 
 	snap := r2.Snapshot()
-	assert.Equal(t, int64(1), snap["probes_started"])
 	assert.Equal(t, int64(1), snap["probes_succeeded"])
 
 	events := snap["recent_events"].([]activityEvent)

--- a/internal/circuitstats/rollup_test.go
+++ b/internal/circuitstats/rollup_test.go
@@ -1,0 +1,67 @@
+package circuitstats
+
+import (
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/adminrollup"
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newRollupStore(t *testing.T) *adminrollup.Store {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+
+	store, err := adminrollup.NewStore(adminrollup.Config{
+		Enabled: true,
+		Redis: &config.RedisConfig{
+			Address: mr.Addr(),
+			DB:      6,
+			DBSet:   true,
+		},
+		RetentionDays: 7,
+		HistoryDays:   3,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestRecorder_SnapshotMergeHistory(t *testing.T) {
+	store := newRollupStore(t)
+	persister := adminrollup.NewPersister(store, adminrollup.MetricCircuitActivity)
+
+	r := NewRecorder()
+	r.BindRollup(store, persister)
+	r.RecordCheck()
+	r.FlushRollup()
+
+	snap := r.Snapshot()
+	require.Equal(t, true, snap["daily_history_available"])
+	rows, ok := snap["daily_history"].([]map[string]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, rows)
+}
+
+func TestRecorder_RollupAggregatesFleetChecks(t *testing.T) {
+	store := newRollupStore(t)
+	persister := adminrollup.NewPersister(store, adminrollup.MetricCircuitActivity)
+
+	r1 := NewRecorder()
+	r1.BindRollup(store, persister)
+	r2 := NewRecorder()
+	r2.BindRollup(store, persister)
+
+	r1.RecordCheck()
+	r2.RecordCheck()
+	r2.RecordCheck()
+	r1.FlushRollup()
+	r2.FlushRollup()
+
+	snap := r1.Snapshot()
+	assert.Equal(t, int64(3), snap["checks_total"])
+}

--- a/internal/circuitstats/stats.go
+++ b/internal/circuitstats/stats.go
@@ -1,7 +1,8 @@
 // Package circuitstats records circuit-breaker activity for the admin dashboard:
 // state checks, fast-fails while open, and half-open probe outcomes when a
-// cooldown window ends. Use NewRecorder for local dev; NewRedisRecorder shares
-// counters and recent events across ECS tasks via the circuit-breaker Redis DB.
+// cooldown window ends. Counters are published to admin rollups (Redis DB 6)
+// so sidecars aggregate fleet-wide; recent events may also be mirrored on the
+// circuit-breaker Redis DB when a shared client is available.
 package circuitstats
 
 import (
@@ -9,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Instawork/llm-proxy/internal/adminrollup"
 	redis "github.com/redis/go-redis/v9"
 )
 
@@ -35,12 +37,23 @@ type activityEvent struct {
 	Reason      string `json:"reason,omitempty"`
 }
 
-// Recorder accumulates rolling circuit activity. Without a Redis client each
-// sidecar keeps its own counters; with Redis (NewRedisRecorder) activity is
-// shared cluster-wide under llm:cb:activity:* keys.
+type activityFlushed struct {
+	checksTotal     int64
+	blockedOpen     int64
+	probesStarted   int64
+	probesSucceeded int64
+	probesFailed    int64
+	circuitsOpened  int64
+	byProvider      map[string]int64
+}
+
+// Recorder accumulates rolling circuit activity. Each instance keeps local
+// counters and publishes deltas to admin rollups; optional Redis mirrors the
+// recent-events ring across tasks on the circuit-breaker DB.
 type Recorder struct {
 	mu        sync.RWMutex
 	startedAt time.Time
+	dayKey    string
 
 	checksTotal     int64
 	blockedOpen     int64
@@ -51,7 +64,10 @@ type Recorder struct {
 
 	byProvider map[string]int64
 
-	recent []activityEvent
+	recent  []activityEvent
+	flushed activityFlushed
+
+	adminrollup.RecorderBinding
 
 	rdb *redis.Client
 	log *slog.Logger
@@ -59,10 +75,34 @@ type Recorder struct {
 
 // NewRecorder returns a recorder scoped to this process.
 func NewRecorder() *Recorder {
+	now := time.Now().UTC()
 	return &Recorder{
-		startedAt:  time.Now().UTC(),
+		startedAt:  now,
+		dayKey:     now.Format("2006-01-02"),
 		byProvider: make(map[string]int64),
 	}
+}
+
+func (r *Recorder) maybeRollDay(now time.Time) {
+	day := now.UTC().Format("2006-01-02")
+	if r.dayKey == day {
+		return
+	}
+	oldDay := r.dayKey
+	r.dayKey = day
+	r.FlushRollup()
+	go func() {
+		r.ArchiveDayFromAggregatesElected(adminrollup.MetricCircuitActivity, oldDay, adminrollup.TopNCaps{})
+	}()
+	r.flushed = activityFlushed{}
+	r.checksTotal = 0
+	r.blockedOpen = 0
+	r.probesStarted = 0
+	r.probesSucceeded = 0
+	r.probesFailed = 0
+	r.circuitsOpened = 0
+	r.byProvider = make(map[string]int64)
+	r.recent = nil
 }
 
 func (r *Recorder) appendEvent(e activityEvent) {
@@ -78,87 +118,124 @@ func (r *Recorder) bumpProvider(provider string) {
 	}
 }
 
-// RecordFastFail records a request blocked because the breaker is open.
-func (r *Recorder) RecordFastFail(provider, key string) {
+func (r *Recorder) activityDeltaLocked() adminrollup.Delta {
+	d := adminrollup.Delta{
+		Totals: map[string]float64{
+			"checks_total":     float64(r.checksTotal - r.flushed.checksTotal),
+			"blocked_open":     float64(r.blockedOpen - r.flushed.blockedOpen),
+			"probes_started":   float64(r.probesStarted - r.flushed.probesStarted),
+			"probes_succeeded": float64(r.probesSucceeded - r.flushed.probesSucceeded),
+			"probes_failed":    float64(r.probesFailed - r.flushed.probesFailed),
+			"circuits_opened":  float64(r.circuitsOpened - r.flushed.circuitsOpened),
+		},
+	}
+	if provDelta := int64MapDelta(r.byProvider, r.flushed.byProvider); len(provDelta) > 0 {
+		if d.Dimensions == nil {
+			d.Dimensions = make(map[string]map[string]float64)
+		}
+		d.Dimensions["by_provider"] = provDelta
+	}
+	return d
+}
+
+func int64MapDelta(cur map[string]int64, prev map[string]int64) map[string]float64 {
+	out := make(map[string]float64)
+	for k, v := range cur {
+		p := prev[k]
+		if dr := float64(v - p); dr != 0 {
+			out[k] = dr
+		}
+	}
+	return out
+}
+
+func (r *Recorder) advanceFlushedLocked() {
+	if r.flushed.byProvider == nil {
+		r.flushed.byProvider = make(map[string]int64)
+	}
+	r.flushed.checksTotal = r.checksTotal
+	r.flushed.blockedOpen = r.blockedOpen
+	r.flushed.probesStarted = r.probesStarted
+	r.flushed.probesSucceeded = r.probesSucceeded
+	r.flushed.probesFailed = r.probesFailed
+	r.flushed.circuitsOpened = r.circuitsOpened
+	for k, v := range r.byProvider {
+		r.flushed.byProvider[k] = v
+	}
+}
+
+func (r *Recorder) publishLocked() {
+	dayKey := r.dayKey
+	delta := r.activityDeltaLocked()
+	r.advanceFlushedLocked()
+	r.mu.Unlock()
+	r.QueueDelta(dayKey, delta)
+	r.mu.Lock()
+}
+
+func (r *Recorder) recordActivity(counterField, provider string, e activityEvent, apply func()) {
 	if r == nil {
 		return
 	}
 	now := time.Now().UTC()
+	e.Time = now.Unix()
+
+	r.mu.Lock()
+	r.maybeRollDay(now)
+	apply()
+	r.bumpProvider(provider)
+	r.appendEvent(e)
+	r.publishLocked()
+	r.mu.Unlock()
+
+	if r.redisEnabled() {
+		r.recordRedisEvent(counterField, provider, e)
+	}
+}
+
+// RecordFastFail records a request blocked because the breaker is open.
+func (r *Recorder) RecordFastFail(provider, key string) {
 	e := activityEvent{
-		Time:     now.Unix(),
 		Provider: provider,
 		Key:      key,
 		Kind:     EventFastFail,
 		NewState: "open",
 	}
-	if r.redisEnabled() {
-		r.recordRedisEvent("blocked_open", provider, e)
-		return
-	}
-	r.mu.Lock()
-	r.blockedOpen++
-	r.bumpProvider(provider)
-	r.appendEvent(e)
-	r.mu.Unlock()
+	r.recordActivity("blocked_open", provider, e, func() {
+		r.blockedOpen++
+	})
 }
 
 // RecordProbe records a half-open probe dispatched to the upstream provider.
 func (r *Recorder) RecordProbe(provider, key string) {
-	if r == nil {
-		return
-	}
-	now := time.Now().UTC()
 	e := activityEvent{
-		Time:     now.Unix(),
 		Provider: provider,
 		Key:      key,
 		Kind:     EventProbe,
 		NewState: "half_open",
 	}
-	if r.redisEnabled() {
-		r.recordRedisEvent("probes_started", provider, e)
-		return
-	}
-	r.mu.Lock()
-	r.probesStarted++
-	r.bumpProvider(provider)
-	r.appendEvent(e)
-	r.mu.Unlock()
+	r.recordActivity("probes_started", provider, e, func() {
+		r.probesStarted++
+	})
 }
 
 // RecordProbeClosed records a successful half-open probe (circuit closed).
 func (r *Recorder) RecordProbeClosed(provider, key string, statusCode int) {
-	if r == nil {
-		return
-	}
-	now := time.Now().UTC()
 	e := activityEvent{
-		Time:       now.Unix(),
 		Provider:   provider,
 		Key:        key,
 		Kind:       EventProbeClosed,
 		NewState:   "closed",
 		StatusCode: statusCode,
 	}
-	if r.redisEnabled() {
-		r.recordRedisEvent("probes_succeeded", provider, e)
-		return
-	}
-	r.mu.Lock()
-	r.probesSucceeded++
-	r.bumpProvider(provider)
-	r.appendEvent(e)
-	r.mu.Unlock()
+	r.recordActivity("probes_succeeded", provider, e, func() {
+		r.probesSucceeded++
+	})
 }
 
 // RecordProbeReopened records a failed half-open probe (circuit open again).
 func (r *Recorder) RecordProbeReopened(provider, key string, statusCode int, failureKind string) {
-	if r == nil {
-		return
-	}
-	now := time.Now().UTC()
 	e := activityEvent{
-		Time:        now.Unix(),
 		Provider:    provider,
 		Key:         key,
 		Kind:        EventProbeReopened,
@@ -166,40 +243,23 @@ func (r *Recorder) RecordProbeReopened(provider, key string, statusCode int, fai
 		StatusCode:  statusCode,
 		FailureKind: failureKind,
 	}
-	if r.redisEnabled() {
-		r.recordRedisEvent("probes_failed", provider, e)
-		return
-	}
-	r.mu.Lock()
-	r.probesFailed++
-	r.bumpProvider(provider)
-	r.appendEvent(e)
-	r.mu.Unlock()
+	r.recordActivity("probes_failed", provider, e, func() {
+		r.probesFailed++
+	})
 }
 
 // RecordOpened records a circuit trip (failure threshold or force-open).
 func (r *Recorder) RecordOpened(provider, key, reason string) {
-	if r == nil {
-		return
-	}
-	now := time.Now().UTC()
 	e := activityEvent{
-		Time:     now.Unix(),
 		Provider: provider,
 		Key:      key,
 		Kind:     EventOpened,
 		NewState: "open",
 		Reason:   reason,
 	}
-	if r.redisEnabled() {
-		r.recordRedisEvent("circuits_opened", provider, e)
-		return
-	}
-	r.mu.Lock()
-	r.circuitsOpened++
-	r.bumpProvider(provider)
-	r.appendEvent(e)
-	r.mu.Unlock()
+	r.recordActivity("circuits_opened", provider, e, func() {
+		r.circuitsOpened++
+	})
 }
 
 // RecordCheck increments the state-check counter (one per routing decision).
@@ -207,13 +267,16 @@ func (r *Recorder) RecordCheck() {
 	if r == nil {
 		return
 	}
+	now := time.Now().UTC()
+	r.mu.Lock()
+	r.maybeRollDay(now)
+	r.checksTotal++
+	r.publishLocked()
+	r.mu.Unlock()
+
 	if r.redisEnabled() {
 		r.incrRedisCheckAsync()
-		return
 	}
-	r.mu.Lock()
-	r.checksTotal++
-	r.mu.Unlock()
 }
 
 // Snapshot returns JSON for the admin API.
@@ -221,14 +284,18 @@ func (r *Recorder) Snapshot() map[string]interface{} {
 	if r == nil {
 		return map[string]interface{}{"available": false}
 	}
-	if r.redisEnabled() {
-		return r.snapshotRedis()
-	}
-	return r.snapshotMemory()
+	r.mu.RLock()
+	dayKey := r.dayKey
+	snap := r.snapshotMemoryLocked()
+	r.mu.RUnlock()
+
+	r.MergeToday(adminrollup.MetricCircuitActivity, dayKey, snap, adminrollup.TopNCaps{})
+	r.MergeHistory(adminrollup.MetricCircuitActivity, snap)
+	r.mergeRedisRecentEvents(snap)
+	return snap
 }
 
-func (r *Recorder) snapshotMemory() map[string]interface{} {
-	r.mu.RLock()
+func (r *Recorder) snapshotMemoryLocked() map[string]interface{} {
 	recent := make([]activityEvent, len(r.recent))
 	for i, e := range r.recent {
 		recent[len(r.recent)-1-i] = e
@@ -237,9 +304,14 @@ func (r *Recorder) snapshotMemory() map[string]interface{} {
 	for k, v := range r.byProvider {
 		byProvider[k] = v
 	}
-	snap := map[string]interface{}{
+	backend := "memory"
+	if r.redisEnabled() {
+		backend = "redis"
+	}
+	return map[string]interface{}{
 		"available":        true,
-		"backend":          "memory",
+		"backend":          backend,
+		"day":              r.dayKey,
 		"started_at":       r.startedAt.Unix(),
 		"checks_total":     r.checksTotal,
 		"blocked_open":     r.blockedOpen,
@@ -250,6 +322,4 @@ func (r *Recorder) snapshotMemory() map[string]interface{} {
 		"by_provider":      byProvider,
 		"recent_events":    recent,
 	}
-	r.mu.RUnlock()
-	return snap
 }

--- a/web/src/lib/daily-history.ts
+++ b/web/src/lib/daily-history.ts
@@ -257,6 +257,75 @@ export function aggNameCount(
     .sort((a, b) => b.count - a.count);
 }
 
+/** Sum a numeric field across each UTC day in the range. */
+export function sumScalarField(
+  rows: DailyHistoryRow[] | undefined,
+  range: RangeKey,
+  field: string,
+): number {
+  return sliceRange(rows, range).reduce((sum, row) => sum + asNum(row[field]), 0);
+}
+
+/** Peak numeric field across each UTC day in the range (for rolling-window gauges). */
+export function maxScalarField(
+  rows: DailyHistoryRow[] | undefined,
+  range: RangeKey,
+  field: string,
+): number {
+  const slice = sliceRange(rows, range);
+  if (!slice.length) return 0;
+  return Math.max(0, ...slice.map((row) => asNum(row[field])));
+}
+
+/** UTC midnight unix seconds at the start of the oldest day in range. */
+export function rangeStartUnix(range: RangeKey): number {
+  const days = range === "today" ? 1 : rangeDays(range);
+  const start = new Date();
+  start.setUTCHours(0, 0, 0, 0);
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+  return Math.floor(start.getTime() / 1000);
+}
+
+// --- Circuit activity (daily counter totals) ---------------------------------
+
+export interface CircuitActivityAgg {
+  checks_total: number;
+  blocked_open: number;
+  probes_started: number;
+  probes_succeeded: number;
+  probes_failed: number;
+  circuits_opened: number;
+}
+
+const CIRCUIT_ACTIVITY_FIELDS = [
+  "checks_total",
+  "blocked_open",
+  "probes_started",
+  "probes_succeeded",
+  "probes_failed",
+  "circuits_opened",
+] as const;
+
+export function aggCircuitActivity(
+  rows: DailyHistoryRow[] | undefined,
+  range: RangeKey,
+): CircuitActivityAgg {
+  const out: CircuitActivityAgg = {
+    checks_total: 0,
+    blocked_open: 0,
+    probes_started: 0,
+    probes_succeeded: 0,
+    probes_failed: 0,
+    circuits_opened: 0,
+  };
+  for (const row of sliceRange(rows, range)) {
+    for (const field of CIRCUIT_ACTIVITY_FIELDS) {
+      out[field] += asNum(row[field]);
+    }
+  }
+  return out;
+}
+
 // --- Circuit providers (map name -> {failures}) -----------------------------
 
 export function aggCircuitProviders(

--- a/web/src/pages/circuit.tsx
+++ b/web/src/pages/circuit.tsx
@@ -8,6 +8,7 @@ import {
   RangeToggle,
   SectionPanel,
   trendChartSource,
+  type DataSource,
 } from "../components/ui/data-source";
 import PageHeader, {
   ErrorAlert,
@@ -17,12 +18,17 @@ import PageHeader, {
   StatusBadge,
 } from "../components/ui/page-header";
 import { useHealth, useCircuitActivity } from "../hooks/queries";
-import type { CircuitActivityEvent } from "../types";
+import type { CircuitActivityEvent, DailyHistoryRow } from "../types";
 import { LIVE_TREND_CHART_SUBTITLE, useHistory } from "../hooks/use-history";
 import {
+  aggCircuitActivity,
+  aggCircuitProviders,
   DAILY_HISTORY_SUBTITLE,
+  maxScalarField,
+  pickToday,
   type RangeKey,
   RANGE_OPTIONS,
+  rangeStartUnix,
   circuitProviderSeries,
   scalarSeries,
 } from "../lib/daily-history";
@@ -66,35 +72,145 @@ function formatEventTime(unix: number): string {
   return new Date(unix * 1000).toLocaleString();
 }
 
+function activityFieldPick(
+  range: RangeKey,
+  field: keyof ReturnType<typeof aggCircuitActivity>,
+  live: number | undefined,
+  history: DailyHistoryRow[] | undefined,
+  hasRedis: boolean,
+) {
+  if (range === "today") {
+    return pickToday(live, history, field, hasRedis);
+  }
+  if (hasRedis && history?.length) {
+    return { value: aggCircuitActivity(history, range)[field], source: "redis" as const };
+  }
+  return { value: live ?? 0, source: "memory" as const };
+}
+
 export default function CircuitPage() {
   const { data, isLoading, error, dataUpdatedAt, isFetching, refetch } = useHealth();
   const activityQuery = useCircuitActivity();
   const [range, setRange] = useState<RangeKey>("today");
 
   const activity = activityQuery.data;
-  const recentEvents = activity?.recent_events ?? [];
+  const allRecentEvents = activity?.recent_events ?? [];
 
   const providers = data?.circuit_breaker?.providers ?? {};
   const names = Object.keys(providers);
   const cb = data?.circuit_breaker;
-  const history = cb?.daily_history;
-  const hasRedis = Boolean(cb?.daily_history_available);
-  const totalFailures =
+  const failureHistory = cb?.daily_history;
+  const hasFailureRedis = Boolean(cb?.daily_history_available);
+
+  const activityHistory = activity?.daily_history;
+  const hasActivityRedis = Boolean(activity?.daily_history_available);
+
+  const liveTotalFailures =
     cb?.total_failures ?? Object.values(providers).reduce((s, p) => s + (p.failures ?? 0), 0);
-  const failureHistory = useHistory(data ? totalFailures : undefined);
-  const dailyFailures = useMemo(
-    () => scalarSeries(history, "total_failures", range),
-    [history, range],
+
+  const totalFailures =
+    range === "today"
+      ? liveTotalFailures
+      : hasFailureRedis
+        ? maxScalarField(failureHistory, range, "total_failures")
+        : liveTotalFailures;
+
+  const failureStatSource: DataSource =
+    range === "today" ? circuitLiveSource(cb?.backend) : hasFailureRedis ? "redis" : "memory";
+
+  const failureStatHint =
+    range === "today" ? "Current 120s window" : `Peak daily window · ${rangeLabel(range)}`;
+
+  const providerFailurePeaks = useMemo(() => {
+    const map = new Map<string, number>();
+    if (range !== "today" && hasFailureRedis) {
+      for (const row of aggCircuitProviders(failureHistory, range)) {
+        map.set(row.name, row.count);
+      }
+    }
+    return map;
+  }, [range, hasFailureRedis, failureHistory]);
+
+  const providerFailureValues = names.map((n) =>
+    range === "today" || !hasFailureRedis
+      ? (providers[n].failures ?? 0)
+      : (providerFailurePeaks.get(n) ?? 0),
   );
-  const useDailyChart = Boolean(hasRedis && range !== "today" && dailyFailures.available);
 
-  const providerSeries = useMemo(() => circuitProviderSeries(history, range), [history, range]);
-  const showProviderHistory = hasRedis && range !== "today" && providerSeries.providers.length > 0;
+  const failureHistoryTrend = useHistory(range === "today" ? liveTotalFailures : undefined);
+  const dailyFailures = useMemo(
+    () => scalarSeries(failureHistory, "total_failures", range),
+    [failureHistory, range],
+  );
+  const useDailyFailureChart = Boolean(hasFailureRedis && range !== "today" && dailyFailures.available);
 
-  const liveSource = circuitLiveSource(cb?.backend);
-  const activitySource = circuitLiveSource(activity?.backend ?? cb?.backend);
+  const providerSeries = useMemo(() => circuitProviderSeries(failureHistory, range), [failureHistory, range]);
+  const showProviderHistory = hasFailureRedis && range !== "today" && providerSeries.providers.length > 0;
+
+  const checksPick = activityFieldPick(
+    range,
+    "checks_total",
+    activity?.checks_total,
+    activityHistory,
+    hasActivityRedis,
+  );
+  const blockedPick = activityFieldPick(
+    range,
+    "blocked_open",
+    activity?.blocked_open,
+    activityHistory,
+    hasActivityRedis,
+  );
+  const probesPick = activityFieldPick(
+    range,
+    "probes_started",
+    activity?.probes_started,
+    activityHistory,
+    hasActivityRedis,
+  );
+  const probesOkPick = activityFieldPick(
+    range,
+    "probes_succeeded",
+    activity?.probes_succeeded,
+    activityHistory,
+    hasActivityRedis,
+  );
+  const probesFailPick = activityFieldPick(
+    range,
+    "probes_failed",
+    activity?.probes_failed,
+    activityHistory,
+    hasActivityRedis,
+  );
+
+  const dailyChecks = useMemo(
+    () => scalarSeries(activityHistory, "checks_total", range),
+    [activityHistory, range],
+  );
+  const useDailyActivityChart = Boolean(
+    hasActivityRedis && range !== "today" && dailyChecks.available,
+  );
+
+  const activitySource: DataSource =
+    range === "today" ? circuitLiveSource(activity?.backend ?? cb?.backend) : hasActivityRedis ? "redis" : "memory";
+
   const activityHint =
-    activity?.backend === "redis" ? "Shared across tasks via Redis" : "Since process start";
+    range === "today"
+      ? activity?.backend === "redis"
+        ? "Fleet total · UTC day"
+        : "Since process start"
+      : `Summed UTC days · ${rangeLabel(range)}`;
+
+  const recentEvents = useMemo(() => {
+    if (range === "today") return allRecentEvents;
+    const cutoff = rangeStartUnix(range);
+    return allRecentEvents.filter((e) => e.time >= cutoff);
+  }, [allRecentEvents, range]);
+
+  const refetchAll = () => {
+    refetch();
+    activityQuery.refetch();
+  };
 
   if (isLoading) return <LoadingBlock />;
   if (error) {
@@ -109,7 +225,11 @@ export default function CircuitPage() {
         actions={
           <div className="flex items-center gap-3">
             <RangeToggle value={range} options={RANGE_OPTIONS} onChange={setRange} />
-            <LiveIndicator updatedAt={dataUpdatedAt} fetching={isFetching} onRefresh={() => refetch()} />
+            <LiveIndicator
+              updatedAt={Math.max(dataUpdatedAt, activityQuery.dataUpdatedAt)}
+              fetching={isFetching || activityQuery.isFetching}
+              onRefresh={refetchAll}
+            />
           </div>
         }
       />
@@ -132,28 +252,38 @@ export default function CircuitPage() {
             </>
           }
           hint="Live breaker state store"
-          source={liveSource}
+          source={circuitLiveSource(cb?.backend)}
           valueClassName="text-lg"
         />
-        <LiveStat title="Total failures" value={totalFailures} hint="Current window" source={liveSource} />
+        <LiveStat
+          title="Total failures"
+          value={totalFailures}
+          hint={failureStatHint}
+          source={failureStatSource}
+        />
       </div>
 
       {activity?.available ? (
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
-          <LiveStat title="State checks" value={activity.checks_total ?? 0} hint={activityHint} source={activitySource} />
-          <LiveStat title="Blocked (open)" value={activity.blocked_open ?? 0} source={activitySource} />
-          <LiveStat title="Recovery probes" value={activity.probes_started ?? 0} hint="After cooldown" source={activitySource} />
+          <LiveStat title="State checks" value={checksPick.value} hint={activityHint} source={activitySource} />
+          <LiveStat title="Blocked (open)" value={blockedPick.value} source={activitySource} />
+          <LiveStat
+            title="Recovery probes"
+            value={probesPick.value}
+            hint={range === "today" ? "After cooldown" : undefined}
+            source={activitySource}
+          />
           <LiveStat
             title="Probes succeeded"
-            value={activity.probes_succeeded ?? 0}
-            hint="Circuit closed"
+            value={probesOkPick.value}
+            hint={range === "today" ? "Circuit closed" : undefined}
             source={activitySource}
             valueClassName="text-success"
           />
           <LiveStat
             title="Probes failed"
-            value={activity.probes_failed ?? 0}
-            hint="Circuit re-opened"
+            value={probesFailPick.value}
+            hint={range === "today" ? "Circuit re-opened" : undefined}
             source={activitySource}
             valueClassName="text-error"
           />
@@ -163,26 +293,35 @@ export default function CircuitPage() {
       <div className="grid gap-4 lg:grid-cols-2">
         <ChartCard
           title="Failure trend"
-          subtitle={useDailyChart ? DAILY_HISTORY_SUBTITLE : LIVE_TREND_CHART_SUBTITLE}
-          source={trendChartSource(useDailyChart)}
+          subtitle={useDailyFailureChart ? DAILY_HISTORY_SUBTITLE : LIVE_TREND_CHART_SUBTITLE}
+          source={trendChartSource(useDailyFailureChart)}
         >
-          {useDailyChart ? (
+          {useDailyFailureChart ? (
             <BarChart
               labels={dailyFailures.labels}
               values={dailyFailures.values}
-              label="Daily failures"
+              label="Daily peak failures"
               colors={dailyFailures.labels.map(() => chartPalette.error())}
             />
           ) : (
-            <TrendChart points={failureHistory} label="Failures" color={chartPalette.error()} />
+            <TrendChart points={failureHistoryTrend} label="Failures" color={chartPalette.error()} />
           )}
         </ChartCard>
-        <ChartCard title="Failures by provider" subtitle="Current count" source={liveSource}>
+        <ChartCard
+          title="Failures by provider"
+          subtitle={
+            range === "today"
+              ? "Current 120s window"
+              : `Peak daily window · ${rangeLabel(range)} · ${DAILY_HISTORY_SUBTITLE}`
+          }
+          source={failureStatSource}
+        >
           <BarChart
             labels={names}
-            values={names.map((n) => providers[n].failures ?? 0)}
+            values={providerFailureValues}
             label="Failures"
             colors={names.map((n) => stateColor(providers[n].state ?? "closed"))}
+            horizontal
           />
         </ChartCard>
       </div>
@@ -206,10 +345,29 @@ export default function CircuitPage() {
         </ChartCard>
       ) : null}
 
+      {activity?.available && useDailyActivityChart ? (
+        <ChartCard
+          title="State checks"
+          subtitle={`Daily UTC totals · ${rangeLabel(range)} · ${DAILY_HISTORY_SUBTITLE}`}
+          source="redis"
+        >
+          <BarChart
+            labels={dailyChecks.labels}
+            values={dailyChecks.values}
+            label="Checks"
+            colors={dailyChecks.labels.map(() => chartPalette.primary())}
+          />
+        </ChartCard>
+      ) : null}
+
       {activity?.available ? (
         <SectionPanel
           title="Recovery activity"
-          subtitle="Half-open probes after cooldown windows end (shared when Redis-backed)"
+          subtitle={
+            range === "today"
+              ? "Half-open probes after cooldown windows end (shared when Redis-backed)"
+              : `Events since ${rangeLabel(range)} · ring buffer may truncate older entries`
+          }
           source={activitySource}
         >
           <div className="overflow-x-auto">
@@ -254,8 +412,8 @@ export default function CircuitPage() {
                 {recentEvents.length === 0 ? (
                   <tr>
                     <td colSpan={6} className="text-center text-base-content/50">
-                      No recovery probes yet — events appear when a cooldown ends and the breaker
-                      probes upstream, or when requests are blocked while open.
+                      No recovery probes in this window — events appear when a cooldown ends and the
+                      breaker probes upstream, or when requests are blocked while open.
                     </td>
                   </tr>
                 ) : null}
@@ -265,14 +423,22 @@ export default function CircuitPage() {
         </SectionPanel>
       ) : null}
 
-      <SectionPanel title="Providers" subtitle="Live trip state and failure counters" source={liveSource}>
+      <SectionPanel
+        title="Providers"
+        subtitle={
+          range === "today"
+            ? "Live trip state and current-window failure counts"
+            : `Live trip state · peak daily failures · ${rangeLabel(range)}`
+        }
+        source={range === "today" ? circuitLiveSource(cb?.backend) : failureStatSource}
+      >
         <div className="overflow-x-auto">
           <table className="table table-zebra">
             <thead>
               <tr>
                 <th>Provider</th>
                 <th>State</th>
-                <th>Failures</th>
+                <th>{range === "today" ? "Failures" : "Peak failures"}</th>
                 <th>Rollup</th>
                 <th>Threshold</th>
               </tr>
@@ -281,6 +447,10 @@ export default function CircuitPage() {
               {names.map((name) => {
                 const p = providers[name];
                 const state = p.state ?? p.error ?? "unknown";
+                const failures =
+                  range === "today" || !hasFailureRedis
+                    ? (p.failures ?? "—")
+                    : (providerFailurePeaks.get(name) ?? 0);
                 return (
                   <tr key={name}>
                     <td>
@@ -293,7 +463,7 @@ export default function CircuitPage() {
                         inactiveLabel={state}
                       />
                     </td>
-                    <td>{p.failures ?? "—"}</td>
+                    <td>{failures}</td>
                     <td>{p.rollup?.open ? "open" : p.rollup?.enabled ? "closed" : "—"}</td>
                     <td>{p.rollup?.threshold ?? "—"}</td>
                   </tr>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -146,6 +146,7 @@ export interface CircuitActivityEvent {
 export interface CircuitActivityResponse {
   available?: boolean;
   backend?: string;
+  day?: string;
   started_at?: number;
   checks_total?: number;
   blocked_open?: number;
@@ -155,6 +156,8 @@ export interface CircuitActivityResponse {
   circuits_opened?: number;
   by_provider?: Record<string, number>;
   recent_events?: CircuitActivityEvent[];
+  daily_history?: DailyHistoryRow[];
+  daily_history_available?: boolean;
 }
 
 export interface RateLimitConfig {


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

The Circuit Breaker admin page was showing zeros because of two bugs: failure counts were keyed per-model (`gemini:gemini-2.5-flash`) but `/health` queried bare provider keys, and activity counters (state checks, probes, trips) were only written to the circuit Redis DB by sidecars without publishing through admin rollups that the standalone UI reads.

This PR fixes both issues and extends the 7d/30d range selector to stat cards and provider bars (not just charts).

- **Provider-level failure aggregation** — `ProviderStatsFor` / `GetProviderStats` roll up per-model keys for `/health`, the circuit archiver, and provider failure bars.
- **Circuit activity rollups** — New `circuit_activity` metric; sidecars queue deltas to admin Redis DB 6; standalone admin merges fleet totals on snapshot. `RecordCheck` now runs in observe-only and bypass transport paths.
- **Range-aware UI** — Today uses live 120s failure window + live activity counters; 7d/30d uses daily peak failures and summed activity history from Redis rollups, plus a daily state-checks bar chart.

## Test plan

- [x] `go test ./internal/circuit/... ./internal/circuitstats/... ./internal/adminrollup/... ./internal/admin/...`
- [x] `npm run check` in `web/`
- [ ] Deploy to staging/prod and verify Circuit Breaker page shows non-zero failures and activity after traffic
- [ ] Confirm 7d/30d stat cards update when switching range (not stuck at today-only live values)
- [ ] Confirm `/health?history=1` provider failure totals match provider bars on the dashboard