### PR TITLE
Fix gofmt lint failure

### DIFF
--- a/integration/live/config.go
+++ b/integration/live/config.go
@@ -66,7 +66,7 @@ func parseSuites(raw string) map[string]bool {
 			"health": true, "admin": true,
 			"openai": true, "anthropic": true, "gemini": true,
 			"ratelimit": true, "cost": true, "pii": true, "presidio": true,
-			"redact": true,
+			"redact":   true,
 			"snippets": true,
 		}
 	}

--- a/internal/redactapi/handler.go
+++ b/internal/redactapi/handler.go
@@ -28,8 +28,8 @@ type ProxyKeyLookup interface {
 
 // Config controls POST /redact runtime behaviour.
 type Config struct {
-	MaxBodyBytes           int
-	AllowUnauthenticated   bool
+	MaxBodyBytes         int
+	AllowUnauthenticated bool
 }
 
 // Handler serves POST /redact.


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary
- The `lint` job's `go fmt check` was failing on `main` because two files were not gofmt-formatted.
- This applies `gofmt -w` to fix the alignment in `integration/live/config.go` and `internal/redactapi/handler.go`.

## Test plan
- `gofmt -l .` returns no files (whole repo passes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting and alignment improvements for better code consistency across the codebase. No functional changes or behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->