### PR TITLE
fix(test): skip Anthropic upstream flakes in integration tests

### DIFF
--- a/internal/providers/anthropic_integration_test.go
+++ b/internal/providers/anthropic_integration_test.go
@@ -15,6 +15,44 @@ import (
 	"time"
 )
 
+// anthropicUpstreamSkipReason reports whether an Anthropic response indicates a
+// transient upstream failure that should not fail CI integration tests.
+func anthropicUpstreamSkipReason(status int, body []byte) (reason string, ok bool) {
+	if status == http.StatusOK {
+		return "", false
+	}
+	var envelope struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", false
+	}
+	if envelope.Type != "error" {
+		return "", false
+	}
+	switch {
+	case status == 529:
+		return "Anthropic upstream overloaded (529)", true
+	case status >= 500 && status <= 504 && envelope.Error.Type == "api_error":
+		return fmt.Sprintf("Anthropic upstream api_error (%d)", status), true
+	default:
+		return "", false
+	}
+}
+
+// skipOnAnthropicUpstreamError skips integration tests when Anthropic returns a
+// transient upstream failure (529 overloaded, 5xx api_error). Those indicate
+// provider-side capacity or availability issues, not a regression in this proxy.
+func skipOnAnthropicUpstreamError(t *testing.T, status int, body []byte) {
+	t.Helper()
+	if reason, ok := anthropicUpstreamSkipReason(status, body); ok {
+		t.Skipf("skipping: %s; not a proxy regression. Response: %s", reason, string(body))
+	}
+}
+
 // testModel represents a model configuration for testing
 type anthropicTestModel struct {
 	name       string
@@ -172,6 +210,7 @@ func TestAnthropicIntegration_AdvancedScenarios(t *testing.T) {
 
 			if resp.StatusCode != http.StatusOK {
 				body, _ := io.ReadAll(resp.Body)
+				skipOnAnthropicUpstreamError(t, resp.StatusCode, body)
 				t.Fatalf("Expected status 200, got %d. Response: %s", resp.StatusCode, string(body))
 			}
 
@@ -243,6 +282,7 @@ func testAnthropicNonStreaming(t *testing.T, server *httptest.Server, providerMa
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		skipOnAnthropicUpstreamError(t, resp.StatusCode, body)
 		t.Fatalf("Expected status 200, got %d. Response: %s", resp.StatusCode, string(body))
 	}
 
@@ -322,6 +362,7 @@ func testAnthropicStreaming(t *testing.T, server *httptest.Server, providerManag
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		skipOnAnthropicUpstreamError(t, resp.StatusCode, body)
 		t.Fatalf("Expected status 200, got %d. Response: %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/providers/anthropic_skip_test.go
+++ b/internal/providers/anthropic_skip_test.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAnthropicUpstreamSkipReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantOK     bool
+		wantSubstr string
+	}{
+		{
+			name:   "ok",
+			status: http.StatusOK,
+			body:   `{}`,
+			wantOK: false,
+		},
+		{
+			name:       "api_error_500",
+			status:     http.StatusInternalServerError,
+			body:       `{"type":"error","error":{"type":"api_error","message":"Internal server error"}}`,
+			wantOK:     true,
+			wantSubstr: "api_error",
+		},
+		{
+			name:       "overloaded_529",
+			status:     529,
+			body:       `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			wantOK:     true,
+			wantSubstr: "overloaded",
+		},
+		{
+			name:   "client_error_400",
+			status: http.StatusBadRequest,
+			body:   `{"type":"error","error":{"type":"invalid_request_error"}}`,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, ok := anthropicUpstreamSkipReason(tc.status, []byte(tc.body))
+			if ok != tc.wantOK {
+				t.Fatalf("ok=%v, want %v (reason=%q)", ok, tc.wantOK, reason)
+			}
+			if tc.wantOK && tc.wantSubstr != "" && !strings.Contains(reason, tc.wantSubstr) {
+				t.Fatalf("reason %q missing %q", reason, tc.wantSubstr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

- CircleCI [job 559](https://app.circleci.com/jobs/github/Instawork/llm-proxy/559) failed in `integration-tests` because `TestAnthropicIntegration_Models/Claude-Opus-4.6/NonStreaming` got a transient Anthropic `500 api_error` while streaming and other Opus scenarios passed on the same run.
- Add `skipOnAnthropicUpstreamError`, mirroring the existing OpenAI `insufficient_quota` skip helper, to treat Anthropic `529` and `5xx api_error` responses as upstream flakes rather than proxy regressions.
- Unit-test the skip-reason matcher.

## Test plan

- [x] `make check`
- [x] `go test ./internal/providers/ -run TestAnthropicUpstreamSkipReason`
- [ ] CircleCI `integration-tests` green on this branch