### PR TITLE
Add DynamoDB admin user RBAC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ MAIN_PATH=./cmd/llm-proxy
 KEYS_BINARY_NAME=llm-proxy-keys
 KEYS_BINARY_PATH=./bin/$(KEYS_BINARY_NAME)
 KEYS_MAIN_PATH=./cmd/llm-proxy-keys
+USERS_BINARY_NAME=llm-proxy-users
+USERS_BINARY_PATH=./bin/$(USERS_BINARY_NAME)
+USERS_MAIN_PATH=./cmd/llm-proxy-users
 GO_VERSION=$(shell go version | cut -d' ' -f3)
 GIT_COMMIT=$(shell git rev-parse --short HEAD || echo "unknown")
 BUILD_TIME=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -145,9 +148,16 @@ build-keys:
 	@go build -ldflags="-X main.Version=$(GIT_COMMIT) -X main.BuildTime=$(BUILD_TIME)" -o $(KEYS_BINARY_PATH) $(KEYS_MAIN_PATH)
 	@echo "$(GREEN)✓ Build completed: $(KEYS_BINARY_PATH)$(NC)"
 
+.PHONY: build-users
+build-users:
+	@echo "$(BLUE)Building $(USERS_BINARY_NAME)...$(NC)"
+	@mkdir -p bin
+	@go build -o $(USERS_BINARY_PATH) $(USERS_MAIN_PATH)
+	@echo "$(GREEN)✓ Build completed: $(USERS_BINARY_PATH)$(NC)"
+
 # Build all binaries
 .PHONY: build-all
-build-all: build build-keys
+build-all: build build-keys build-users
 	@echo "$(GREEN)✓ All binaries built successfully$(NC)"
 
 # Clean build artifacts

--- a/cmd/llm-proxy-users/main.go
+++ b/cmd/llm-proxy-users/main.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+const version = "1.0.0"
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "set-role", "list", "get":
+		runCommand(os.Args[1], os.Args[2:])
+	default:
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "LLM Proxy Admin User Manager v%s\n\n", version)
+	fmt.Fprintf(os.Stderr, "Usage:\n")
+	fmt.Fprintf(os.Stderr, "  %s set-role -email user@example.com -role admin\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s list\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s get -email user@example.com\n\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Flags:\n")
+	fmt.Fprintf(os.Stderr, "  -config-dir  Path to configuration directory (default: configs)\n")
+	fmt.Fprintf(os.Stderr, "  -env         Environment overlay (default: dev)\n")
+	fmt.Fprintf(os.Stderr, "  -email       User email\n")
+	fmt.Fprintf(os.Stderr, "  -role        admin, editor, or viewer\n")
+}
+
+func runCommand(command string, args []string) {
+	fs := flag.NewFlagSet(command, flag.ExitOnError)
+	configDir := fs.String("config-dir", "configs", "Path to configuration directory")
+	environment := fs.String("env", "dev", "Environment (dev, staging, production)")
+	email := fs.String("email", "", "User email")
+	role := fs.String("role", "", "Role: admin, editor, or viewer")
+	_ = fs.Parse(args)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	yamlConfig, err := loadConfig(*configDir, *environment)
+	if err != nil {
+		logger.Error("failed to load configuration", "error", err)
+		os.Exit(1)
+	}
+	if !yamlConfig.Features.AdminDashboard.Enabled {
+		logger.Error("admin dashboard is not enabled in configuration")
+		os.Exit(1)
+	}
+
+	userCfg := yamlConfig.Features.AdminDashboard.Users.DynamoDB
+	if userCfg.TableName == "" || userCfg.Region == "" {
+		logger.Error("admin users dynamodb table_name and region are required in config")
+		os.Exit(1)
+	}
+
+	endpointURL := userCfg.EndpointURL
+	if endpointURL == "" {
+		endpointURL = os.Getenv("AWS_ENDPOINT_URL")
+	}
+
+	store, err := adminusers.NewStore(adminusers.StoreConfig{
+		TableName:       userCfg.TableName,
+		Region:          userCfg.Region,
+		EndpointURL:     endpointURL,
+		Logger:          logger,
+		AutoCreateTable: userCfg.AutoCreateTable,
+	})
+	if err != nil {
+		logger.Error("failed to create admin user store", "error", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	switch command {
+	case "set-role":
+		if *email == "" || *role == "" {
+			logger.Error("set-role requires -email and -role")
+			os.Exit(1)
+		}
+		handleSetRole(ctx, store, *email, *role, logger)
+	case "list":
+		handleList(ctx, store, logger)
+	case "get":
+		if *email == "" {
+			logger.Error("get requires -email")
+			os.Exit(1)
+		}
+		handleGet(ctx, store, *email, logger)
+	}
+}
+
+func loadConfig(configDir, environment string) (*config.YAMLConfig, error) {
+	configFiles := []string{filepath.Join(configDir, "base.yml")}
+	if environment != "base" {
+		configFiles = append(configFiles, filepath.Join(configDir, fmt.Sprintf("%s.yml", environment)))
+	}
+	return config.LoadAndMergeConfigs(configFiles)
+}
+
+func handleSetRole(ctx context.Context, store *adminusers.Store, email, roleStr string, logger *slog.Logger) {
+	role, err := adminusers.ParseRole(roleStr)
+	if err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+
+	_, getErr := store.GetUser(ctx, email)
+	if getErr != nil {
+		if _, err := store.CreateUser(ctx, email, role); err != nil {
+			logger.Error("failed to create user", "error", err)
+			os.Exit(1)
+		}
+		fmt.Printf("✅ Created %s with role %s\n", strings.ToLower(email), role)
+		return
+	}
+
+	if err := store.SetRole(ctx, email, role); err != nil {
+		logger.Error("failed to set role", "error", err)
+		os.Exit(1)
+	}
+	fmt.Printf("✅ Updated %s to role %s\n", strings.ToLower(email), role)
+}
+
+func handleList(ctx context.Context, store *adminusers.Store, logger *slog.Logger) {
+	users, err := store.ListUsers(ctx)
+	if err != nil {
+		logger.Error("failed to list users", "error", err)
+		os.Exit(1)
+	}
+	if len(users) == 0 {
+		fmt.Println("No users found")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "EMAIL\tROLE\tNAME\tLAST LOGIN\tCREATED")
+	fmt.Fprintln(w, "-----\t----\t----\t----------\t-------")
+	for _, u := range users {
+		lastLogin := "—"
+		if !u.LastLoginAt.IsZero() {
+			lastLogin = u.LastLoginAt.Format(time.RFC3339)
+		}
+		name := u.Name
+		if name == "" {
+			name = "—"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", u.Email, u.Role, name, lastLogin, u.CreatedAt.Format("2006-01-02"))
+	}
+	w.Flush()
+}
+
+func handleGet(ctx context.Context, store *adminusers.Store, email string, logger *slog.Logger) {
+	u, err := store.GetUser(ctx, email)
+	if err != nil {
+		logger.Error("failed to get user", "error", err)
+		os.Exit(1)
+	}
+	fmt.Printf("\nUser Details:\n\n")
+	fmt.Printf("Email:      %s\n", u.Email)
+	fmt.Printf("Role:       %s\n", u.Role)
+	if u.Name != "" {
+		fmt.Printf("Name:       %s\n", u.Name)
+	}
+	if !u.LastLoginAt.IsZero() {
+		fmt.Printf("Last login: %s\n", u.LastLoginAt.Format(time.RFC3339))
+	}
+	fmt.Printf("Created:    %s\n", u.CreatedAt.Format(time.RFC3339))
+	fmt.Printf("Updated:    %s\n", u.UpdatedAt.Format(time.RFC3339))
+}

--- a/cmd/llm-proxy-users/main.go
+++ b/cmd/llm-proxy-users/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -88,7 +89,8 @@ func runCommand(command string, args []string) {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	switch command {
 	case "set-role":
@@ -125,12 +127,16 @@ func handleSetRole(ctx context.Context, store *adminusers.Store, email, roleStr 
 
 	_, getErr := store.GetUser(ctx, email)
 	if getErr != nil {
-		if _, err := store.CreateUser(ctx, email, role); err != nil {
-			logger.Error("failed to create user", "error", err)
-			os.Exit(1)
+		if errors.Is(getErr, adminusers.ErrUserNotFound) {
+			if _, err := store.CreateUser(ctx, email, role); err != nil {
+				logger.Error("failed to create user", "error", err)
+				os.Exit(1)
+			}
+			fmt.Printf("✅ Created %s with role %s\n", strings.ToLower(email), role)
+			return
 		}
-		fmt.Printf("✅ Created %s with role %s\n", strings.ToLower(email), role)
-		return
+		logger.Error("failed to get user", "error", getErr)
+		os.Exit(1)
 	}
 
 	if err := store.SetRole(ctx, email, role); err != nil {

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/Instawork/llm-proxy/internal/admin"
 	"github.com/Instawork/llm-proxy/internal/adminrollup"
+	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/circuit"
 	"github.com/Instawork/llm-proxy/internal/circuitstats"
@@ -106,6 +107,8 @@ var globalCostStatsRecorder *coststats.Recorder
 var (
 	globalAPIKeyStore          providers.APIKeyStore
 	globalAPIKeyStoreInitError error
+	globalAdminUserStore       *adminusers.Store
+	globalAdminUserStoreError  error
 	globalKeyProvisioner       *provision.Manager
 )
 
@@ -783,6 +786,41 @@ func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore 
 	return store
 }
 
+func initializeAdminUserStore(yamlConfig *config.YAMLConfig) *adminusers.Store {
+	if yamlConfig == nil || !yamlConfig.Features.AdminDashboard.Enabled {
+		logger.Info("👤 Admin User Store: admin dashboard disabled")
+		return nil
+	}
+
+	userCfg := yamlConfig.Features.AdminDashboard.Users.DynamoDB
+	if userCfg.TableName == "" || userCfg.Region == "" {
+		logger.Error("👤 Admin User Store: missing table_name or region")
+		globalAdminUserStoreError = fmt.Errorf("admin users dynamodb table_name and region are required")
+		return nil
+	}
+
+	endpointURL := userCfg.EndpointURL
+	if endpointURL == "" {
+		endpointURL = os.Getenv("AWS_ENDPOINT_URL")
+	}
+
+	store, err := adminusers.NewStore(adminusers.StoreConfig{
+		TableName:       userCfg.TableName,
+		Region:          userCfg.Region,
+		EndpointURL:     endpointURL,
+		Logger:          logger,
+		AutoCreateTable: userCfg.AutoCreateTable,
+	})
+	if err != nil {
+		globalAdminUserStoreError = err
+		logger.Error("👤 Admin User Store: failed to initialize", "error", err)
+		return nil
+	}
+
+	logger.Info("👤 Admin User Store: successfully initialized", "table", userCfg.TableName)
+	return store
+}
+
 // piiSummaryFunc returns a snapshot closure for the admin /pii endpoint, or
 // newPerKeyOverrideProvider returns a cached PerKeyOverrideFunc that resolves
 // an iw: key's rate-limit overrides from its DynamoDB record. Results (hits
@@ -1206,6 +1244,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 
 	// Initialize API key store if enabled
 	globalAPIKeyStore = initializeAPIKeyStore(yamlConfig)
+	globalAdminUserStore = initializeAdminUserStore(yamlConfig)
 
 	provRT := provision.RuntimeFromYAML(yamlConfig.Features.APIKeyManagement.Provisioning)
 	keyProvisioner, provErr := provision.NewManagerFromRuntime(provRT, logger)
@@ -1450,6 +1489,8 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			YAMLConfig:       yamlConfig,
 			APIKeyStore:      keyStore,
 			APIKeyStoreError: globalAPIKeyStoreInitError,
+			UserStore:        globalAdminUserStore,
+			UserStoreError:   globalAdminUserStoreError,
 			RateLimiter:      globalRateLimiter,
 			HealthFunc:       healthHandler,
 			PIISummary:       piiSummaryFunc(),

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -74,6 +74,13 @@ features:
         db: 6
       retention_days: 90
       history_days: 30
+    users:
+      dynamodb:
+        region: "us-west-2"
+        table_name: "llm-proxy-admin-users"
+        auto_create_table: false
+    editor_limits:
+      max_daily_cost_limit_cents: 10000
   # ---------------------------------------------------------------------------
   # Row history (gzipped JSONL archive — independent of Redis rollups)
   # ---------------------------------------------------------------------------

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -50,6 +50,10 @@ features:
   admin_dashboard:
     enabled: true
     dev_bypass_login: true
+    users:
+      dynamodb:
+        table_name: "llm-proxy-admin-users-dev"
+        auto_create_table: true
     rollups:
       enabled: true
       redis:

--- a/configs/staging.yml
+++ b/configs/staging.yml
@@ -22,6 +22,10 @@ features:
     key_prefix: "iw"
     provisioning:
       enabled: false
+  admin_dashboard:
+    users:
+      dynamodb:
+        table_name: "llm-proxy-admin-users-staging"
   # Circuit breaker: enforce mode (matching production).
   circuit_breaker:
     enabled: true

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -379,14 +379,16 @@ func (a *authenticator) currentUser(r *http.Request) (*UserResponse, error) {
 
 	role := string(adminusers.RoleViewer)
 	if a.userStore != nil {
-		if u, err := a.userStore.GetUser(r.Context(), email); err == nil {
-			role = string(u.Role)
-			if u.Name != "" {
-				name = u.Name
-			}
-			if u.Picture != "" {
-				picture = u.Picture
-			}
+		u, err := a.userStore.GetUser(r.Context(), email)
+		if err != nil {
+			return nil, fmt.Errorf("user lookup failed: %w", err)
+		}
+		role = string(u.Role)
+		if u.Name != "" {
+			name = u.Name
+		}
+		if u.Picture != "" {
+			picture = u.Picture
 		}
 	}
 

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -45,10 +46,12 @@ type authenticator struct {
 	redirectURLEnv    string
 	devBypass         bool
 	devFrontendOrigin string
+	userStore         *adminusers.Store
+	editorLimits      config.EditorLimitsConfig
 	logger            *slog.Logger
 }
 
-func newAuthenticator(logger *slog.Logger, adminCfg config.AdminDashboardConfig) (*authenticator, error) {
+func newAuthenticator(logger *slog.Logger, adminCfg config.AdminDashboardConfig, userStore *adminusers.Store) (*authenticator, error) {
 	// Resolve the allowed sign-in domain with the env var taking precedence over
 	// the YAML value, then fall back to example.com. Doing it here (not just in
 	// loadAuthConfig) ensures auth.allowedDomain — the value isAllowedUser checks —
@@ -86,6 +89,8 @@ func newAuthenticator(logger *slog.Logger, adminCfg config.AdminDashboardConfig)
 		allowedDomain:     allowedDomain,
 		devBypass:         adminCfg.DevBypassLogin,
 		devFrontendOrigin: adminCfg.DevCORSOrigin,
+		userStore:         userStore,
+		editorLimits:      adminCfg.EditorLimits,
 		logger:            logger,
 	}
 
@@ -206,6 +211,15 @@ func (a *authenticator) handleDevLogin(w http.ResponseWriter, r *http.Request) {
 	session.Values[sessionUserEmail] = email
 	session.Values[sessionUserName] = "Dev User"
 	session.Values[sessionUserPicture] = devUserPicture("Dev User")
+
+	if a.userStore != nil {
+		if _, _, err := a.userStore.EnsureUser(r.Context(), email, "Dev User", devUserPicture("Dev User")); err != nil {
+			a.logger.Error("admin auth: dev ensure user failed", "error", err, "email", email)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+
 	if err := session.Save(r, w); err != nil {
 		a.logger.Error("admin auth: dev login session save failed", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -318,6 +332,14 @@ func (a *authenticator) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if a.userStore != nil {
+		if _, _, err := a.userStore.EnsureUser(r.Context(), claims.Email, claims.Name, claims.Picture); err != nil {
+			a.logger.Error("admin auth: ensure user failed", "error", err, "email", claims.Email)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+
 	session.Values[sessionUserEmail] = claims.Email
 	session.Values[sessionUserName] = claims.Name
 	session.Values[sessionUserPicture] = claims.Picture
@@ -354,12 +376,33 @@ func (a *authenticator) currentUser(r *http.Request) (*UserResponse, error) {
 	}
 	name, _ := session.Values[sessionUserName].(string)
 	picture, _ := session.Values[sessionUserPicture].(string)
-	return &UserResponse{
+
+	role := string(adminusers.RoleViewer)
+	if a.userStore != nil {
+		if u, err := a.userStore.GetUser(r.Context(), email); err == nil {
+			role = string(u.Role)
+			if u.Name != "" {
+				name = u.Name
+			}
+			if u.Picture != "" {
+				picture = u.Picture
+			}
+		}
+	}
+
+	resp := &UserResponse{
 		Email:                           email,
 		Name:                            name,
 		Picture:                         picture,
+		Role:                            role,
 		CanBypassPIIOffNonBedrockPolicy: apikeys.CanBypassPIIOffNonBedrockPolicy(email),
-	}, nil
+	}
+	if role == string(adminusers.RoleEditor) && a.editorLimits.MaxDailyCostLimitCents > 0 {
+		resp.EditorLimits = &EditorLimitsResponse{
+			MaxDailyCostLimitCents: a.editorLimits.MaxDailyCostLimitCents,
+		}
+	}
+	return resp, nil
 }
 
 func devUserPicture(name string) string {

--- a/internal/admin/auth_oauth_test.go
+++ b/internal/admin/auth_oauth_test.go
@@ -201,7 +201,7 @@ func TestNewAuthenticator_AllowedDomainHonorsEnvOverride(t *testing.T) {
 	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
 		DevBypassLogin: true,
 		AllowedDomain:  "example.com",
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "instawork.com", auth.allowedDomain)
 	assert.True(t, auth.isAllowedUser("alice@instawork.com", "instawork.com"))
@@ -449,7 +449,7 @@ func TestNewAuthenticator_DevBypassWithoutGoogleOAuth(t *testing.T) {
 	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
 		DevBypassLogin: true,
 		AllowedDomain:  "example.com",
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Nil(t, auth.oauthConfig)
 	assert.True(t, auth.devBypass)
@@ -466,7 +466,7 @@ func TestNewAuthenticator_RequiresSessionSecretInProd(t *testing.T) {
 	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "")
 	_, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
 		DevBypassLogin: false,
-	})
+	}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "LLM_PROXY_ADMIN_SESSION_SECRET")
 }

--- a/internal/admin/auth_oauth_test.go
+++ b/internal/admin/auth_oauth_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-jose/go-jose/v4"
@@ -140,7 +141,7 @@ func (td *testOIDCServer) mintIDToken(claims idTokenClaims) string {
 	return raw
 }
 
-func newTestOAuthAuthenticator(t *testing.T, oidcSrv *testOIDCServer, allowedDomain string) *authenticator {
+func newTestOAuthAuthenticator(t *testing.T, oidcSrv *testOIDCServer, allowedDomain string, userStore ...*adminusers.Store) *authenticator {
 	t.Helper()
 	provider, err := oidc.NewProvider(context.Background(), oidcSrv.issuer)
 	require.NoError(t, err)
@@ -148,7 +149,7 @@ func newTestOAuthAuthenticator(t *testing.T, oidcSrv *testOIDCServer, allowedDom
 	sessionStore := sessions.NewCookieStore([]byte("test-secret-at-least-32-bytes-long"))
 	sessionStore.Options = &sessions.Options{Path: "/", MaxAge: 3600, HttpOnly: true}
 
-	return &authenticator{
+	auth := &authenticator{
 		oauthConfig: &oauth2.Config{
 			ClientID:     testOAuthClientID,
 			ClientSecret: "test-secret",
@@ -165,6 +166,10 @@ func newTestOAuthAuthenticator(t *testing.T, oidcSrv *testOIDCServer, allowedDom
 		devFrontendOrigin: "http://localhost:5173",
 		logger:            testLogger(),
 	}
+	if len(userStore) > 0 {
+		auth.userStore = userStore[0]
+	}
+	return auth
 }
 
 func saveOAuthStateSession(t *testing.T, auth *authenticator, w http.ResponseWriter, r *http.Request, state string) {
@@ -297,6 +302,30 @@ func TestHandleCallback_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "alice@example.com", user.Email)
 	assert.Equal(t, "Alice Example", user.Name)
+}
+
+func TestHandleCallback_EnsureUser(t *testing.T) {
+	oidcSrv := newTestOIDCServer(t)
+	userStore := testAdminUserStore(t)
+	auth := newTestOAuthAuthenticator(t, oidcSrv, "example.com", userStore)
+	state := "test-oauth-state-ensure-user"
+
+	loginRec := httptest.NewRecorder()
+	loginReq := httptest.NewRequest(http.MethodGet, "/admin/auth/login", nil)
+	saveOAuthStateSession(t, auth, loginRec, loginReq, state)
+
+	cbRec := httptest.NewRecorder()
+	cbReq := httptest.NewRequest(http.MethodGet, "/admin/auth/callback?state="+state+"&code=auth-code-xyz", nil)
+	for _, c := range sessionCookies(t, loginRec) {
+		cbReq.AddCookie(c)
+	}
+	auth.handleCallback(cbRec, cbReq)
+	require.Equal(t, http.StatusFound, cbRec.Code)
+
+	got, err := userStore.GetUser(context.Background(), "alice@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, adminusers.RoleViewer, got.Role)
+	assert.Equal(t, "Alice Example", got.Name)
 }
 
 func TestHandleCallback_InvalidState(t *testing.T) {

--- a/internal/admin/auth_test.go
+++ b/internal/admin/auth_test.go
@@ -36,7 +36,7 @@ func TestHandleDevLogin_SetsSession(t *testing.T) {
 	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
 		DevBypassLogin: true,
 		DevCORSOrigin:  "http://localhost:5173",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("newAuthenticator: %v", err)
 	}

--- a/internal/admin/deps.go
+++ b/internal/admin/deps.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/provision"
@@ -16,6 +17,8 @@ type Deps struct {
 	YAMLConfig       *config.YAMLConfig
 	APIKeyStore      *apikeys.Store
 	APIKeyStoreError error
+	UserStore        *adminusers.Store
+	UserStoreError   error
 	RateLimiter      ratelimit.RateLimiter
 	HealthFunc       http.HandlerFunc
 	CostSummary      func() map[string]interface{}

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -162,6 +162,11 @@ func (h *handler) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := h.validateEditorCostLimit(r, req.DailyCostLimit); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
 	key, err := h.deps.APIKeyStore.CreateKeyWithMeta(
 		r.Context(),
 		req.Provider,
@@ -234,6 +239,10 @@ func (h *handler) handleUpdateKey(w http.ResponseWriter, r *http.Request) {
 		updates["description"] = *req.Description
 	}
 	if req.DailyCostLimit != nil {
+		if err := h.validateEditorCostLimit(r, *req.DailyCostLimit); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
 		updates["daily_cost_limit"] = *req.DailyCostLimit
 	}
 	if req.Tags != nil {
@@ -611,6 +620,12 @@ func (h *handler) handleGetShare(w http.ResponseWriter, r *http.Request) {
 		"client_ip", clientIP(r),
 		"created_by", link.CreatedBy,
 	)
+
+	if user, err := h.auth.currentUser(r); err == nil && h.deps.UserStore != nil {
+		if recErr := h.deps.UserStore.RecordShareAwareness(r.Context(), user.Email, id); recErr != nil {
+			h.deps.Logger.Warn("admin: record share awareness failed", "error", recErr, "email", user.Email, "share_id", id)
+		}
+	}
 
 	// Belt-and-suspenders against the capability URL being indexed if it ever
 	// leaks into a crawlable surface.

--- a/internal/admin/rbac.go
+++ b/internal/admin/rbac.go
@@ -83,7 +83,7 @@ func (h *handler) editorMaxDailyCostCents() int64 {
 func (h *handler) validateEditorCostLimit(r *http.Request, cents int64) error {
 	role, err := h.auth.userRole(r)
 	if err != nil {
-		return nil
+		return fmt.Errorf("unable to resolve user role: %w", err)
 	}
 	if role != adminusers.RoleEditor {
 		return nil

--- a/internal/admin/rbac.go
+++ b/internal/admin/rbac.go
@@ -1,0 +1,96 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+)
+
+func (a *authenticator) userRole(r *http.Request) (adminusers.Role, error) {
+	user, err := a.currentUser(r)
+	if err != nil {
+		return "", err
+	}
+	role, err := adminusers.ParseRole(user.Role)
+	if err != nil {
+		return adminusers.RoleViewer, nil
+	}
+	return role, nil
+}
+
+func (a *authenticator) requireRole(min adminusers.Role) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			role, err := a.userRole(r)
+			if err != nil {
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+				return
+			}
+			if !role.AtLeast(min) {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func isAllowedDomainEmail(email, allowedDomain string) bool {
+	email = strings.TrimSpace(email)
+	allowedDomain = strings.TrimSpace(allowedDomain)
+	if email == "" || allowedDomain == "" {
+		return false
+	}
+	at := strings.LastIndex(email, "@")
+	if at < 0 {
+		return false
+	}
+	return strings.EqualFold(email[at+1:], allowedDomain)
+}
+
+func validateAllowedEmail(email, allowedDomain string) error {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if !strings.Contains(email, "@") {
+		return fmt.Errorf("invalid email")
+	}
+	if !isAllowedDomainEmail(email, allowedDomain) {
+		return fmt.Errorf("email domain not allowed")
+	}
+	return nil
+}
+
+func userRecordFromStore(u adminusers.User) AdminUserRecord {
+	return AdminUserRecord{
+		Email:       u.Email,
+		Name:        u.Name,
+		Picture:     u.Picture,
+		Role:        string(u.Role),
+		CreatedAt:   u.CreatedAt,
+		UpdatedAt:   u.UpdatedAt,
+		LastLoginAt: u.LastLoginAt,
+	}
+}
+
+func (h *handler) editorMaxDailyCostCents() int64 {
+	if h.deps.YAMLConfig == nil {
+		return 0
+	}
+	return h.deps.YAMLConfig.Features.AdminDashboard.EditorLimits.MaxDailyCostLimitCents
+}
+
+func (h *handler) validateEditorCostLimit(r *http.Request, cents int64) error {
+	role, err := h.auth.userRole(r)
+	if err != nil {
+		return nil
+	}
+	if role != adminusers.RoleEditor {
+		return nil
+	}
+	max := h.editorMaxDailyCostCents()
+	if max > 0 && cents > max {
+		return fmt.Errorf("daily_cost_limit exceeds editor maximum of %d cents", max)
+	}
+	return nil
+}

--- a/internal/admin/rbac_test.go
+++ b/internal/admin/rbac_test.go
@@ -1,0 +1,69 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAllowedEmail(t *testing.T) {
+	assert.NoError(t, validateAllowedEmail("user@example.com", "example.com"))
+	assert.Error(t, validateAllowedEmail("bad", "example.com"))
+	assert.Error(t, validateAllowedEmail("user@other.com", "example.com"))
+}
+
+func TestIsAllowedDomainEmail(t *testing.T) {
+	assert.True(t, isAllowedDomainEmail("a@Example.COM", "example.com"))
+	assert.False(t, isAllowedDomainEmail("", "example.com"))
+	assert.False(t, isAllowedDomainEmail("no-at-sign", "example.com"))
+}
+
+func TestRequireRoleAllowsAdmin(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/users", nil)
+	rec := httptest.NewRecorder()
+	roleHandler(h.auth, adminusers.RoleAdmin, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestRequireRoleAllowsEditorForEditorRoute(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "editor@example.com", adminusers.RoleEditor)
+	require.NoError(t, err)
+
+	req := authenticatedRequestAs(t, h, "editor@example.com", http.MethodGet, "/admin/api/keys", nil)
+	rec := httptest.NewRecorder()
+	roleHandler(h.auth, adminusers.RoleEditor, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestValidateEditorCostLimitSkipsAdmin(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", nil)
+	err := h.validateEditorCostLimit(req, 99999999)
+	assert.NoError(t, err)
+}
+
+func TestValidateEditorCostLimitRejectsOverCap(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "editor@example.com", adminusers.RoleEditor)
+	require.NoError(t, err)
+
+	req := authenticatedRequestAs(t, h, "editor@example.com", http.MethodPost, "/admin/api/keys", nil)
+	err = h.validateEditorCostLimit(req, 99999999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "editor maximum")
+}
+
+func TestErrLastAdminMessage(t *testing.T) {
+	assert.Equal(t, "cannot remove the last admin", errLastAdmin.Error())
+}

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -4,9 +4,14 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/gorilla/mux"
 )
+
+func roleHandler(auth *authenticator, min adminusers.Role, fn http.HandlerFunc) http.Handler {
+	return auth.requireRole(min)(http.HandlerFunc(fn))
+}
 
 // RegisterRoutes mounts admin auth and JSON API routes on r.
 func RegisterRoutes(r *mux.Router, deps Deps) {
@@ -19,7 +24,7 @@ func RegisterRoutes(r *mux.Router, deps Deps) {
 	if deps.YAMLConfig != nil {
 		adminCfg = deps.YAMLConfig.Features.AdminDashboard
 	}
-	auth, err := newAuthenticator(logger, adminCfg)
+	auth, err := newAuthenticator(logger, adminCfg, deps.UserStore)
 	if err != nil {
 		logger.Error("admin dashboard disabled: auth setup failed", "error", err)
 		return
@@ -63,21 +68,28 @@ func RegisterRoutes(r *mux.Router, deps Deps) {
 	api.Use(auth.requireSession)
 
 	api.HandleFunc("/me", h.handleMe).Methods(http.MethodGet, http.MethodOptions)
-	api.HandleFunc("/keys", h.handleListKeys).Methods(http.MethodGet, http.MethodOptions)
-	api.HandleFunc("/keys", h.handleCreateKey).Methods(http.MethodPost, http.MethodOptions)
-	api.HandleFunc("/provisioning", h.handleProvisioning).Methods(http.MethodGet, http.MethodOptions)
-	api.HandleFunc("/keys/{key:.+}", h.handleGetKey).Methods(http.MethodGet, http.MethodOptions)
-	api.HandleFunc("/keys/{key:.+}", h.handleUpdateKey).Methods(http.MethodPatch, http.MethodOptions)
-	api.HandleFunc("/keys/{key:.+}", h.handleDeleteKey).Methods(http.MethodDelete, http.MethodOptions)
-	api.HandleFunc("/config", h.handleConfig).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/health", h.handleHealth).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/circuit-activity", h.handleCircuitActivity).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/rate-limits", h.handleRateLimits).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/cost", h.handleCost).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/usage", h.handleUsage).Methods(http.MethodGet, http.MethodOptions)
 	api.HandleFunc("/pii", h.handlePII).Methods(http.MethodGet, http.MethodOptions)
-	api.HandleFunc("/share", h.handleCreateShare).Methods(http.MethodPost, http.MethodOptions)
-	api.HandleFunc("/share/{id}", h.handleDeleteShare).Methods(http.MethodDelete, http.MethodOptions)
+
+	api.Handle("/config", roleHandler(auth, adminusers.RoleEditor, h.handleConfig)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/keys", roleHandler(auth, adminusers.RoleEditor, h.handleListKeys)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/keys", roleHandler(auth, adminusers.RoleEditor, h.handleCreateKey)).Methods(http.MethodPost, http.MethodOptions)
+	api.Handle("/provisioning", roleHandler(auth, adminusers.RoleEditor, h.handleProvisioning)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleEditor, h.handleGetKey)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleEditor, h.handleUpdateKey)).Methods(http.MethodPatch, http.MethodOptions)
+	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleAdmin, h.handleDeleteKey)).Methods(http.MethodDelete, http.MethodOptions)
+	api.Handle("/share", roleHandler(auth, adminusers.RoleEditor, h.handleCreateShare)).Methods(http.MethodPost, http.MethodOptions)
+	api.Handle("/share/{id}", roleHandler(auth, adminusers.RoleEditor, h.handleDeleteShare)).Methods(http.MethodDelete, http.MethodOptions)
+
+	api.Handle("/users", roleHandler(auth, adminusers.RoleAdmin, h.handleListUsers)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/users", roleHandler(auth, adminusers.RoleAdmin, h.handleCreateUser)).Methods(http.MethodPost, http.MethodOptions)
+	api.Handle("/users/{email:.+}", roleHandler(auth, adminusers.RoleAdmin, h.handleGetUser)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/users/{email:.+}", roleHandler(auth, adminusers.RoleAdmin, h.handleUpdateUserRole)).Methods(http.MethodPatch, http.MethodOptions)
+	api.Handle("/users/{email:.+}", roleHandler(auth, adminusers.RoleAdmin, h.handleDeleteUser)).Methods(http.MethodDelete, http.MethodOptions)
 
 	mountSPA(adminRouter)
 

--- a/internal/admin/share_handlers_test.go
+++ b/internal/admin/share_handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/testhelpers/dynamodbfake"
@@ -17,26 +18,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testAdminUserStore(t *testing.T) *adminusers.Store {
+	t.Helper()
+	store, err := adminusers.NewStore(adminusers.StoreConfig{
+		TableName:       "test-admin-users",
+		Region:          "us-west-2",
+		AutoCreateTable: true,
+	})
+	require.NoError(t, err)
+	return store
+}
+
 func testAdminHandler(t *testing.T) (*handler, *apikeys.Store) {
 	t.Helper()
 	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "admin@example.com")
 
 	fake := dynamodbfake.New(t)
 	dynamodbfake.UseFakeDynamo(t, fake.URL())
 	store, err := apikeys.NewStore(apikeys.StoreConfig{TableName: "test-keys", Region: "us-west-2"})
 	require.NoError(t, err)
 
+	userStore := testAdminUserStore(t)
+	_, err = userStore.CreateUser(context.Background(), "admin@example.com", adminusers.RoleAdmin)
+	require.NoError(t, err)
+
 	yamlCfg := config.GetDefaultYAMLConfig()
 	yamlCfg.Features.AdminDashboard.DevBypassLogin = true
 	yamlCfg.Features.AdminDashboard.DevCORSOrigin = "http://localhost:5173"
+	yamlCfg.Features.AdminDashboard.EditorLimits.MaxDailyCostLimitCents = 5000
 
-	auth, err := newAuthenticator(slog.Default(), yamlCfg.Features.AdminDashboard)
+	auth, err := newAuthenticator(slog.Default(), yamlCfg.Features.AdminDashboard, userStore)
 	require.NoError(t, err)
 
 	h := newHandler(Deps{
 		Logger:      slog.Default(),
 		YAMLConfig:  yamlCfg,
 		APIKeyStore: store,
+		UserStore:   userStore,
 	}, auth)
 	return h, store
 }

--- a/internal/admin/share_handlers_test.go
+++ b/internal/admin/share_handlers_test.go
@@ -44,6 +44,7 @@ func testAdminHandler(t *testing.T) (*handler, *apikeys.Store) {
 	require.NoError(t, err)
 
 	yamlCfg := config.GetDefaultYAMLConfig()
+	yamlCfg.Features.AdminDashboard.AllowedDomain = "example.com"
 	yamlCfg.Features.AdminDashboard.DevBypassLogin = true
 	yamlCfg.Features.AdminDashboard.DevCORSOrigin = "http://localhost:5173"
 	yamlCfg.Features.AdminDashboard.EditorLimits.MaxDailyCostLimitCents = 5000

--- a/internal/admin/share_handlers_test.go
+++ b/internal/admin/share_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/Instawork/llm-proxy/internal/adminusers"
@@ -18,8 +19,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ensureTestDynamoFake(t *testing.T) {
+	t.Helper()
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "test" && os.Getenv("AWS_ENDPOINT_URL") != "" {
+		return
+	}
+	fake := dynamodbfake.New(t)
+	dynamodbfake.UseFakeDynamo(t, fake.URL())
+}
+
 func testAdminUserStore(t *testing.T) *adminusers.Store {
 	t.Helper()
+	ensureTestDynamoFake(t)
 	store, err := adminusers.NewStore(adminusers.StoreConfig{
 		TableName:       "test-admin-users",
 		Region:          "us-west-2",
@@ -34,8 +45,7 @@ func testAdminHandler(t *testing.T) (*handler, *apikeys.Store) {
 	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
 	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "admin@example.com")
 
-	fake := dynamodbfake.New(t)
-	dynamodbfake.UseFakeDynamo(t, fake.URL())
+	ensureTestDynamoFake(t)
 	store, err := apikeys.NewStore(apikeys.StoreConfig{TableName: "test-keys", Region: "us-west-2"})
 	require.NoError(t, err)
 

--- a/internal/admin/types.go
+++ b/internal/admin/types.go
@@ -13,10 +13,39 @@ const maskedActualKey = "***HIDDEN***"
 
 // UserResponse is the authenticated admin user.
 type UserResponse struct {
-	Email                           string `json:"email"`
-	Name                            string `json:"name,omitempty"`
-	Picture                         string `json:"picture,omitempty"`
-	CanBypassPIIOffNonBedrockPolicy bool   `json:"can_bypass_pii_off_non_bedrock_policy"`
+	Email                           string                `json:"email"`
+	Name                            string                `json:"name,omitempty"`
+	Picture                         string                `json:"picture,omitempty"`
+	Role                            string                `json:"role"`
+	CanBypassPIIOffNonBedrockPolicy bool                  `json:"can_bypass_pii_off_non_bedrock_policy"`
+	EditorLimits                    *EditorLimitsResponse `json:"editor_limits,omitempty"`
+}
+
+// EditorLimitsResponse exposes editor caps to the UI.
+type EditorLimitsResponse struct {
+	MaxDailyCostLimitCents int64 `json:"max_daily_cost_limit_cents"`
+}
+
+// AdminUserRecord is a user in the admin roster.
+type AdminUserRecord struct {
+	Email       string    `json:"email"`
+	Name        string    `json:"name,omitempty"`
+	Picture     string    `json:"picture,omitempty"`
+	Role        string    `json:"role"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	LastLoginAt time.Time `json:"last_login_at,omitempty"`
+}
+
+// CreateUserRequest pre-provisions a user.
+type CreateUserRequest struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+// UpdateUserRoleRequest changes a user's role.
+type UpdateUserRoleRequest struct {
+	Role string `json:"role"`
 }
 
 // KeyResponse is a safe JSON view of an API key record.

--- a/internal/admin/users_handlers.go
+++ b/internal/admin/users_handlers.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -140,7 +141,7 @@ func (h *handler) handleUpdateUserRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.guardLastAdminDemotion(r, email, role); err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeLastAdminGuardError(w, h, err, "update user")
 		return
 	}
 
@@ -183,7 +184,7 @@ func (h *handler) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.guardLastAdminRemoval(r, email); err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeLastAdminGuardError(w, h, err, "delete user")
 		return
 	}
 
@@ -209,7 +210,10 @@ func (h *handler) guardLastAdminDemotion(r *http.Request, email string, newRole 
 func (h *handler) guardLastAdminRemoval(r *http.Request, email string) error {
 	target, err := h.deps.UserStore.GetUser(r.Context(), email)
 	if err != nil {
-		return nil
+		if errors.Is(err, adminusers.ErrUserNotFound) {
+			return nil
+		}
+		return err
 	}
 	if target.Role != adminusers.RoleAdmin {
 		return nil
@@ -230,4 +234,13 @@ type lastAdminError struct{}
 
 func (e *lastAdminError) Error() string {
 	return "cannot remove the last admin"
+}
+
+func writeLastAdminGuardError(w http.ResponseWriter, h *handler, err error, action string) {
+	if errors.Is(err, errLastAdmin) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+	h.deps.Logger.Error("admin: guard last admin failed", "action", action, "error", err)
+	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to " + action})
 }

--- a/internal/admin/users_handlers.go
+++ b/internal/admin/users_handlers.go
@@ -1,0 +1,233 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+	"github.com/gorilla/mux"
+)
+
+func (h *handler) writeUserStoreUnavailable(w http.ResponseWriter) {
+	msg := "admin user store unavailable"
+	if h.deps.UserStoreError != nil {
+		msg = "admin user store unavailable: " + h.deps.UserStoreError.Error()
+	}
+	writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": msg})
+}
+
+func (h *handler) allowedDomain() string {
+	if h.deps.YAMLConfig == nil {
+		return "example.com"
+	}
+	return h.deps.YAMLConfig.Features.AdminDashboard.AllowedDomain
+}
+
+func (h *handler) handleListUsers(w http.ResponseWriter, r *http.Request) {
+	if h.deps.UserStore == nil {
+		h.writeUserStoreUnavailable(w)
+		return
+	}
+	users, err := h.deps.UserStore.ListUsers(r.Context())
+	if err != nil {
+		h.deps.Logger.Error("admin: list users failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list users"})
+		return
+	}
+	resp := make([]AdminUserRecord, 0, len(users))
+	for _, u := range users {
+		resp = append(resp, userRecordFromStore(u))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *handler) handleGetUser(w http.ResponseWriter, r *http.Request) {
+	if h.deps.UserStore == nil {
+		h.writeUserStoreUnavailable(w)
+		return
+	}
+	email := mux.Vars(r)["email"]
+	if strings.TrimSpace(email) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+		return
+	}
+	u, err := h.deps.UserStore.GetUser(r.Context(), email)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+			return
+		}
+		h.deps.Logger.Error("admin: get user failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get user"})
+		return
+	}
+	writeJSON(w, http.StatusOK, userRecordFromStore(u))
+}
+
+func (h *handler) handleCreateUser(w http.ResponseWriter, r *http.Request) {
+	if h.deps.UserStore == nil {
+		h.writeUserStoreUnavailable(w)
+		return
+	}
+	var req CreateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	if req.Email == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+		return
+	}
+	if err := validateAllowedEmail(req.Email, h.allowedDomain()); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	role := adminusers.RoleViewer
+	if req.Role != "" {
+		parsed, err := adminusers.ParseRole(req.Role)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		role = parsed
+	}
+	u, err := h.deps.UserStore.CreateUser(r.Context(), req.Email, role)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "user already exists"})
+			return
+		}
+		h.deps.Logger.Error("admin: create user failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
+		return
+	}
+	writeJSON(w, http.StatusCreated, userRecordFromStore(u))
+}
+
+func (h *handler) handleUpdateUserRole(w http.ResponseWriter, r *http.Request) {
+	if h.deps.UserStore == nil {
+		h.writeUserStoreUnavailable(w)
+		return
+	}
+	email := mux.Vars(r)["email"]
+	if strings.TrimSpace(email) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+		return
+	}
+	var req UpdateUserRoleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	role, err := adminusers.ParseRole(req.Role)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	actor, err := h.auth.currentUser(r)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	if strings.EqualFold(actor.Email, email) {
+		target, getErr := h.deps.UserStore.GetUser(r.Context(), email)
+		if getErr == nil && target.Role == adminusers.RoleAdmin && role != adminusers.RoleAdmin {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "cannot demote your own admin account"})
+			return
+		}
+	}
+
+	if err := h.guardLastAdminDemotion(r, email, role); err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if err := h.deps.UserStore.SetRole(r.Context(), email, role); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+			return
+		}
+		h.deps.Logger.Error("admin: update user role failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update user"})
+		return
+	}
+	u, err := h.deps.UserStore.GetUser(r.Context(), email)
+	if err != nil {
+		writeJSON(w, http.StatusOK, AdminUserRecord{Email: email, Role: string(role)})
+		return
+	}
+	writeJSON(w, http.StatusOK, userRecordFromStore(u))
+}
+
+func (h *handler) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	if h.deps.UserStore == nil {
+		h.writeUserStoreUnavailable(w)
+		return
+	}
+	email := mux.Vars(r)["email"]
+	if strings.TrimSpace(email) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+		return
+	}
+
+	actor, err := h.auth.currentUser(r)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	if strings.EqualFold(actor.Email, email) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "cannot delete your own account"})
+		return
+	}
+
+	if err := h.guardLastAdminRemoval(r, email); err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if err := h.deps.UserStore.DeleteUser(r.Context(), email); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+			return
+		}
+		h.deps.Logger.Error("admin: delete user failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete user"})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handler) guardLastAdminDemotion(r *http.Request, email string, newRole adminusers.Role) error {
+	if newRole == adminusers.RoleAdmin {
+		return nil
+	}
+	return h.guardLastAdminRemoval(r, email)
+}
+
+func (h *handler) guardLastAdminRemoval(r *http.Request, email string) error {
+	target, err := h.deps.UserStore.GetUser(r.Context(), email)
+	if err != nil {
+		return nil
+	}
+	if target.Role != adminusers.RoleAdmin {
+		return nil
+	}
+	count, err := h.deps.UserStore.CountAdmins(r.Context())
+	if err != nil {
+		return err
+	}
+	if count <= 1 {
+		return errLastAdmin
+	}
+	return nil
+}
+
+var errLastAdmin = &lastAdminError{}
+
+type lastAdminError struct{}
+
+func (e *lastAdminError) Error() string {
+	return "cannot remove the last admin"
+}

--- a/internal/admin/users_handlers_test.go
+++ b/internal/admin/users_handlers_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -13,16 +14,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func authenticatedRequestAs(t *testing.T, h *handler, email, method, path string, body []byte) *http.Request {
+	t.Helper()
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", email)
+	return authenticatedRequest(t, h, method, path, body)
+}
+
 func TestRequireRoleForbiddenForViewer(t *testing.T) {
 	h, _ := testAdminHandler(t)
 	_, err := h.deps.UserStore.CreateUser(context.Background(), "viewer@example.com", adminusers.RoleViewer)
 	require.NoError(t, err)
 
-	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "viewer@example.com")
-	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/users", nil)
+	req := authenticatedRequestAs(t, h, "viewer@example.com", http.MethodGet, "/admin/api/users", nil)
 	rec := httptest.NewRecorder()
 	roleHandler(h.auth, adminusers.RoleAdmin, h.handleListUsers).ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestRequireRoleUnauthorizedWithoutSession(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/users", nil)
+	rec := httptest.NewRecorder()
+	roleHandler(h.auth, adminusers.RoleAdmin, h.handleListUsers).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestHandleListUsers(t *testing.T) {
@@ -37,6 +51,46 @@ func TestHandleListUsers(t *testing.T) {
 	assert.NotEmpty(t, users)
 }
 
+func TestHandleListUsersNilStore(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	h.deps.UserStore = nil
+	rec := httptest.NewRecorder()
+	h.handleListUsers(rec, httptest.NewRequest(http.MethodGet, "/admin/api/users", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleGetUser(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/users/admin@example.com", nil)
+	req = mux.SetURLVars(req, map[string]string{"email": "admin@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleGetUser(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var user AdminUserRecord
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &user))
+	assert.Equal(t, "admin@example.com", user.Email)
+	assert.Equal(t, "admin", user.Role)
+}
+
+func TestHandleGetUserNotFound(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/users/nobody@example.com", nil)
+	req = mux.SetURLVars(req, map[string]string{"email": "nobody@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleGetUser(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleCreateUserRejectsMissingEmail(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	body, _ := json.Marshal(CreateUserRequest{Role: "viewer"})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/users", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateUser(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestHandleCreateUserRejectsBadDomain(t *testing.T) {
 	h, _ := testAdminHandler(t)
 	body, _ := json.Marshal(CreateUserRequest{Email: "x@other.com", Role: "viewer"})
@@ -44,6 +98,92 @@ func TestHandleCreateUserRejectsBadDomain(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.handleCreateUser(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleCreateUserHappyPath(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	body, _ := json.Marshal(CreateUserRequest{Email: "neweditor@example.com", Role: "editor"})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/users", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateUser(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var user AdminUserRecord
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &user))
+	assert.Equal(t, "neweditor@example.com", user.Email)
+	assert.Equal(t, "editor", user.Role)
+}
+
+func TestHandleCreateUserDuplicate(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	body, _ := json.Marshal(CreateUserRequest{Email: "admin@example.com", Role: "viewer"})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/users", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateUser(rec, req)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestHandleCreateUserInvalidRole(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	body, _ := json.Marshal(CreateUserRequest{Email: "x@example.com", Role: "superuser"})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/users", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateUser(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleUpdateUserRole(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "promote@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(UpdateUserRoleRequest{Role: "editor"})
+	req := authenticatedRequest(t, h, http.MethodPatch, "/admin/api/users/promote@example.com", body)
+	req = mux.SetURLVars(req, map[string]string{"email": "promote@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleUpdateUserRole(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var user AdminUserRecord
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &user))
+	assert.Equal(t, "editor", user.Role)
+}
+
+func TestHandleUpdateUserRoleNotFound(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	body, _ := json.Marshal(UpdateUserRoleRequest{Role: "editor"})
+	req := authenticatedRequest(t, h, http.MethodPatch, "/admin/api/users/nobody@example.com", body)
+	req = mux.SetURLVars(req, map[string]string{"email": "nobody@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleUpdateUserRole(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleUpdateUserRoleBlocksSelfDemote(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	body, _ := json.Marshal(UpdateUserRoleRequest{Role: "editor"})
+	req := authenticatedRequest(t, h, http.MethodPatch, "/admin/api/users/admin@example.com", body)
+	req = mux.SetURLVars(req, map[string]string{"email": "admin@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleUpdateUserRole(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleUpdateUserRoleBlocksLastAdminDemotion(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	ctx := context.Background()
+
+	_, err := h.deps.UserStore.CreateUser(ctx, "other@example.com", adminusers.RoleAdmin)
+	require.NoError(t, err)
+	require.NoError(t, h.deps.UserStore.DeleteUser(ctx, "admin@example.com"))
+
+	body, _ := json.Marshal(UpdateUserRoleRequest{Role: "viewer"})
+	req := authenticatedRequestAs(t, h, "other@example.com", http.MethodPatch, "/admin/api/users/other@example.com", body)
+	req = mux.SetURLVars(req, map[string]string{"email": "other@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleUpdateUserRole(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "cannot demote your own admin account")
 }
 
 func TestHandleDeleteUserBlocksSelf(t *testing.T) {
@@ -55,19 +195,123 @@ func TestHandleDeleteUserBlocksSelf(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestHandleDeleteUserSuccess(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "remove@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	req := authenticatedRequest(t, h, http.MethodDelete, "/admin/api/users/remove@example.com", nil)
+	req = mux.SetURLVars(req, map[string]string{"email": "remove@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleDeleteUser(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestHandleDeleteUserAllowsDeletingViewerWithMultipleAdmins(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	ctx := context.Background()
+
+	_, err := h.deps.UserStore.CreateUser(ctx, "actor@example.com", adminusers.RoleAdmin)
+	require.NoError(t, err)
+	_, err = h.deps.UserStore.CreateUser(ctx, "remove@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	req := authenticatedRequestAs(t, h, "actor@example.com", http.MethodDelete, "/admin/api/users/remove@example.com", nil)
+	req = mux.SetURLVars(req, map[string]string{"email": "remove@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleDeleteUser(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestHandleMeIncludesRoleAndEditorLimits(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "editor@example.com", adminusers.RoleEditor)
+	require.NoError(t, err)
+
+	req := authenticatedRequestAs(t, h, "editor@example.com", http.MethodGet, "/admin/api/me", nil)
+	rec := httptest.NewRecorder()
+	h.handleMe(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var user UserResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &user))
+	assert.Equal(t, "editor", user.Role)
+	require.NotNil(t, user.EditorLimits)
+	assert.Equal(t, int64(5000), user.EditorLimits.MaxDailyCostLimitCents)
+}
+
 func TestHandleCreateKeyEditorCostCap(t *testing.T) {
 	h, _ := testAdminHandler(t)
 	_, err := h.deps.UserStore.CreateUser(context.Background(), "editor@example.com", adminusers.RoleEditor)
 	require.NoError(t, err)
 
-	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "editor@example.com")
 	body, _ := json.Marshal(CreateKeyRequest{
 		Provider:       "openai",
 		ActualKey:      "sk-real",
 		DailyCostLimit: 999999,
 	})
-	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", body)
+	req := authenticatedRequestAs(t, h, "editor@example.com", http.MethodPost, "/admin/api/keys", body)
 	rec := httptest.NewRecorder()
 	h.handleCreateKey(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleUpdateKeyEditorCostCap(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+	_, err := h.deps.UserStore.CreateUser(ctx, "editor@example.com", adminusers.RoleEditor)
+	require.NoError(t, err)
+
+	key, err := store.CreateKey(ctx, "openai", "sk", "", 1000, nil, nil)
+	require.NoError(t, err)
+
+	body := []byte(`{"daily_cost_limit": 999999}`)
+	req := authenticatedRequestAs(t, h, "editor@example.com", http.MethodPatch, "/admin/api/keys/"+key.PK, body)
+	req = mux.SetURLVars(req, map[string]string{"key": key.PK})
+	rec := httptest.NewRecorder()
+	h.handleUpdateKey(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleDeleteKeyForbiddenForEditor(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+	_, err := h.deps.UserStore.CreateUser(ctx, "editor@example.com", adminusers.RoleEditor)
+	require.NoError(t, err)
+
+	key, err := store.CreateKey(ctx, "openai", "sk", "", 0, nil, nil)
+	require.NoError(t, err)
+
+	req := authenticatedRequestAs(t, h, "editor@example.com", http.MethodDelete, "/admin/api/keys/"+key.PK, nil)
+	req = mux.SetURLVars(req, map[string]string{"key": key.PK})
+	rec := httptest.NewRecorder()
+	roleHandler(h.auth, adminusers.RoleAdmin, h.handleDeleteKey).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleConfigForbiddenForViewer(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "viewer@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	req := authenticatedRequestAs(t, h, "viewer@example.com", http.MethodGet, "/admin/api/config", nil)
+	rec := httptest.NewRecorder()
+	roleHandler(h.auth, adminusers.RoleEditor, h.handleConfig).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleDevLoginEnsuresUser(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "fresh@example.com")
+
+	loginRec := httptest.NewRecorder()
+	loginBody, _ := json.Marshal(map[string]string{"redirect": "http://localhost:9002/admin/"})
+	loginReq := httptest.NewRequest(http.MethodPost, "/admin/auth/dev-login", bytes.NewReader(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	h.auth.handleDevLogin(loginRec, loginReq)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	user, err := h.deps.UserStore.GetUser(context.Background(), "fresh@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, adminusers.RoleViewer, user.Role)
 }

--- a/internal/admin/users_handlers_test.go
+++ b/internal/admin/users_handlers_test.go
@@ -1,0 +1,73 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireRoleForbiddenForViewer(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "viewer@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "viewer@example.com")
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/users", nil)
+	rec := httptest.NewRecorder()
+	roleHandler(h.auth, adminusers.RoleAdmin, h.handleListUsers).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleListUsers(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/users", nil)
+	rec := httptest.NewRecorder()
+	h.handleListUsers(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var users []AdminUserRecord
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &users))
+	assert.NotEmpty(t, users)
+}
+
+func TestHandleCreateUserRejectsBadDomain(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	body, _ := json.Marshal(CreateUserRequest{Email: "x@other.com", Role: "viewer"})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/users", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateUser(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleDeleteUserBlocksSelf(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	req := authenticatedRequest(t, h, http.MethodDelete, "/admin/api/users/admin@example.com", nil)
+	req = mux.SetURLVars(req, map[string]string{"email": "admin@example.com"})
+	rec := httptest.NewRecorder()
+	h.handleDeleteUser(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleCreateKeyEditorCostCap(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	_, err := h.deps.UserStore.CreateUser(context.Background(), "editor@example.com", adminusers.RoleEditor)
+	require.NoError(t, err)
+
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "editor@example.com")
+	body, _ := json.Marshal(CreateKeyRequest{
+		Provider:       "openai",
+		ActualKey:      "sk-real",
+		DailyCostLimit: 999999,
+	})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateKey(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/adminusers/role.go
+++ b/internal/adminusers/role.go
@@ -1,0 +1,43 @@
+package adminusers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Role is an admin dashboard permission level.
+type Role string
+
+const (
+	RoleViewer Role = "viewer"
+	RoleEditor Role = "editor"
+	RoleAdmin  Role = "admin"
+)
+
+// ParseRole validates and normalizes a role string.
+func ParseRole(s string) (Role, error) {
+	switch Role(strings.ToLower(strings.TrimSpace(s))) {
+	case RoleViewer, RoleEditor, RoleAdmin:
+		return Role(strings.ToLower(strings.TrimSpace(s))), nil
+	default:
+		return "", fmt.Errorf("invalid role %q: must be admin, editor, or viewer", s)
+	}
+}
+
+// AtLeast reports whether r meets or exceeds min.
+func (r Role) AtLeast(min Role) bool {
+	return roleRank(r) >= roleRank(min)
+}
+
+func roleRank(r Role) int {
+	switch r {
+	case RoleAdmin:
+		return 3
+	case RoleEditor:
+		return 2
+	case RoleViewer:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/adminusers/role_test.go
+++ b/internal/adminusers/role_test.go
@@ -1,0 +1,25 @@
+package adminusers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRole(t *testing.T) {
+	role, err := ParseRole(" Admin ")
+	require.NoError(t, err)
+	assert.Equal(t, RoleAdmin, role)
+
+	_, err = ParseRole("superuser")
+	require.Error(t, err)
+}
+
+func TestRoleAtLeast(t *testing.T) {
+	assert.True(t, RoleAdmin.AtLeast(RoleViewer))
+	assert.True(t, RoleAdmin.AtLeast(RoleEditor))
+	assert.True(t, RoleEditor.AtLeast(RoleViewer))
+	assert.False(t, RoleViewer.AtLeast(RoleEditor))
+	assert.False(t, Role("").AtLeast(RoleViewer))
+}

--- a/internal/adminusers/store.go
+++ b/internal/adminusers/store.go
@@ -23,6 +23,9 @@ const (
 	userPKP   = "USER#"
 )
 
+// ErrUserNotFound is returned when a user profile row does not exist.
+var ErrUserNotFound = errors.New("user not found")
+
 // User is an admin dashboard user record.
 type User struct {
 	Email       string    `json:"email"`
@@ -70,6 +73,10 @@ type StoreConfig struct {
 
 // NewStore creates a new admin users store.
 func NewStore(cfg StoreConfig) (*Store, error) {
+	if strings.TrimSpace(cfg.TableName) == "" {
+		return nil, fmt.Errorf("table name is required")
+	}
+
 	startupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -134,6 +141,9 @@ func (s *Store) ensureTableExists(ctx context.Context) error {
 		s.logger.Debug("admin users table already exists", "table", s.tableName)
 		return nil
 	}
+	if !isResourceNotFound(err) {
+		return fmt.Errorf("describe table failed: %w", err)
+	}
 
 	s.logger.Info("Creating DynamoDB table for admin users", "table", s.tableName)
 
@@ -157,6 +167,11 @@ func (s *Store) ensureTableExists(ctx context.Context) error {
 	return waiter.Wait(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(s.tableName),
 	}, 2*time.Minute)
+}
+
+func isResourceNotFound(err error) bool {
+	var notFound *types.ResourceNotFoundException
+	return errors.As(err, &notFound)
 }
 
 func normalizeEmail(email string) (string, error) {
@@ -183,7 +198,7 @@ func (s *Store) getProfileItem(ctx context.Context, email string) (*userItem, er
 		return nil, err
 	}
 	if out.Item == nil {
-		return nil, fmt.Errorf("user not found")
+		return nil, ErrUserNotFound
 	}
 	var item userItem
 	if err := attributevalue.UnmarshalMap(out.Item, &item); err != nil {
@@ -238,6 +253,9 @@ func (s *Store) EnsureUser(ctx context.Context, email, name, picture string) (Us
 		}
 		return itemToUser(&item), false, nil
 	}
+	if !errors.Is(getErr, ErrUserNotFound) {
+		return User{}, false, getErr
+	}
 
 	item := userItem{
 		PK:          userPK(email),
@@ -261,7 +279,25 @@ func (s *Store) EnsureUser(ctx context.Context, email, name, picture string) (Us
 	}); err != nil {
 		var cond *types.ConditionalCheckFailedException
 		if errors.As(err, &cond) {
-			return s.EnsureUser(ctx, email, name, picture)
+			existing, getErr := s.getProfileItem(ctx, email)
+			if getErr != nil {
+				return User{}, false, getErr
+			}
+			item.Role = existing.Role
+			item.CreatedAt = existing.CreatedAt
+			item.UpdatedAt = now
+			item.LastLoginAt = now
+			av, err := attributevalue.MarshalMap(item)
+			if err != nil {
+				return User{}, false, err
+			}
+			if _, err := s.client.PutItem(ctx, &dynamodb.PutItemInput{
+				TableName: aws.String(s.tableName),
+				Item:      av,
+			}); err != nil {
+				return User{}, false, err
+			}
+			return itemToUser(&item), false, nil
 		}
 		return User{}, false, err
 	}
@@ -287,7 +323,8 @@ func (s *Store) CreateUser(ctx context.Context, email string, role Role) (User, 
 	if err != nil {
 		return User{}, err
 	}
-	if _, err := ParseRole(string(role)); err != nil {
+	parsedRole, err := ParseRole(string(role))
+	if err != nil {
 		return User{}, err
 	}
 
@@ -296,7 +333,7 @@ func (s *Store) CreateUser(ctx context.Context, email string, role Role) (User, 
 		PK:        userPK(email),
 		SK:        profileSK,
 		Email:     email,
-		Role:      string(role),
+		Role:      string(parsedRole),
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -325,7 +362,8 @@ func (s *Store) SetRole(ctx context.Context, email string, role Role) error {
 	if err != nil {
 		return err
 	}
-	if _, err := ParseRole(string(role)); err != nil {
+	parsedRole, err := ParseRole(string(role))
+	if err != nil {
 		return err
 	}
 
@@ -341,7 +379,7 @@ func (s *Store) SetRole(ctx context.Context, email string, role Role) error {
 			"#role": "role",
 		},
 		ExpressionAttributeValues: map[string]types.AttributeValue{
-			":role":       &types.AttributeValueMemberS{Value: string(role)},
+			":role":       &types.AttributeValueMemberS{Value: string(parsedRole)},
 			":updated_at": &types.AttributeValueMemberS{Value: now.Format(time.RFC3339Nano)},
 		},
 		ConditionExpression: aws.String("attribute_exists(pk)"),

--- a/internal/adminusers/store.go
+++ b/internal/adminusers/store.go
@@ -1,0 +1,468 @@
+package adminusers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+const (
+	profileSK = "PROFILE"
+	shareSKP  = "SHARE#"
+	userPKP   = "USER#"
+)
+
+// User is an admin dashboard user record.
+type User struct {
+	Email       string    `json:"email"`
+	Name        string    `json:"name,omitempty"`
+	Picture     string    `json:"picture,omitempty"`
+	Role        Role      `json:"role"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	LastLoginAt time.Time `json:"last_login_at,omitempty"`
+}
+
+type userItem struct {
+	PK          string    `dynamodbav:"pk"`
+	SK          string    `dynamodbav:"sk"`
+	Email       string    `dynamodbav:"email"`
+	Name        string    `dynamodbav:"name,omitempty"`
+	Picture     string    `dynamodbav:"picture,omitempty"`
+	Role        string    `dynamodbav:"role"`
+	CreatedAt   time.Time `dynamodbav:"created_at"`
+	UpdatedAt   time.Time `dynamodbav:"updated_at"`
+	LastLoginAt time.Time `dynamodbav:"last_login_at,omitempty"`
+}
+
+type shareAwarenessItem struct {
+	PK          string    `dynamodbav:"pk"`
+	SK          string    `dynamodbav:"sk"`
+	FirstSeenAt time.Time `dynamodbav:"first_seen_at"`
+}
+
+// Store handles admin user persistence in DynamoDB.
+type Store struct {
+	client    *dynamodb.Client
+	tableName string
+	logger    *slog.Logger
+}
+
+// StoreConfig holds configuration for the admin users store.
+type StoreConfig struct {
+	TableName       string
+	Region          string
+	EndpointURL     string
+	Logger          *slog.Logger
+	AutoCreateTable bool
+}
+
+// NewStore creates a new admin users store.
+func NewStore(cfg StoreConfig) (*Store, error) {
+	startupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(
+		startupCtx,
+		awsconfig.WithRegion(cfg.Region),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	endpointURL := cfg.EndpointURL
+	if endpointURL == "" {
+		endpointURL = os.Getenv("AWS_ENDPOINT_URL")
+	}
+
+	var client *dynamodb.Client
+	if endpointURL != "" {
+		client = dynamodb.NewFromConfig(awsCfg, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpointURL)
+		})
+	} else {
+		client = dynamodb.NewFromConfig(awsCfg)
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	store := &Store{
+		client:    client,
+		tableName: cfg.TableName,
+		logger:    logger,
+	}
+
+	if cfg.AutoCreateTable {
+		if err := store.ensureTableExists(startupCtx); err != nil {
+			return nil, fmt.Errorf("failed to ensure table exists: %w", err)
+		}
+	} else {
+		if err := store.verifyTableExists(startupCtx); err != nil {
+			return nil, fmt.Errorf("admin users table %q is not accessible (pass AutoCreateTable: true in dev only): %w", cfg.TableName, err)
+		}
+	}
+
+	return store, nil
+}
+
+func (s *Store) verifyTableExists(ctx context.Context) error {
+	_, err := s.client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(s.tableName),
+	})
+	return err
+}
+
+func (s *Store) ensureTableExists(ctx context.Context) error {
+	_, err := s.client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(s.tableName),
+	})
+	if err == nil {
+		s.logger.Debug("admin users table already exists", "table", s.tableName)
+		return nil
+	}
+
+	s.logger.Info("Creating DynamoDB table for admin users", "table", s.tableName)
+
+	_, err = s.client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(s.tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String("sk"), KeyType: types.KeyTypeRange},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create table: %w", err)
+	}
+
+	waiter := dynamodb.NewTableExistsWaiter(s.client)
+	return waiter.Wait(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(s.tableName),
+	}, 2*time.Minute)
+}
+
+func normalizeEmail(email string) (string, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" || !strings.Contains(email, "@") {
+		return "", fmt.Errorf("invalid email")
+	}
+	return email, nil
+}
+
+func userPK(email string) string {
+	return userPKP + email
+}
+
+func (s *Store) getProfileItem(ctx context.Context, email string) (*userItem, error) {
+	out, err := s.client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: userPK(email)},
+			"sk": &types.AttributeValueMemberS{Value: profileSK},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if out.Item == nil {
+		return nil, fmt.Errorf("user not found")
+	}
+	var item userItem
+	if err := attributevalue.UnmarshalMap(out.Item, &item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+func itemToUser(item *userItem) User {
+	role, _ := ParseRole(item.Role)
+	return User{
+		Email:       item.Email,
+		Name:        item.Name,
+		Picture:     item.Picture,
+		Role:        role,
+		CreatedAt:   item.CreatedAt,
+		UpdatedAt:   item.UpdatedAt,
+		LastLoginAt: item.LastLoginAt,
+	}
+}
+
+// EnsureUser creates a viewer if missing and updates profile + last login.
+func (s *Store) EnsureUser(ctx context.Context, email, name, picture string) (User, bool, error) {
+	email, err := normalizeEmail(email)
+	if err != nil {
+		return User{}, false, err
+	}
+
+	now := time.Now().UTC()
+	existing, getErr := s.getProfileItem(ctx, email)
+	if getErr == nil {
+		item := userItem{
+			PK:          userPK(email),
+			SK:          profileSK,
+			Email:       email,
+			Name:        name,
+			Picture:     picture,
+			Role:        existing.Role,
+			CreatedAt:   existing.CreatedAt,
+			UpdatedAt:   now,
+			LastLoginAt: now,
+		}
+		av, err := attributevalue.MarshalMap(item)
+		if err != nil {
+			return User{}, false, err
+		}
+		if _, err := s.client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(s.tableName),
+			Item:      av,
+		}); err != nil {
+			return User{}, false, err
+		}
+		return itemToUser(&item), false, nil
+	}
+
+	item := userItem{
+		PK:          userPK(email),
+		SK:          profileSK,
+		Email:       email,
+		Name:        name,
+		Picture:     picture,
+		Role:        string(RoleViewer),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		LastLoginAt: now,
+	}
+	av, err := attributevalue.MarshalMap(item)
+	if err != nil {
+		return User{}, false, err
+	}
+	if _, err := s.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(s.tableName),
+		Item:                av,
+		ConditionExpression: aws.String("attribute_not_exists(pk)"),
+	}); err != nil {
+		var cond *types.ConditionalCheckFailedException
+		if errors.As(err, &cond) {
+			return s.EnsureUser(ctx, email, name, picture)
+		}
+		return User{}, false, err
+	}
+	return itemToUser(&item), true, nil
+}
+
+// GetUser returns a user by email.
+func (s *Store) GetUser(ctx context.Context, email string) (User, error) {
+	email, err := normalizeEmail(email)
+	if err != nil {
+		return User{}, err
+	}
+	item, err := s.getProfileItem(ctx, email)
+	if err != nil {
+		return User{}, err
+	}
+	return itemToUser(item), nil
+}
+
+// CreateUser pre-provisions a user with the given role.
+func (s *Store) CreateUser(ctx context.Context, email string, role Role) (User, error) {
+	email, err := normalizeEmail(email)
+	if err != nil {
+		return User{}, err
+	}
+	if _, err := ParseRole(string(role)); err != nil {
+		return User{}, err
+	}
+
+	now := time.Now().UTC()
+	item := userItem{
+		PK:        userPK(email),
+		SK:        profileSK,
+		Email:     email,
+		Role:      string(role),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	av, err := attributevalue.MarshalMap(item)
+	if err != nil {
+		return User{}, err
+	}
+	_, err = s.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(s.tableName),
+		Item:                av,
+		ConditionExpression: aws.String("attribute_not_exists(pk)"),
+	})
+	if err != nil {
+		var cond *types.ConditionalCheckFailedException
+		if errors.As(err, &cond) {
+			return User{}, fmt.Errorf("user already exists")
+		}
+		return User{}, err
+	}
+	return itemToUser(&item), nil
+}
+
+// SetRole updates a user's role.
+func (s *Store) SetRole(ctx context.Context, email string, role Role) error {
+	email, err := normalizeEmail(email)
+	if err != nil {
+		return err
+	}
+	if _, err := ParseRole(string(role)); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	_, err = s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: userPK(email)},
+			"sk": &types.AttributeValueMemberS{Value: profileSK},
+		},
+		UpdateExpression: aws.String("SET #role = :role, updated_at = :updated_at"),
+		ExpressionAttributeNames: map[string]string{
+			"#role": "role",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":role":       &types.AttributeValueMemberS{Value: string(role)},
+			":updated_at": &types.AttributeValueMemberS{Value: now.Format(time.RFC3339Nano)},
+		},
+		ConditionExpression: aws.String("attribute_exists(pk)"),
+	})
+	if err != nil {
+		var cond *types.ConditionalCheckFailedException
+		if errors.As(err, &cond) {
+			return fmt.Errorf("user not found")
+		}
+		return err
+	}
+	return nil
+}
+
+// DeleteUser removes a user's profile row (share awareness rows are left orphaned).
+func (s *Store) DeleteUser(ctx context.Context, email string) error {
+	email, err := normalizeEmail(email)
+	if err != nil {
+		return err
+	}
+	_, err = s.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: userPK(email)},
+			"sk": &types.AttributeValueMemberS{Value: profileSK},
+		},
+		ConditionExpression: aws.String("attribute_exists(pk)"),
+	})
+	if err != nil {
+		var cond *types.ConditionalCheckFailedException
+		if errors.As(err, &cond) {
+			return fmt.Errorf("user not found")
+		}
+		return err
+	}
+	return nil
+}
+
+// ListUsers returns all user profiles sorted by email.
+func (s *Store) ListUsers(ctx context.Context) ([]User, error) {
+	var users []User
+	var startKey map[string]types.AttributeValue
+
+	for {
+		out, err := s.client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:        aws.String(s.tableName),
+			FilterExpression: aws.String("sk = :profile"),
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":profile": &types.AttributeValueMemberS{Value: profileSK},
+			},
+			ExclusiveStartKey: startKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range out.Items {
+			var item userItem
+			if err := attributevalue.UnmarshalMap(raw, &item); err != nil {
+				return nil, err
+			}
+			users = append(users, itemToUser(&item))
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+		startKey = out.LastEvaluatedKey
+	}
+
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].Email < users[j].Email
+	})
+	return users, nil
+}
+
+// CountAdmins returns the number of users with the admin role.
+func (s *Store) CountAdmins(ctx context.Context) (int, error) {
+	users, err := s.ListUsers(ctx)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, u := range users {
+		if u.Role == RoleAdmin {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// RecordShareAwareness records that a user opened a share link while authenticated.
+func (s *Store) RecordShareAwareness(ctx context.Context, email, shareID string) error {
+	email, err := normalizeEmail(email)
+	if err != nil {
+		return err
+	}
+	shareID = strings.TrimSpace(shareID)
+	if shareID == "" {
+		return fmt.Errorf("share id required")
+	}
+
+	now := time.Now().UTC()
+	item := shareAwarenessItem{
+		PK:          userPK(email),
+		SK:          shareSKP + shareID,
+		FirstSeenAt: now,
+	}
+	av, err := attributevalue.MarshalMap(item)
+	if err != nil {
+		return err
+	}
+	_, err = s.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(s.tableName),
+		Item:                av,
+		ConditionExpression: aws.String("attribute_not_exists(pk)"),
+	})
+	if err != nil {
+		var cond *types.ConditionalCheckFailedException
+		if errors.As(err, &cond) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/adminusers/store_test.go
+++ b/internal/adminusers/store_test.go
@@ -1,0 +1,98 @@
+package adminusers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/testhelpers/dynamodbfake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testUserStore(t *testing.T) *Store {
+	t.Helper()
+	fake := dynamodbfake.New(t)
+	dynamodbfake.UseFakeDynamo(t, fake.URL())
+	store, err := NewStore(StoreConfig{
+		TableName:       "test-admin-users",
+		Region:          "us-west-2",
+		AutoCreateTable: true,
+	})
+	require.NoError(t, err)
+	return store
+}
+
+func TestEnsureUserCreatesViewer(t *testing.T) {
+	store := testUserStore(t)
+	ctx := context.Background()
+
+	user, created, err := store.EnsureUser(ctx, "Alice@Example.com", "Alice", "pic")
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, "alice@example.com", user.Email)
+	assert.Equal(t, RoleViewer, user.Role)
+
+	_, createdAgain, err := store.EnsureUser(ctx, "alice@example.com", "Alice Updated", "pic2")
+	require.NoError(t, err)
+	assert.False(t, createdAgain)
+
+	got, err := store.GetUser(ctx, "alice@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "Alice Updated", got.Name)
+	assert.Equal(t, RoleViewer, got.Role)
+}
+
+func TestCreateUserAndSetRole(t *testing.T) {
+	store := testUserStore(t)
+	ctx := context.Background()
+
+	_, err := store.CreateUser(ctx, "editor@example.com", RoleEditor)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetRole(ctx, "editor@example.com", RoleAdmin))
+
+	got, err := store.GetUser(ctx, "editor@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, RoleAdmin, got.Role)
+}
+
+func TestListUsersAndCountAdmins(t *testing.T) {
+	store := testUserStore(t)
+	ctx := context.Background()
+
+	_, err := store.CreateUser(ctx, "a@example.com", RoleAdmin)
+	require.NoError(t, err)
+	_, err = store.CreateUser(ctx, "b@example.com", RoleViewer)
+	require.NoError(t, err)
+
+	users, err := store.ListUsers(ctx)
+	require.NoError(t, err)
+	assert.Len(t, users, 2)
+
+	count, err := store.CountAdmins(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestRecordShareAwarenessIdempotent(t *testing.T) {
+	store := testUserStore(t)
+	ctx := context.Background()
+
+	_, _, err := store.EnsureUser(ctx, "viewer@example.com", "", "")
+	require.NoError(t, err)
+
+	require.NoError(t, store.RecordShareAwareness(ctx, "viewer@example.com", "share-uuid"))
+	require.NoError(t, store.RecordShareAwareness(ctx, "viewer@example.com", "share-uuid"))
+}
+
+func TestDeleteUser(t *testing.T) {
+	store := testUserStore(t)
+	ctx := context.Background()
+
+	_, err := store.CreateUser(ctx, "gone@example.com", RoleViewer)
+	require.NoError(t, err)
+	require.NoError(t, store.DeleteUser(ctx, "gone@example.com"))
+
+	_, err = store.GetUser(ctx, "gone@example.com")
+	require.Error(t, err)
+}

--- a/internal/adminusers/store_test.go
+++ b/internal/adminusers/store_test.go
@@ -96,3 +96,64 @@ func TestDeleteUser(t *testing.T) {
 	_, err = store.GetUser(ctx, "gone@example.com")
 	require.Error(t, err)
 }
+
+func TestCreateUserDuplicate(t *testing.T) {
+	store := testUserStore(t)
+	ctx := context.Background()
+
+	_, err := store.CreateUser(ctx, "dup@example.com", RoleViewer)
+	require.NoError(t, err)
+
+	_, err = store.CreateUser(ctx, "dup@example.com", RoleEditor)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestSetRoleNotFound(t *testing.T) {
+	store := testUserStore(t)
+	err := store.SetRole(context.Background(), "missing@example.com", RoleAdmin)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDeleteUserNotFound(t *testing.T) {
+	store := testUserStore(t)
+	err := store.DeleteUser(context.Background(), "missing@example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestNormalizeEmailInvalid(t *testing.T) {
+	store := testUserStore(t)
+	_, _, err := store.EnsureUser(context.Background(), "not-an-email", "", "")
+	require.Error(t, err)
+}
+
+func TestGetUserNotFound(t *testing.T) {
+	store := testUserStore(t)
+	_, err := store.GetUser(context.Background(), "nobody@example.com")
+	require.Error(t, err)
+}
+
+func TestRecordShareAwarenessInvalidInput(t *testing.T) {
+	store := testUserStore(t)
+	err := store.RecordShareAwareness(context.Background(), "", "share-id")
+	require.Error(t, err)
+	err = store.RecordShareAwareness(context.Background(), "user@example.com", "")
+	require.Error(t, err)
+}
+
+func TestEnsureUserCreateRaceRetries(t *testing.T) {
+	store := testUserStore(t)
+	ctx := context.Background()
+
+	user, created, err := store.EnsureUser(ctx, "race@example.com", "Race", "")
+	require.NoError(t, err)
+	require.True(t, created)
+	assert.Equal(t, RoleViewer, user.Role)
+
+	user, created, err = store.EnsureUser(ctx, "race@example.com", "Race Again", "")
+	require.NoError(t, err)
+	assert.False(t, created)
+	assert.Equal(t, "Race Again", user.Name)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -942,6 +942,10 @@ func (c *YAMLConfig) Validate() error {
 		}
 	}
 
+	if c.Features.AdminDashboard.EditorLimits.MaxDailyCostLimitCents < 0 {
+		return fmt.Errorf("invalid admin_dashboard configuration: editor_limits.max_daily_cost_limit_cents cannot be negative")
+	}
+
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,30 @@ type AdminDashboardConfig struct {
 	// default list applies (see apikeys.SetPIIOffNonBedrockBypassAdmins).
 	// Prefer setting this in YAML so roster changes don't require a deploy.
 	PIIOffBypassAdmins []string `yaml:"pii_off_bypass_admins"`
+	// Users configures the DynamoDB-backed admin user roster and RBAC.
+	Users AdminUsersConfig `yaml:"users"`
+	// EditorLimits caps what editors may set when creating/updating keys.
+	EditorLimits EditorLimitsConfig `yaml:"editor_limits"`
+}
+
+// AdminUsersConfig configures the admin user DynamoDB store.
+type AdminUsersConfig struct {
+	DynamoDB AdminUsersDynamoDBConfig `yaml:"dynamodb"`
+}
+
+// AdminUsersDynamoDBConfig is DynamoDB settings for admin users.
+type AdminUsersDynamoDBConfig struct {
+	Region          string `yaml:"region"`
+	TableName       string `yaml:"table_name"`
+	EndpointURL     string `yaml:"endpoint_url"`
+	AutoCreateTable bool   `yaml:"auto_create_table"`
+}
+
+// EditorLimitsConfig caps editor key-management permissions.
+type EditorLimitsConfig struct {
+	// MaxDailyCostLimitCents is the maximum daily_cost_limit (cents) editors
+	// may set on keys. Zero means no cap.
+	MaxDailyCostLimitCents int64 `yaml:"max_daily_cost_limit_cents"`
 }
 
 // AdminRollupsConfig configures daily rollups for the admin UI.

--- a/internal/testhelpers/dynamodbfake/server.go
+++ b/internal/testhelpers/dynamodbfake/server.go
@@ -127,17 +127,17 @@ func (f *Server) handle(w http.ResponseWriter, r *http.Request) {
 	case "PutItem":
 		tableName, _ := input["TableName"].(string)
 		item, _ := input["Item"].(map[string]any)
-		pk := ExtractDDBString(item, "pk")
+		storageKey := storageKeyFromAttrs(item)
 		if f.tables[tableName] == nil {
 			f.tables[tableName] = make(map[string]any)
 		}
-		f.tables[tableName][pk] = item
+		f.tables[tableName][storageKey] = item
 		_, _ = w.Write([]byte(`{}`))
 	case "GetItem":
 		tableName, _ := input["TableName"].(string)
 		key, _ := input["Key"].(map[string]any)
-		pk := ExtractDDBString(key, "pk")
-		item := f.tables[tableName][pk]
+		storageKey := storageKeyFromAttrs(key)
+		item := f.tables[tableName][storageKey]
 		if item == nil {
 			_, _ = w.Write([]byte(`{}`))
 			return
@@ -146,33 +146,58 @@ func (f *Server) handle(w http.ResponseWriter, r *http.Request) {
 	case "DeleteItem":
 		tableName, _ := input["TableName"].(string)
 		key, _ := input["Key"].(map[string]any)
-		pk := ExtractDDBString(key, "pk")
+		storageKey := storageKeyFromAttrs(key)
 		conditionExpr, _ := input["ConditionExpression"].(string)
-		if strings.Contains(conditionExpr, "attribute_exists") && f.tables[tableName][pk] == nil {
+		if strings.Contains(conditionExpr, "attribute_exists") && f.tables[tableName][storageKey] == nil {
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(`{"__type":"com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException"}`))
 			return
 		}
 		if f.tables[tableName] != nil {
-			delete(f.tables[tableName], pk)
+			delete(f.tables[tableName], storageKey)
 		}
 		_, _ = w.Write([]byte(`{}`))
 	case "UpdateItem":
-		// Stub UpdateItem: we do not parse DynamoDB UpdateExpressions
-		// here. Tests that need to assert mutated field values should
-		// either drive the store through PutItem (CreateKey) or use the
-		// expressive fake methods (InjectItem). Returning 200 keeps the
-		// happy path green for callers that only assert no error.
+		tableName, _ := input["TableName"].(string)
+		key, _ := input["Key"].(map[string]any)
+		storageKey := storageKeyFromAttrs(key)
+		conditionExpr, _ := input["ConditionExpression"].(string)
+		item, exists := f.tables[tableName][storageKey]
+		if strings.Contains(conditionExpr, "attribute_exists") && !exists {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"__type":"com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException"}`))
+			return
+		}
+		if exists {
+			itemMap, _ := item.(map[string]any)
+			if vals, ok := input["ExpressionAttributeValues"].(map[string]any); ok {
+				if role := extractAttrValueString(vals, ":role"); role != "" {
+					itemMap["role"] = map[string]any{"S": role}
+				}
+				if updated := extractAttrValueString(vals, ":updated_at"); updated != "" {
+					itemMap["updated_at"] = map[string]any{"S": updated}
+				}
+			}
+			f.tables[tableName][storageKey] = itemMap
+		}
 		_, _ = w.Write([]byte(`{}`))
 	case "Query", "Scan":
 		tableName, _ := input["TableName"].(string)
 		filterExpr, _ := input["FilterExpression"].(string)
 		attrValues, _ := input["ExpressionAttributeValues"].(map[string]any)
 		var items []any
-		for pk, it := range f.tables[tableName] {
+		for _, it := range f.tables[tableName] {
+			item, _ := it.(map[string]any)
+			if filterExpr != "" && strings.Contains(filterExpr, "sk =") {
+				wantSK := extractAttrValueString(attrValues, ":profile")
+				if wantSK != "" && ExtractDDBString(item, "sk") != wantSK {
+					continue
+				}
+			}
 			if filterExpr != "" && strings.Contains(filterExpr, "begins_with") {
+				pkVal := ExtractDDBString(item, "pk")
 				pfx := extractAttrValueString(attrValues, ":pfx")
-				if pfx != "" && !strings.HasPrefix(pk, pfx) {
+				if pfx != "" && !strings.HasPrefix(pkVal, pfx) {
 					continue
 				}
 			}
@@ -202,6 +227,15 @@ func ExtractDDBString(m map[string]any, k string) string {
 		}
 	}
 	return ""
+}
+
+func storageKeyFromAttrs(m map[string]any) string {
+	pk := ExtractDDBString(m, "pk")
+	sk := ExtractDDBString(m, "sk")
+	if sk != "" {
+		return pk + "\x00" + sk
+	}
+	return pk
 }
 
 func extractAttrValueString(attrs map[string]any, key string) string {

--- a/internal/testhelpers/dynamodbfake/server.go
+++ b/internal/testhelpers/dynamodbfake/server.go
@@ -131,6 +131,12 @@ func (f *Server) handle(w http.ResponseWriter, r *http.Request) {
 		if f.tables[tableName] == nil {
 			f.tables[tableName] = make(map[string]any)
 		}
+		conditionExpr, _ := input["ConditionExpression"].(string)
+		if strings.Contains(conditionExpr, "attribute_not_exists") && f.tables[tableName][storageKey] != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"__type":"com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException"}`))
+			return
+		}
 		f.tables[tableName][storageKey] = item
 		_, _ = w.Write([]byte(`{}`))
 	case "GetItem":

--- a/internal/testhelpers/dynamodbfake/server.go
+++ b/internal/testhelpers/dynamodbfake/server.go
@@ -86,7 +86,11 @@ func (f *Server) InjectItem(table, pk string, item map[string]any) {
 	if f.tables[table] == nil {
 		f.tables[table] = make(map[string]any)
 	}
-	f.tables[table][pk] = item
+	storageKey := storageKeyFromAttrs(item)
+	if storageKey == "" {
+		storageKey = pk
+	}
+	f.tables[table][storageKey] = item
 }
 
 func (f *Server) handle(w http.ResponseWriter, r *http.Request) {

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -10,8 +10,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <script type="module" crossorigin src="/admin/assets/index-CnGqW0fs.js"></script>
-  <link rel="stylesheet" crossorigin href="/admin/assets/index-BUYoJxVI.css">
+  <script type="module" crossorigin src="/admin/assets/index-GfZ8DV6a.js"></script>
+  <link rel="stylesheet" crossorigin href="/admin/assets/index-BtoJ0YVW.css">
 </head>
 
 <body>

--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -41,6 +41,10 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     throw new APIClientError(401, "Unauthorized");
   }
 
+  if (response.status === 403) {
+    throw new APIClientError(403, await parseError(response));
+  }
+
   if (!response.ok) {
     throw new APIClientError(response.status, await parseError(response));
   }

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -105,6 +105,16 @@ function ConfigIcon() {
   );
 }
 
+function UsersIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-5 w-5">
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+
 function SidebarUserFooter({
   user,
   displayName,
@@ -123,6 +133,9 @@ function SidebarUserFooter({
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium text-base-content">{displayName}</p>
           {user?.email ? <p className="truncate text-xs text-base-content/60">{user.email}</p> : null}
+          {user?.role ? (
+            <p className="mt-0.5 truncate text-[0.65rem] uppercase tracking-wide text-base-content/45">{user.role}</p>
+          ) : null}
         </div>
       </div>
       <div className="mt-2">
@@ -159,26 +172,30 @@ export default function AppShell({ children }: { children: ReactNode }) {
 
   const isActive = (to: string) => (to === "/" ? location.pathname === "/" : location.pathname.startsWith(to));
 
-  const navSections = [
-    {
-      heading: "Monitoring",
-      items: [
-        { to: "/", label: "Overview", icon: <DashboardIcon /> },
-        { to: "/usage", label: "Usage", icon: <UsageIcon /> },
-        { to: "/circuit", label: "Circuit Breaker", icon: <CircuitIcon /> },
-        { to: "/rate-limits", label: "Rate Limits", icon: <GaugeIcon /> },
-        { to: "/cost", label: "Cost Tracking", icon: <CostIcon /> },
-        { to: "/pii", label: "PII Redaction", icon: <ShieldIcon /> },
-      ],
-    },
-    {
-      heading: "Manage",
-      items: [
-        { to: "/keys", label: "API Keys", icon: <KeyIcon /> },
-        { to: "/config", label: "Configuration", icon: <ConfigIcon /> },
-      ],
-    },
+  const role = me?.role ?? "viewer";
+
+  const monitoringItems = [
+    { to: "/", label: "Overview", icon: <DashboardIcon /> },
+    { to: "/usage", label: "Usage", icon: <UsageIcon /> },
+    { to: "/circuit", label: "Circuit Breaker", icon: <CircuitIcon /> },
+    { to: "/rate-limits", label: "Rate Limits", icon: <GaugeIcon /> },
+    { to: "/cost", label: "Cost Tracking", icon: <CostIcon /> },
+    { to: "/pii", label: "PII Redaction", icon: <ShieldIcon /> },
   ];
+
+  const manageItems: { to: string; label: string; icon: React.ReactElement }[] = [];
+  if (role === "editor" || role === "admin") {
+    manageItems.push({ to: "/keys", label: "API Keys", icon: <KeyIcon /> });
+  }
+  if (role === "admin") {
+    manageItems.push({ to: "/config", label: "Configuration", icon: <ConfigIcon /> });
+    manageItems.push({ to: "/users", label: "Users", icon: <UsersIcon /> });
+  }
+
+  const navSections = [{ heading: "Monitoring", items: monitoringItems }];
+  if (manageItems.length > 0) {
+    navSections.push({ heading: "Manage", items: manageItems });
+  }
 
   const displayName = me?.name || me?.email?.split("@")[0] || "User";
 

--- a/web/src/components/keys/keys-table.tsx
+++ b/web/src/components/keys/keys-table.tsx
@@ -18,6 +18,7 @@ interface KeysTableProps {
   onShare: (record: APIKey) => void;
   onEdit: (record: APIKey) => void;
   onDelete: (record: APIKey) => void;
+  canDelete?: boolean;
   sharingKey?: string | null;
   maskKey: (key: string) => string;
   formatRateLimits: (record: APIKey) => string;
@@ -28,6 +29,7 @@ export default function KeysTable({
   onShare,
   onEdit,
   onDelete,
+  canDelete = true,
   sharingKey,
   maskKey,
   formatRateLimits,
@@ -113,18 +115,20 @@ export default function KeysTable({
             <button type="button" className="btn btn-ghost btn-xs" onClick={() => onEdit(row.original)}>
               Edit
             </button>
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs text-error"
-              onClick={() => onDelete(row.original)}
-            >
-              Delete
-            </button>
+            {canDelete ? (
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs text-error"
+                onClick={() => onDelete(row.original)}
+              >
+                Delete
+              </button>
+            ) : null}
           </div>
         ),
       },
     ],
-    [keys, maskKey, formatRateLimits, onShare, onEdit, onDelete, sharingKey],
+    [keys, maskKey, formatRateLimits, onShare, onEdit, onDelete, canDelete, sharingKey],
   );
 
   return (

--- a/web/src/components/users/users-table.tsx
+++ b/web/src/components/users/users-table.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import DataTable from "../ui/data-table";
+import type { AdminRole, AdminUserRecord } from "../../types";
+
+function RoleBadge({ role }: { role: AdminRole }) {
+  const cls =
+    role === "admin"
+      ? "badge badge-primary"
+      : role === "editor"
+        ? "badge badge-secondary"
+        : "badge badge-ghost";
+  return <span className={cls}>{role}</span>;
+}
+
+function formatOptionalTime(value?: string): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
+}
+
+interface UsersTableProps {
+  users: AdminUserRecord[];
+  currentEmail?: string;
+  adminCount: number;
+  onEdit: (user: AdminUserRecord) => void;
+  onDelete: (user: AdminUserRecord) => void;
+}
+
+export default function UsersTable({
+  users,
+  currentEmail,
+  adminCount,
+  onEdit,
+  onDelete,
+}: UsersTableProps) {
+  const columns = useMemo<ColumnDef<AdminUserRecord, unknown>[]>(
+    () => [
+      {
+        id: "email",
+        accessorKey: "email",
+        header: "Email",
+        cell: ({ row }) => {
+          const isSelf = currentEmail && row.original.email === currentEmail;
+          return (
+            <span>
+              {row.original.email}
+              {isSelf ? <span className="ml-2 text-xs text-base-content/50">(you)</span> : null}
+            </span>
+          );
+        },
+      },
+      {
+        id: "name",
+        accessorKey: "name",
+        header: "Name",
+        cell: ({ getValue }) => (getValue<string>() || "—"),
+      },
+      {
+        id: "role",
+        accessorKey: "role",
+        header: "Role",
+        cell: ({ getValue }) => <RoleBadge role={getValue<AdminRole>()} />,
+      },
+      {
+        id: "last_login_at",
+        accessorKey: "last_login_at",
+        header: "Last login",
+        cell: ({ getValue }) => formatOptionalTime(getValue<string>()),
+      },
+      {
+        id: "created_at",
+        accessorKey: "created_at",
+        header: "Created",
+        cell: ({ getValue }) => formatOptionalTime(getValue<string>()),
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }) => {
+          const user = row.original;
+          const isSelf = currentEmail === user.email;
+          const isLastAdmin = user.role === "admin" && adminCount <= 1;
+          return (
+            <div className="flex justify-end gap-2">
+              <button type="button" className="btn btn-ghost btn-xs" disabled={isSelf} onClick={() => onEdit(user)}>
+                Edit role
+              </button>
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs text-error"
+                disabled={isSelf || isLastAdmin}
+                onClick={() => onDelete(user)}
+              >
+                Delete
+              </button>
+            </div>
+          );
+        },
+      },
+    ],
+    [adminCount, currentEmail, onDelete, onEdit],
+  );
+
+  return <DataTable columns={columns} data={users} emptyMessage="No users yet" />;
+}

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -3,9 +3,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "../client";
 import type {
   AdminUser,
+  AdminUserRecord,
   APIKey,
   ConfigSummary,
   CostResponse,
+  CreateAdminUserRequest,
   CreateAPIKeyRequest,
   HealthResponse,
   CircuitActivityResponse,
@@ -15,6 +17,7 @@ import type {
   RateLimitsResponse,
   ShareCreateResponse,
   ShareInfo,
+  UpdateAdminUserRoleRequest,
   UpdateAPIKeyRequest,
   UsageResponse,
 } from "../types";
@@ -32,6 +35,7 @@ export const queryKeys = {
   usage: ["admin", "usage"] as const,
   pii: ["admin", "pii"] as const,
   provisioning: ["admin", "provisioning"] as const,
+  users: ["admin", "users"] as const,
 };
 
 export function useMe() {
@@ -199,5 +203,48 @@ export function useDeleteShare() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch<void>(`/admin/api/share/${encodeURIComponent(id)}`, { method: "DELETE" }),
+  });
+}
+
+export function useUsers() {
+  return useQuery({
+    queryKey: queryKeys.users,
+    queryFn: () => apiFetch<AdminUserRecord[]>("/admin/api/users"),
+  });
+}
+
+export function useCreateUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateAdminUserRequest) =>
+      apiFetch<AdminUserRecord>("/admin/api/users", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.users }),
+  });
+}
+
+export function useUpdateUserRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ email, role }: { email: string; role: UpdateAdminUserRoleRequest["role"] }) =>
+      apiFetch<AdminUserRecord>(`/admin/api/users/${encodeURIComponent(email)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ role }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.users });
+      qc.invalidateQueries({ queryKey: queryKeys.me });
+    },
+  });
+}
+
+export function useDeleteUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (email: string) =>
+      apiFetch<void>(`/admin/api/users/${encodeURIComponent(email)}`, { method: "DELETE" }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.users }),
   });
 }

--- a/web/src/pages/keys/index.tsx
+++ b/web/src/pages/keys/index.tsx
@@ -117,6 +117,9 @@ export default function KeysPage() {
   const { data: config } = useConfig();
   const globalPiiEnabled = Boolean(config?.features?.pii_redact);
   const canBypassPiiBedrockPolicy = Boolean(me?.can_bypass_pii_off_non_bedrock_policy);
+  const canDeleteKeys = me?.role === "admin";
+  const editorMaxCents = me?.editor_limits?.max_daily_cost_limit_cents ?? 0;
+  const editorMaxDollars = editorMaxCents > 0 ? editorMaxCents / 100 : null;
   const [providerFilter, setProviderFilter] = useState<Provider | "">("");
   const [modalOpen, setModalOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<APIKey | null>(null);
@@ -208,6 +211,10 @@ export default function KeysPage() {
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
     const dailyCostLimit = Math.round(Number(form.daily_cost_limit_dollars || "0") * 100);
+    if (editorMaxCents > 0 && dailyCostLimit > editorMaxCents) {
+      push(`Daily cost limit cannot exceed $${editorMaxDollars}`, "error");
+      return;
+    }
     const redactPii = piiFromFormValue(form.redact_pii);
 
     try {
@@ -314,6 +321,7 @@ export default function KeysPage() {
             onShare={onShare}
             onEdit={openEdit}
             onDelete={setDeleteTarget}
+            canDelete={canDeleteKeys}
             sharingKey={sharingKey}
             maskKey={maskKey}
             formatRateLimits={formatRateLimits}
@@ -433,7 +441,10 @@ export default function KeysPage() {
                       }))
                     }
                   />
-                  <p className="mt-1.5 text-xs text-base-content/60">Leave at 0 for unlimited</p>
+                  <p className="mt-1.5 text-xs text-base-content/60">
+                    Leave at 0 for unlimited
+                    {editorMaxDollars != null ? ` · Editor max $${editorMaxDollars}/day` : null}
+                  </p>
                 </label>
 
                 <div className="form-control w-full sm:w-auto">

--- a/web/src/pages/users/index.tsx
+++ b/web/src/pages/users/index.tsx
@@ -1,0 +1,219 @@
+import { FormEvent, useMemo, useState } from "react";
+
+import UsersTable from "../../components/users/users-table";
+import PageHeader, { ErrorAlert, LoadingBlock } from "../../components/ui/page-header";
+import { useToast } from "../../components/ui/toast";
+import { APIClientError } from "../../client";
+import {
+  useCreateUser,
+  useDeleteUser,
+  useMe,
+  useUpdateUserRole,
+  useUsers,
+} from "../../hooks/queries";
+import type { AdminRole, AdminUserRecord } from "../../types";
+
+const ROLES: AdminRole[] = ["viewer", "editor", "admin"];
+
+export default function UsersPage() {
+  const { data: me } = useMe();
+  const usersQuery = useUsers();
+  const createUser = useCreateUser();
+  const updateRole = useUpdateUserRole();
+  const deleteUser = useDeleteUser();
+  const toast = useToast();
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [editUser, setEditUser] = useState<AdminUserRecord | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AdminUserRecord | null>(null);
+  const [addEmail, setAddEmail] = useState("");
+  const [addRole, setAddRole] = useState<AdminRole>("viewer");
+  const [editRole, setEditRole] = useState<AdminRole>("viewer");
+
+  const adminCount = useMemo(
+    () => (usersQuery.data ?? []).filter((u) => u.role === "admin").length,
+    [usersQuery.data],
+  );
+
+  const forbidden = usersQuery.error instanceof APIClientError && usersQuery.error.status === 403;
+
+  const onAddSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      await createUser.mutateAsync({ email: addEmail.trim(), role: addRole });
+      toast.push("User added", "success");
+      setAddOpen(false);
+      setAddEmail("");
+      setAddRole("viewer");
+    } catch (err) {
+      toast.push(err instanceof Error ? err.message : "Failed to add user", "error");
+    }
+  };
+
+  const onEditSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!editUser) return;
+    try {
+      await updateRole.mutateAsync({ email: editUser.email, role: editRole });
+      toast.push("Role updated", "success");
+      setEditUser(null);
+    } catch (err) {
+      toast.push(err instanceof Error ? err.message : "Failed to update role", "error");
+    }
+  };
+
+  const onConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteUser.mutateAsync(deleteTarget.email);
+      toast.push("User deleted", "success");
+      setDeleteTarget(null);
+    } catch (err) {
+      toast.push(err instanceof Error ? err.message : "Failed to delete user", "error");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Users"
+        description="Manage admin dashboard access. Pre-provision roles before a user's first sign-in."
+        actions={
+          <button type="button" className="btn btn-primary btn-sm" onClick={() => setAddOpen(true)}>
+            Add user
+          </button>
+        }
+      />
+
+      {forbidden ? (
+        <ErrorAlert message="You do not have permission to view this page." />
+      ) : usersQuery.isLoading ? (
+        <LoadingBlock />
+      ) : usersQuery.isError ? (
+        <ErrorAlert message={usersQuery.error instanceof Error ? usersQuery.error.message : "Failed to load users"} />
+      ) : (
+        <UsersTable
+          users={usersQuery.data ?? []}
+          currentEmail={me?.email}
+          adminCount={adminCount}
+          onEdit={(user) => {
+            setEditUser(user);
+            setEditRole(user.role);
+          }}
+          onDelete={setDeleteTarget}
+        />
+      )}
+
+      {addOpen ? (
+        <dialog className="modal modal-open">
+          <div className="modal-box">
+            <h3 className="text-lg font-semibold">Add user</h3>
+            <form className="mt-4 space-y-4" onSubmit={onAddSubmit}>
+              <label className="form-control w-full">
+                <span className="label-text">Email</span>
+                <input
+                  type="email"
+                  className="input input-bordered w-full"
+                  required
+                  value={addEmail}
+                  onChange={(e) => setAddEmail(e.target.value)}
+                />
+              </label>
+              <label className="form-control w-full">
+                <span className="label-text">Role</span>
+                <select
+                  className="select select-bordered w-full"
+                  value={addRole}
+                  onChange={(e) => setAddRole(e.target.value as AdminRole)}
+                >
+                  {ROLES.map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="modal-action">
+                <button type="button" className="btn btn-ghost" onClick={() => setAddOpen(false)}>
+                  Cancel
+                </button>
+                <button type="submit" className="btn btn-primary" disabled={createUser.isPending}>
+                  Add
+                </button>
+              </div>
+            </form>
+          </div>
+          <form method="dialog" className="modal-backdrop">
+            <button type="button" onClick={() => setAddOpen(false)}>
+              close
+            </button>
+          </form>
+        </dialog>
+      ) : null}
+
+      {editUser ? (
+        <dialog className="modal modal-open">
+          <div className="modal-box">
+            <h3 className="text-lg font-semibold">Edit role</h3>
+            <p className="mt-1 text-sm text-base-content/60">{editUser.email}</p>
+            <form className="mt-4 space-y-4" onSubmit={onEditSubmit}>
+              <label className="form-control w-full">
+                <span className="label-text">Role</span>
+                <select
+                  className="select select-bordered w-full"
+                  value={editRole}
+                  onChange={(e) => setEditRole(e.target.value as AdminRole)}
+                  disabled={editUser.email === me?.email && editUser.role === "admin"}
+                >
+                  {ROLES.map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="modal-action">
+                <button type="button" className="btn btn-ghost" onClick={() => setEditUser(null)}>
+                  Cancel
+                </button>
+                <button type="submit" className="btn btn-primary" disabled={updateRole.isPending}>
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>
+          <form method="dialog" className="modal-backdrop">
+            <button type="button" onClick={() => setEditUser(null)}>
+              close
+            </button>
+          </form>
+        </dialog>
+      ) : null}
+
+      {deleteTarget ? (
+        <dialog className="modal modal-open">
+          <div className="modal-box">
+            <h3 className="text-lg font-semibold">Delete user</h3>
+            <p className="py-4">
+              Remove <span className="font-medium">{deleteTarget.email}</span>? They will be re-created as a viewer on
+              next sign-in.
+            </p>
+            <div className="modal-action">
+              <button type="button" className="btn btn-ghost" onClick={() => setDeleteTarget(null)}>
+                Cancel
+              </button>
+              <button type="button" className="btn btn-error" disabled={deleteUser.isPending} onClick={onConfirmDelete}>
+                Delete
+              </button>
+            </div>
+          </div>
+          <form method="dialog" className="modal-backdrop">
+            <button type="button" onClick={() => setDeleteTarget(null)}>
+              close
+            </button>
+          </form>
+        </dialog>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -15,6 +15,7 @@ import OverviewPage from "./pages/overview";
 import PIIPage from "./pages/pii";
 import RateLimitsPage from "./pages/rate-limits";
 import SharePage from "./pages/share";
+import UsersPage from "./pages/users";
 import UsagePage from "./pages/usage";
 
 function shell(page: ReactNode) {
@@ -41,6 +42,7 @@ export default function Router() {
           <Route path="/config" element={shell(<ConfigPage />)} />
           <Route path="/keys/:key" element={shell(<KeyDetailPage />)} />
           <Route path="/keys" element={shell(<KeysPage />)} />
+          <Route path="/users" element={shell(<UsersPage />)} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </BrowserRouter>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,11 +2,38 @@ export type Provider = "openai" | "anthropic" | "gemini" | "bedrock";
 
 export type PiiRedactSetting = boolean | null;
 
+export type AdminRole = "admin" | "editor" | "viewer";
+
+export interface EditorLimits {
+  max_daily_cost_limit_cents: number;
+}
+
 export interface AdminUser {
   email: string;
   name?: string;
   picture?: string;
+  role?: AdminRole;
   can_bypass_pii_off_non_bedrock_policy?: boolean;
+  editor_limits?: EditorLimits;
+}
+
+export interface AdminUserRecord {
+  email: string;
+  name?: string;
+  picture?: string;
+  role: AdminRole;
+  created_at: string;
+  updated_at: string;
+  last_login_at?: string;
+}
+
+export interface CreateAdminUserRequest {
+  email: string;
+  role: AdminRole;
+}
+
+export interface UpdateAdminUserRoleRequest {
+  role: AdminRole;
 }
 
 export interface APIKey {


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

- Adds a DynamoDB-backed admin user table with `admin`, `editor`, and `viewer` roles; new sign-ins are auto-provisioned as viewers after Google email verification.
- Enforces route-level RBAC: viewers get read-only stats, editors can create/update keys within admin-defined daily cost caps, admins get full access including user management.
- Ships `llm-proxy-users` CLI for bootstrap admins, admin `/users` CRUD API + UI, and share-awareness recording for logged-in share visits (public UUID share access unchanged).

## Test plan

- [x] `go test ./internal/adminusers/... ./internal/admin/...`
- [x] `go vet ./...`
- [x] `make build-users`
- [x] `npm run build` in `web/`
- [ ] Deploy dev table (`llm-proxy-admin-users-dev` with `auto_create_table: true`)
- [ ] `./bin/llm-proxy-users -env dev set-role -email you@instawork.com -role admin`
- [ ] Sign in via Google/dev-login and verify viewer default, editor key cap, admin Users page

## Post-deploy

- Provision `llm-proxy-admin-users` / `-staging` DynamoDB tables (pk + sk, PAY_PER_REQUEST) and IAM permissions.
- Bootstrap at least one admin via `llm-proxy-users set-role` before relying on RBAC in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin user management backed by DynamoDB, including Viewer/Editor/Admin roles, role-based access control, and “ensure” on login when enabled.
  * Introduced an admin CLI for user operations (set role, list, get).
  * Added an admin Users page and API support for listing/creating/updating/deleting users.
  * Enforced editor maximum daily cost limits in both API and UI.
* **Bug Fixes**
  * Improved web client handling of HTTP 403 responses for clearer authorization errors.
* **Chores**
  * Added a new build target to build the additional admin users CLI binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->