### PR TITLE
fix(circuit): report Open in GetProviderStats when failure window is empty

### DIFF
--- a/internal/circuit/memory_test.go
+++ b/internal/circuit/memory_test.go
@@ -214,6 +214,27 @@ func TestMemoryStore_GetProviderStats_AggregatesPerModelKeys(t *testing.T) {
 	require.Equal(t, 3, agg.Failures)
 }
 
+// Parity with the RedisStore regression: an Open breaker with an empty
+// failure window (re-opened via a failed probe) must still report Open.
+func TestMemoryStore_GetProviderStats_OpenWithEmptyFailureWindow(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.WindowSeconds = 60
+	cfg.CooldownSeconds = 300
+	s := NewMemoryStore(cfg)
+	ctx := context.Background()
+
+	require.NoError(t, s.RecordProbeFailed(ctx, "openai"))
+
+	bare, err := s.GetStats(ctx, "openai")
+	require.NoError(t, err)
+	require.Equal(t, 0, bare.Failures)
+
+	agg, err := s.GetProviderStats(ctx, "openai")
+	require.NoError(t, err)
+	require.Equal(t, StateOpen, agg.State)
+	require.Equal(t, 0, agg.Failures)
+}
+
 func TestMemoryStore_GetStatsPrunesExpiredFailures(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.WindowSeconds = 1

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -432,46 +432,66 @@ func (s *RedisStore) GetStats(ctx context.Context, key string) (*ProviderStats, 
 
 // GetProviderStats aggregates failures and worst-case state across every
 // per-model key for provider (see ProviderStatsFor).
+//
+// Keys are enumerated from the failures, state, AND half-open marker
+// keyspaces, then unioned.  Scanning failures alone is NOT enough: a circuit
+// that re-opened via a failed half-open probe (RecordProbeFailed sets the
+// state + half-open marker but adds no failure timestamp), or whose failure
+// window has simply pruned to empty while the cooldown is still in force, has
+// a live state/half-open key but zero entries in `failures:<key>`.
+// Enumerating only `failures:*` misses such a key entirely and reports the
+// provider Closed even though it is actively fast-failing — the exact
+// dashboard-says-closed-while-Redis-says-open discrepancy this guards against.
 func (s *RedisStore) GetProviderStats(ctx context.Context, provider string) (*ProviderStats, error) {
 	now := float64(time.Now().UnixNano()) / 1e9
 	cutoff := fmt.Sprintf("%f", now-float64(s.cfg.WindowSeconds))
 	stats := &ProviderStats{State: StateClosed}
 
-	match := redisKeyFailures + provider + "*"
-	var cursor uint64
-	for {
-		keys, next, err := s.rdb.Scan(ctx, cursor, match, 128).Result()
-		if err != nil {
-			return nil, err
+	// Union of every circuit key for this provider across all three per-key
+	// keyspaces, de-duped so a key carrying both failures and a state marker
+	// is only processed once.
+	cbKeys := make(map[string]struct{})
+	for _, prefix := range []string{redisKeyFailures, redisKeyState, redisKeyHalfOpen} {
+		match := prefix + provider + "*"
+		var cursor uint64
+		for {
+			keys, next, err := s.rdb.Scan(ctx, cursor, match, 128).Result()
+			if err != nil {
+				return nil, err
+			}
+			for _, rk := range keys {
+				cbKey := strings.TrimPrefix(rk, prefix)
+				if !providerKeyMatches(cbKey, provider) {
+					continue
+				}
+				cbKeys[cbKey] = struct{}{}
+			}
+			cursor = next
+			if cursor == 0 {
+				break
+			}
 		}
-		for _, fkey := range keys {
-			cbKey := strings.TrimPrefix(fkey, redisKeyFailures)
-			if !providerKeyMatches(cbKey, provider) {
-				continue
-			}
-			count, err := s.rdb.ZCount(ctx, fkey, cutoff, "+inf").Result()
-			if err != nil {
-				continue
-			}
-			stats.Failures += int(count)
+	}
 
-			state, err := s.GetState(ctx, cbKey)
-			if err != nil {
-				continue
-			}
-			stats.State = worseState(stats.State, state)
-			if state == StateOpen {
-				if dur, err := s.rdb.TTL(ctx, s.stateKey(cbKey)).Result(); err == nil && dur > 0 {
-					t := time.Now().Add(dur)
-					if stats.CooldownUntil == nil || t.Before(*stats.CooldownUntil) {
-						stats.CooldownUntil = &t
-					}
+	for cbKey := range cbKeys {
+		// Failure count is best-effort: a missing/expired failures zset just
+		// contributes 0, but must NOT skip the state evaluation below.
+		if count, err := s.rdb.ZCount(ctx, s.failuresKey(cbKey), cutoff, "+inf").Result(); err == nil {
+			stats.Failures += int(count)
+		}
+
+		state, err := s.GetState(ctx, cbKey)
+		if err != nil {
+			continue
+		}
+		stats.State = worseState(stats.State, state)
+		if state == StateOpen {
+			if dur, err := s.rdb.TTL(ctx, s.stateKey(cbKey)).Result(); err == nil && dur > 0 {
+				t := time.Now().Add(dur)
+				if stats.CooldownUntil == nil || t.Before(*stats.CooldownUntil) {
+					stats.CooldownUntil = &t
 				}
 			}
-		}
-		cursor = next
-		if cursor == 0 {
-			break
 		}
 	}
 	return stats, nil

--- a/internal/circuit/redis_behavior_test.go
+++ b/internal/circuit/redis_behavior_test.go
@@ -99,6 +99,59 @@ func TestRedisStore_GetProviderStats_AggregatesPerModelKeys(t *testing.T) {
 	require.Equal(t, 3, agg.Failures)
 }
 
+// Regression: a circuit that is Open with an EMPTY failure window must still
+// be reported Open by GetProviderStats. This reproduces the production
+// dashboard-says-closed-while-Redis-says-open bug, where the per-model
+// breaker re-opened via a failed half-open probe (RecordProbeFailed sets the
+// state + half-open marker but records no failure timestamp), so scanning
+// only `failures:*` keys found nothing and defaulted to Closed.
+func TestRedisStore_GetProviderStats_OpenWithEmptyFailureWindow(t *testing.T) {
+	cfg := Config{
+		FailureThreshold: 1,
+		WindowSeconds:    60,
+		CooldownSeconds:  300,
+	}.Defaults()
+	store, _ := newRedisStoreForBehaviorTest(t, cfg)
+	ctx := context.Background()
+
+	// Re-open the bare-provider key via a failed probe: this sets state=open
+	// and the half-open marker but adds NO entry to the failures zset.
+	require.NoError(t, store.RecordProbeFailed(ctx, "openai"))
+
+	// Sanity: the failures zset is empty, so the old failures-only scan would
+	// have seen nothing here.
+	cnt, err := store.rdb.ZCard(ctx, store.failuresKey("openai")).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), cnt)
+
+	agg, err := store.GetProviderStats(ctx, "openai")
+	require.NoError(t, err)
+	require.Equal(t, StateOpen, agg.State, "open breaker with empty failure window must report Open")
+	require.Equal(t, 0, agg.Failures)
+	require.NotNil(t, agg.CooldownUntil, "Open state should surface a cooldown expiry")
+}
+
+// Regression: a per-model breaker that is Open with an empty failure window
+// must propagate Open to the provider-level aggregate even when a sibling
+// model key is Closed.
+func TestRedisStore_GetProviderStats_OpenPerModelKeyWithoutFailures(t *testing.T) {
+	cfg := Config{
+		FailureThreshold: 1,
+		WindowSeconds:    60,
+		CooldownSeconds:  300,
+	}.Defaults()
+	store, _ := newRedisStoreForBehaviorTest(t, cfg)
+	ctx := context.Background()
+
+	// One model re-opened via a failed probe (no failure timestamps), another
+	// is healthy/closed.
+	require.NoError(t, store.RecordProbeFailed(ctx, "openai:gpt-5.5"))
+
+	agg, err := store.GetProviderStats(ctx, "openai")
+	require.NoError(t, err)
+	require.Equal(t, StateOpen, agg.State, "worst-case state across model keys must be Open")
+}
+
 func TestRedisStore_StateTransitionsFromOpenToHalfOpenThenClosedAfterIdle(t *testing.T) {
 	cfg := Config{
 		FailureThreshold: 1,


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

Fixes a production bug where the admin circuit dashboard and `/health` reported a provider as `closed` while Redis actually held `state:<provider>=open` and the proxy was actively fast-failing requests with `[LLM_PROXY_PROVIDER_DEGRADED]`.

`RedisStore.GetProviderStats` enumerated circuit keys **only** from `llm:cb:failures:<provider>*`. A breaker that:

- re-opened via a failed half-open probe (`RecordProbeFailed` sets the `state` + half-open marker but records **no** failure timestamp), or
- had its sliding failure window prune to empty while the cooldown was still in force

…has a live `state:`/`halfopen:` key but an **empty** `failures:` zset. The failures-only `SCAN` found nothing, so the function fell through to its `StateClosed` default. Because `/health`, the admin dashboard provider table, and the daily-history rollups all funnel through `GetProviderStats` (via `ProviderStatsFor`), they all under-reported the state.

This was confirmed live in prod via `aws ecs execute-command` against the `llm-proxy` task (Redis DB 5):

- `GET llm:cb:state:openai` -> `open` (TTL ~252s)
- `llm:cb:halfopen:openai` present, `llm:cb:rollup:openai` -> `openai`
- `ZCARD llm:cb:failures:openai` -> `0`
- `/health` -> `openai.state: closed`  ← the bug

## Fix

- Enumerate the **union** of `failures:`, `state:`, and `halfopen:` keys per provider, de-duped, then evaluate `GetState` for each key.
- Failure count is now best-effort and no longer gates the state read (a missing/expired failures zset contributes `0` but never skips state).
- `MemoryStore.GetProviderStats` was already correct (it iterates live entries); added a parity regression test to keep it that way.

## Test plan

- [ ] `TestRedisStore_GetProviderStats_OpenWithEmptyFailureWindow` (new) — Open via failed probe, empty failures zset, still reports Open + cooldown.
- [ ] `TestRedisStore_GetProviderStats_OpenPerModelKeyWithoutFailures` (new) — per-model open key propagates Open to provider aggregate.
- [ ] `TestMemoryStore_GetProviderStats_OpenWithEmptyFailureWindow` (new) — memory parity.
- [ ] `go test ./internal/circuit/ ./internal/adminrollup/ ./internal/circuitstats/` passes; `gofmt`/`go vet` clean; `go build ./...` clean.

## Notes / follow-ups (not in this PR)

- The "Failures by provider" bar + "Failure trend" charts are a **current 120s window gauge**, so they can legitimately read 0 even when a breaker is Open — that is by design, not part of this fix.
- The admin "Recovery activity" table renders each event's `new_state` under a column titled `Result`, which reads confusingly next to the live provider `State`. Consider relabeling to `State at event` / `Current state` in a follow-up UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed circuit breaker state reporting to accurately reflect provider status even when the failure window is empty, ensuring open states are properly communicated regardless of failure count.

* **Tests**
  * Added regression tests verifying correct circuit breaker state aggregation across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->