### PR TITLE
feat(fuzz): add fake upstream mode and local fuzz CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,19 @@ jobs:
           name: Run integration tests
           command: make test-integration
 
+  fuzz-tests:
+    docker:
+      - image: cimg/base:stable
+    working_directory: ~/llm-proxy
+    steps:
+      - setup_go_environment
+      - run:
+          name: Run fake-mode unit tests with race detector
+          command: make fuzz-test
+      - run:
+          name: Build fuzz CLI
+          command: make build-fuzz
+
   build-and-push:
     docker:
       - image: cimg/base:stable
@@ -187,11 +200,19 @@ workflows:
             tags:
               only: /.*/
 
+      - fuzz-tests:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+
       - build-and-push:
           requires:
             - lint
             - unit-tests
             - integration-tests
+            - fuzz-tests
           filters:
             branches:
               only:

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ help:
 	@echo "  test-live      - Run standalone HTTP integration CLI (needs running proxy)"
 	@echo "  test-live-pii  - Bring up Presidio + run live admin/pii/presidio suites"
 	@echo "  test-live-snippets - Verify share-box snippets (see integration/snippets/README.md)"
+	@echo "  fuzz-test      - Run fake-mode unit tests with -race"
+	@echo "  fuzz           - Smoke fuzz scenarios (needs fuzz-mode proxy)"
+	@echo "  fuzz-all       - All fuzz scenarios"
+	@echo "  fuzz-chaos     - Circuit/chaos fuzz scenarios"
+	@echo "  fuzz-matrix    - Rate-limit/circuit scenarios on Redis + memory backends"
 	@echo "  install-snippet-deps - Install node/python/go deps for snippet smoke tests"
 	@echo "  install-live-deps - install-snippet-deps (alias)"
 	@echo "  build-live     - Build the llm-proxy-live integration binary"
@@ -330,6 +335,46 @@ test-live-pii: test-pii-up build-live
 	@echo "$(BLUE)Running live PII integration checks (Presidio + admin/pii suites)...$(NC)"
 	@cd $(LIVE_INTEGRATION_DIR) && go run ./cmd/llm-proxy-live -suite presidio,pii,admin $(LIVE_ARGS)
 	@echo "$(GREEN)✓ Live PII integration checks completed$(NC)"
+
+FUZZ_BINARY=$(LIVE_INTEGRATION_DIR)/bin/llm-proxy-fuzz
+FUZZ_ARGS?=-workers 4 -requests 25 -seed 42
+
+.PHONY: build-fuzz
+build-fuzz:
+	@echo "$(BLUE)Building llm-proxy-fuzz CLI...$(NC)"
+	@mkdir -p $(LIVE_INTEGRATION_DIR)/bin
+	@cd $(LIVE_INTEGRATION_DIR) && go build -o bin/llm-proxy-fuzz ./cmd/llm-proxy-fuzz
+	@echo "$(GREEN)✓ Build completed: $(FUZZ_BINARY)$(NC)"
+
+.PHONY: fuzz-test
+fuzz-test:
+	@echo "$(BLUE)Running fake-mode unit tests with -race...$(NC)"
+	@go test -race ./internal/fake/... ./cmd/llm-proxy/... -count=1
+	@echo "$(GREEN)✓ fuzz-test completed$(NC)"
+
+.PHONY: fuzz
+fuzz: build-fuzz
+	@echo "$(BLUE)Running fuzz smoke scenarios...$(NC)"
+	@cd $(LIVE_INTEGRATION_DIR) && go run ./cmd/llm-proxy-fuzz -scenario smoke $(FUZZ_ARGS)
+	@echo "$(GREEN)✓ fuzz smoke completed$(NC)"
+
+.PHONY: fuzz-all
+fuzz-all: build-fuzz
+	@cd $(LIVE_INTEGRATION_DIR) && go run ./cmd/llm-proxy-fuzz -scenario all $(FUZZ_ARGS)
+
+.PHONY: fuzz-chaos
+fuzz-chaos: build-fuzz
+	@cd $(LIVE_INTEGRATION_DIR) && go run ./cmd/llm-proxy-fuzz -scenario chaos -seed 42 $(FUZZ_ARGS)
+
+.PHONY: fuzz-matrix
+fuzz-matrix: build-fuzz
+	@echo "$(BLUE)Fuzz matrix: Redis backend (ENVIRONMENT=fuzz)...$(NC)"
+	@cd $(LIVE_INTEGRATION_DIR) && go run ./cmd/llm-proxy-fuzz -scenario matrix $(FUZZ_ARGS)
+	@echo "$(BLUE)Fuzz matrix: memory backend — restart proxy with ENVIRONMENT=fuzz-mem first$(NC)"
+
+.PHONY: fuzz-race
+fuzz-race: build-fuzz
+	@cd $(LIVE_INTEGRATION_DIR) && go run ./cmd/llm-proxy-fuzz -scenario "ratelimit-race,cost-concurrent-async,circuit-mixed" -workers 16 -requests 8 -seed 42
 
 .PHONY: test-live-snippets
 test-live-snippets: build-live install-snippet-deps

--- a/README.md
+++ b/README.md
@@ -328,6 +328,36 @@ When `test_mode_enabled: true`, the proxy honours an `X-LLM-Proxy-Test-Mode` req
 
 This is intended strictly for integration tests — leave `test_mode_enabled` off in production.
 
+#### Fake upstream mode (local fuzzing)
+
+For local rate-limit / cost / circuit-breaker fuzzing without calling real LLM providers, use the `fuzz` environment overlay:
+
+```bash
+ENVIRONMENT=fuzz \
+  LLM_PROXY_ALLOW_FAKE_MODE=1 \
+  LLM_PROXY_ALLOW_TEST_MODE=1 \
+  docker compose up -d
+```
+
+Both gates are required:
+
+- `features.fake_upstream.enabled: true` in [`configs/fuzz.yml`](configs/fuzz.yml)
+- `LLM_PROXY_ALLOW_FAKE_MODE=1` in the process environment
+
+When active, the proxy returns synthetic provider-shaped JSON (with realistic `usage` metadata) from an inner fake transport. Optional chaos failures (`chaos_failure_rate` or per-request `X-LLM-Proxy-Fake-Chaos-Rate`) exercise the circuit breaker. **Never enable fake upstream in production.**
+
+Run fuzz scenarios against a running fuzz-mode proxy:
+
+```bash
+make fuzz              # smoke: ratelimit + cost + circuit trip
+make fuzz-all          # every scenario
+make fuzz-chaos        # circuit / mixed / latency
+make fuzz-test         # go test -race ./internal/fake/...
+go run ./integration/cmd/llm-proxy-fuzz -scenario cost-jsonl-count -seed 42
+```
+
+Use `ENVIRONMENT=fuzz-mem` for the in-memory rate-limit / circuit backend matrix (no Redis).
+
 #### Bypassing the breaker
 
 Some callers cannot tolerate a fast-fail with a synthetic 503 — they have no fallback wired up and would rather try the real upstream and accept whatever it returns (including a real 5xx). For those callers the proxy honours an opt-in bypass header:

--- a/cmd/llm-proxy/fake_gate_test.go
+++ b/cmd/llm-proxy/fake_gate_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func TestIsFakeModeAllowed_RequiresEnv(t *testing.T) {
+	yc := config.GetDefaultYAMLConfig()
+	yc.Features.FakeUpstream.Enabled = true
+	os.Unsetenv("LLM_PROXY_ALLOW_FAKE_MODE")
+	if isFakeModeAllowed(yc) {
+		t.Fatal("expected false without env")
+	}
+}
+
+func TestIsFakeModeAllowed_RequiresYAML(t *testing.T) {
+	yc := config.GetDefaultYAMLConfig()
+	yc.Features.FakeUpstream.Enabled = false
+	t.Setenv("LLM_PROXY_ALLOW_FAKE_MODE", "1")
+	if isFakeModeAllowed(yc) {
+		t.Fatal("expected false when yaml disabled")
+	}
+}
+
+func TestIsFakeModeAllowed_BothRequired(t *testing.T) {
+	yc := config.GetDefaultYAMLConfig()
+	yc.Features.FakeUpstream.Enabled = true
+	t.Setenv("LLM_PROXY_ALLOW_FAKE_MODE", "1")
+	if !isFakeModeAllowed(yc) {
+		t.Fatal("expected true when both gates satisfied")
+	}
+}

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/cost"
 	"github.com/Instawork/llm-proxy/internal/coststats"
+	"github.com/Instawork/llm-proxy/internal/fake"
 	"github.com/Instawork/llm-proxy/internal/history"
 	"github.com/Instawork/llm-proxy/internal/middleware"
 	"github.com/Instawork/llm-proxy/internal/pii"
@@ -455,6 +456,52 @@ func isTestModeAllowed(yc *config.YAMLConfig) bool {
 	return yc.Features.CircuitBreaker.Enabled &&
 		yc.Features.CircuitBreaker.TestModeEnabled &&
 		os.Getenv("LLM_PROXY_ALLOW_TEST_MODE") == "1"
+}
+
+// isFakeModeAllowed gates global fake-upstream responses. Both YAML opt-in
+// and LLM_PROXY_ALLOW_FAKE_MODE=1 are required.
+func isFakeModeAllowed(yc *config.YAMLConfig) bool {
+	return yc.Features.FakeUpstream.Enabled &&
+		os.Getenv("LLM_PROXY_ALLOW_FAKE_MODE") == "1"
+}
+
+func fakeConfigFromYAML(yc *config.YAMLConfig, allowed bool) fake.Config {
+	fu := yc.Features.FakeUpstream
+	est := providers.YAMLConfigEstimationAdapter{
+		MaxSampleBytes:        yc.Features.RateLimiting.Estimation.MaxSampleBytes,
+		BytesPerToken:         yc.Features.RateLimiting.Estimation.BytesPerToken,
+		CharsPerToken:         yc.Features.RateLimiting.Estimation.CharsPerToken,
+		ProviderCharsPerToken: yc.Features.RateLimiting.Estimation.ProviderCharsPerToken,
+	}
+	if est.MaxSampleBytes == 0 {
+		est.MaxSampleBytes = 200000
+	}
+	if est.BytesPerToken == 0 {
+		est.BytesPerToken = 4
+	}
+	if est.CharsPerToken == 0 {
+		est.CharsPerToken = 4
+	}
+	return fake.Config{
+		Enabled:          allowed,
+		ChaosFailureRate: fu.ChaosFailureRate,
+		ChaosSeed:        fu.ChaosSeed,
+		LatencyMS:        fu.LatencyMS,
+		JitterMS:         fu.JitterMS,
+		Estimation:       est,
+	}
+}
+
+func wrapProviderWithFake(
+	p interface {
+		WrapTransport(func(http.RoundTripper) http.RoundTripper)
+	},
+	providerName string,
+	cfg fake.Config,
+) {
+	p.WrapTransport(func(inner http.RoundTripper) http.RoundTripper {
+		return fake.NewTransport(inner, providerName, cfg)
+	})
 }
 
 // circuitConfigFromYAML converts the YAML circuit breaker config into the
@@ -1297,6 +1344,39 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 
 	openAIProvider, anthropicProvider, geminiProvider, bedrockProvider := registerProviders(yamlConfig, disableGzip)
 
+	fakeAllowed := isFakeModeAllowed(yamlConfig)
+	fakeCfg := fakeConfigFromYAML(yamlConfig, fakeAllowed)
+	if fakeAllowed {
+		logger.Warn("🎭 Fake upstream: ENABLED — synthetic LLM responses, no real provider calls",
+			"chaos_failure_rate", yamlConfig.Features.FakeUpstream.ChaosFailureRate,
+		)
+	} else if yamlConfig.Features.FakeUpstream.Enabled {
+		logger.Warn(
+			"🎭 Fake upstream: requested in YAML but LLM_PROXY_ALLOW_FAKE_MODE is not set; fake transport NOT installed",
+		)
+	}
+
+	type namedProvider struct {
+		name string
+		p    interface {
+			WrapTransport(func(http.RoundTripper) http.RoundTripper)
+		}
+	}
+	namedProviders := []namedProvider{
+		{"openai", openAIProvider},
+		{"anthropic", anthropicProvider},
+		{"gemini", geminiProvider},
+	}
+	if bedrockProvider != nil {
+		namedProviders = append(namedProviders, namedProvider{"bedrock", bedrockProvider})
+	}
+
+	if fakeAllowed {
+		for _, np := range namedProviders {
+			wrapProviderWithFake(np.p, np.name, fakeCfg)
+		}
+	}
+
 	// Inject circuit-breaking transports when the feature is enabled.
 	if globalCircuitStore != nil {
 		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker, isTestModeAllowed(yamlConfig))
@@ -1319,22 +1399,6 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			opts = append(opts, circuit.WithActivityRecorder(globalCircuitStatsRecorder))
 		}
 
-		// Pair each provider with its canonical name so the wiring loop
-		// iterates the same set of names that /health queries.
-		type namedProvider struct {
-			name string
-			p    interface {
-				WrapTransport(func(http.RoundTripper) http.RoundTripper)
-			}
-		}
-		namedProviders := []namedProvider{
-			{"openai", openAIProvider},
-			{"anthropic", anthropicProvider},
-			{"gemini", geminiProvider},
-		}
-		if bedrockProvider != nil {
-			namedProviders = append(namedProviders, namedProvider{"bedrock", bedrockProvider})
-		}
 		for _, np := range namedProviders {
 			wrapProviderWithCircuitBreaker(np.p, globalCircuitStore, cbCfg, np.name, opts...)
 		}

--- a/configs/fuzz-mem.yml
+++ b/configs/fuzz-mem.yml
@@ -1,0 +1,62 @@
+# Fuzz overlay with in-memory rate limit + circuit stores (ENVIRONMENT=fuzz-mem).
+# Same fake-upstream profile as fuzz.yml but no Redis dependency for backend matrix runs.
+
+enabled: true
+
+features:
+  fake_upstream:
+    enabled: true
+    chaos_failure_rate: 0.15
+    chaos_seed: 0
+  circuit_breaker:
+    enabled: true
+    mode: enforce
+    backend: memory
+    failure_threshold: 3
+    window_seconds: 60
+    cooldown_seconds: 10
+    max_transient_retries: 2
+    max_rate_limit_retries: 2
+    test_mode_enabled: true
+  rate_limiting:
+    enabled: true
+    backend: memory
+    limits:
+      requests_per_minute: 0
+      tokens_per_minute: 0
+      requests_per_day: 0
+      tokens_per_day: 0
+  cost_tracking:
+    enabled: true
+    async: true
+    workers: 3
+    queue_size: 50
+    flush_interval: 2
+    transports:
+      - type: "file"
+        file:
+          path: "./logs/cost-tracking.jsonl"
+  api_key_management:
+    enabled: true
+    table_name: "llm-proxy-api-keys-fuzz-mem"
+    region: "us-west-2"
+    key_prefix: "iw"
+    auto_create_table: true
+  admin_dashboard:
+    enabled: true
+    dev_bypass_login: true
+    users:
+      dynamodb:
+        table_name: "llm-proxy-admin-users-fuzz-mem"
+        region: "us-west-2"
+        auto_create_table: true
+    rollups:
+      enabled: false
+  pii_redact:
+    enabled: false
+  redact_api:
+    enabled: false
+
+providers:
+  bedrock:
+    enabled: false

--- a/configs/fuzz.yml
+++ b/configs/fuzz.yml
@@ -1,0 +1,97 @@
+# Fuzz / fake-upstream overlay (ENVIRONMENT=fuzz).
+# Requires LLM_PROXY_ALLOW_FAKE_MODE=1 and LLM_PROXY_ALLOW_TEST_MODE=1 in process env.
+
+enabled: true
+
+features:
+  fake_upstream:
+    enabled: true
+    chaos_failure_rate: 0.15
+    chaos_seed: 0
+    latency_ms: 0
+    jitter_ms: 0
+  cost_tracking:
+    enabled: true
+    async: true
+    workers: 3
+    queue_size: 50
+    flush_interval: 2
+    transports:
+      - type: "file"
+        file:
+          path: "./logs/cost-tracking.jsonl"
+  api_key_management:
+    enabled: true
+    table_name: "llm-proxy-api-keys-fuzz"
+    region: "us-west-2"
+    key_prefix: "iw"
+    auto_create_table: true
+    provisioning:
+      enabled: false
+  circuit_breaker:
+    enabled: true
+    mode: enforce
+    backend: "redis"
+    redis:
+      address: "redis:6379"
+      db: 5
+    failure_threshold: 3
+    window_seconds: 60
+    cooldown_seconds: 10
+    max_transient_retries: 2
+    max_rate_limit_retries: 2
+    global_rate_limit_escalation_window: 60
+    retry_contribution_mode: "log"
+    test_mode_enabled: true
+  admin_dashboard:
+    enabled: true
+    dev_bypass_login: true
+    users:
+      dynamodb:
+        table_name: "llm-proxy-admin-users-fuzz"
+        region: "us-west-2"
+        auto_create_table: true
+    rollups:
+      enabled: true
+      redis:
+        address: "redis:6379"
+        db: 6
+      retention_days: 7
+      history_days: 7
+  pii_redact:
+    enabled: false
+  redact_api:
+    enabled: false
+  rate_limiting:
+    enabled: true
+    backend: "redis"
+    estimation:
+      max_sample_bytes: 200000
+      bytes_per_token: 4
+      chars_per_token: 4
+      provider_chars_per_token:
+        openai: 5
+        anthropic: 3
+    limits:
+      requests_per_minute: 0
+      tokens_per_minute: 0
+      requests_per_day: 0
+      tokens_per_day: 0
+    redis:
+      address: "redis:6379"
+      password: ""
+      db: 4
+  history:
+    backend: local
+    role: global
+    streams: [cost, usage, ratelimit]
+    max_records: 100
+    max_bytes: 1048576
+    max_age_seconds: 60
+    gzip: true
+    local:
+      dir: logs/history
+
+providers:
+  bedrock:
+    enabled: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       - COST_TRACKING_FILE=/app/logs/cost-tracking.jsonl
       - CGO_ENABLED=0
       - ENVIRONMENT=${ENVIRONMENT:-dev}
+      # Fuzz / fake-upstream overlay: set ENVIRONMENT=fuzz and both allow flags:
+      # LLM_PROXY_ALLOW_FAKE_MODE=1 LLM_PROXY_ALLOW_TEST_MODE=1
+      - LLM_PROXY_ALLOW_FAKE_MODE=${LLM_PROXY_ALLOW_FAKE_MODE:-}
+      - LLM_PROXY_ALLOW_TEST_MODE=${LLM_PROXY_ALLOW_TEST_MODE:-}
       - LLM_PROXY_ADMIN_SESSION_SECRET=${LLM_PROXY_ADMIN_SESSION_SECRET:-dev-local-session-secret-not-for-prod}
       - LLM_PROXY_ADMIN_DEV_USER_EMAIL=${LLM_PROXY_ADMIN_DEV_USER_EMAIL:-dev@example.com}
       # Externally-visible origin for absolute share links. Defaults to the

--- a/integration/cmd/llm-proxy-fuzz/main.go
+++ b/integration/cmd/llm-proxy-fuzz/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Instawork/llm-proxy-live/fuzz"
+)
+
+func main() {
+	base := flag.String("base", envOr("PROXY_BASE_URL", "http://localhost:9002"), "proxy base URL")
+	scenario := flag.String("scenario", "smoke", "scenario name, comma list, smoke, all, chaos, or matrix")
+	workers := flag.Int("workers", 8, "concurrent workers")
+	requests := flag.Int("requests", 4, "requests per worker for burst scenarios")
+	timeoutSec := flag.Int("timeout", 60, "HTTP timeout seconds")
+	seed := flag.Int64("seed", 0, "chaos seed (logged for repro)")
+	chaosRate := flag.Float64("chaos-rate", 0, "per-request X-LLM-Proxy-Fake-Chaos-Rate override")
+	costFile := flag.String("cost-file", "./logs/cost-tracking.jsonl", "cost tracking jsonl path")
+	resetCost := flag.Bool("reset-cost-file", false, "truncate cost file before run")
+	reportJSON := flag.String("report-json", "", "write machine-readable report JSON")
+	flag.Parse()
+
+	cfg := fuzz.Config{
+		BaseURL:       *base,
+		Scenario:      *scenario,
+		Workers:       *workers,
+		Requests:      *requests,
+		Timeout:       time.Duration(*timeoutSec) * time.Second,
+		Seed:          *seed,
+		ChaosRate:     *chaosRate,
+		CostFile:      *costFile,
+		ResetCostFile: *resetCost,
+		ReportJSON:    *reportJSON,
+	}
+
+	runner, err := fuzz.NewRunner(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fuzz: %v\n", err)
+		os.Exit(1)
+	}
+	report, err := runner.Run(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fuzz: %v\n", err)
+		os.Exit(1)
+	}
+	report.Print()
+	if err := report.WriteJSON(cfg.ReportJSON); err != nil {
+		fmt.Fprintf(os.Stderr, "report json: %v\n", err)
+		os.Exit(1)
+	}
+	if report.Failed() {
+		os.Exit(1)
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/integration/fuzz/config.go
+++ b/integration/fuzz/config.go
@@ -1,0 +1,79 @@
+package fuzz
+
+import (
+	"strings"
+	"time"
+)
+
+type Config struct {
+	BaseURL       string
+	Scenario      string
+	Workers       int
+	Requests      int
+	Timeout       time.Duration
+	Seed          int64
+	ChaosRate     float64
+	CostFile      string
+	ResetCostFile bool
+	ReportJSON    string
+	Verbose       bool
+}
+
+func AllScenarios() []string {
+	return []string{
+		"ratelimit-key-rpm",
+		"ratelimit-key-tpm",
+		"ratelimit-race",
+		"ratelimit-reconcile",
+		"ratelimit-cancel-5xx",
+		"cost-jsonl-count",
+		"cost-token-math",
+		"cost-fuzzy-model",
+		"cost-unknown-model",
+		"cost-no-charge-429",
+		"cost-no-charge-degraded",
+		"cost-concurrent-async",
+		"cost-admin-stats",
+		"circuit-random-trip",
+		"circuit-recovery",
+		"circuit-mixed",
+		"circuit-transient-retry",
+		"latency-timeout",
+	}
+}
+
+func DefaultSmokeScenarios() []string {
+	return []string{"ratelimit-key-rpm", "cost-jsonl-count", "circuit-random-trip"}
+}
+
+func ChaosScenarios() []string {
+	return []string{"circuit-random-trip", "circuit-mixed", "latency-timeout"}
+}
+
+func MatrixScenarios() []string {
+	return []string{"ratelimit-key-rpm", "circuit-random-trip"}
+}
+
+func ParseScenarioList(raw string) []string {
+	if raw == "" || raw == "all" {
+		return AllScenarios()
+	}
+	if raw == "smoke" {
+		return DefaultSmokeScenarios()
+	}
+	if raw == "chaos" {
+		return ChaosScenarios()
+	}
+	if raw == "matrix" {
+		return MatrixScenarios()
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/integration/fuzz/cost.go
+++ b/integration/fuzz/cost.go
@@ -1,0 +1,94 @@
+package fuzz
+
+import (
+	"bufio"
+	"encoding/json"
+	"math"
+	"os"
+	"strings"
+)
+
+const degradedSignal = "[LLM_PROXY_PROVIDER_DEGRADED]"
+
+type CostRecord struct {
+	Provider     string  `json:"provider"`
+	Model        string  `json:"model"`
+	InputTokens  int     `json:"input_tokens"`
+	OutputTokens int     `json:"output_tokens"`
+	TotalCost    float64 `json:"total_cost"`
+	IsEstimate   bool    `json:"is_estimate"`
+	MatchedModel string  `json:"matched_model"`
+}
+
+func CountLines(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer f.Close()
+	n := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) != "" {
+			n++
+		}
+	}
+	return n, sc.Err()
+}
+
+func ReadNewRecords(path string, before int) ([]CostRecord, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	var out []CostRecord
+	idx := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		idx++
+		if idx <= before {
+			continue
+		}
+		var rec CostRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, sc.Err()
+}
+
+func ResetCostFile(path string) error {
+	return os.WriteFile(path, nil, 0o644)
+}
+
+func RoundUpCost(v float64) float64 {
+	return math.Ceil(v*10000) / 10000
+}
+
+func ExpectedOpenAICost(inputTokens, outputTokens int) float64 {
+	const inputPerM = 0.15
+	const outputPerM = 0.60
+	in := RoundUpCost(float64(inputTokens) / 1_000_000 * inputPerM)
+	out := RoundUpCost(float64(outputTokens) / 1_000_000 * outputPerM)
+	return RoundUpCost(in + out)
+}
+
+func SumCost(recs []CostRecord) float64 {
+	var total float64
+	for _, r := range recs {
+		total += r.TotalCost
+	}
+	return RoundUpCost(total)
+}

--- a/integration/fuzz/proxy.go
+++ b/integration/fuzz/proxy.go
@@ -1,0 +1,187 @@
+package fuzz
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Instawork/llm-proxy-live/live"
+)
+
+type Proxy struct {
+	base    string
+	timeout time.Duration
+	client  *http.Client
+	report  *Report
+}
+
+func NewProxy(base string, timeout time.Duration, report *Report) *Proxy {
+	return &Proxy{
+		base:    strings.TrimRight(base, "/"),
+		timeout: timeout,
+		client:  &http.Client{Timeout: timeout},
+		report:  report,
+	}
+}
+
+type ChatOpts struct {
+	APIKey      string
+	Model       string
+	Content     string
+	ChaosRate   *float64
+	OutputTok   int
+	LatencyMS   int
+	TestMode    string
+	MaxTokens   int
+}
+
+type ChatResult struct {
+	Status  int
+	Headers http.Header
+	Body    string
+	Err     error
+}
+
+func (p *Proxy) OpenAIChat(ctx context.Context, opts ChatOpts) ChatResult {
+	if opts.Model == "" {
+		opts.Model = "gpt-4o-mini"
+	}
+	if opts.Content == "" {
+		opts.Content = "fuzz"
+	}
+	if opts.MaxTokens == 0 {
+		opts.MaxTokens = 16
+	}
+	payload := map[string]any{
+		"model": opts.Model,
+		"messages": []map[string]string{
+			{"role": "user", "content": opts.Content},
+		},
+		"max_tokens": opts.MaxTokens,
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.base+"/openai/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return ChatResult{Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+	p.applyFakeHeaders(req, opts)
+	return p.do(req)
+}
+
+func (p *Proxy) applyFakeHeaders(req *http.Request, opts ChatOpts) {
+	if opts.ChaosRate != nil {
+		req.Header.Set("X-LLM-Proxy-Fake-Chaos-Rate", strconv.FormatFloat(*opts.ChaosRate, 'f', -1, 64))
+	}
+	if opts.OutputTok > 0 {
+		req.Header.Set("X-LLM-Proxy-Fake-Output-Tokens", strconv.Itoa(opts.OutputTok))
+	}
+	if opts.LatencyMS > 0 {
+		req.Header.Set("X-LLM-Proxy-Fake-Latency-Ms", strconv.Itoa(opts.LatencyMS))
+	}
+	if opts.TestMode != "" {
+		req.Header.Set("X-LLM-Proxy-Test-Mode", opts.TestMode)
+	}
+}
+
+func (p *Proxy) do(req *http.Request) ChatResult {
+	resp, err := p.client.Do(req)
+	if err != nil {
+		if p.report != nil {
+			if strings.Contains(err.Error(), "context deadline") || strings.Contains(err.Error(), "Client.Timeout") {
+				p.report.RecordError("timeout")
+			} else {
+				p.report.RecordError("conn-error")
+			}
+		}
+		return ChatResult{Err: err}
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if p.report != nil {
+		p.report.RecordStatus(resp.StatusCode)
+		if strings.Contains(string(data), degradedSignal) {
+			p.report.DegradedResponses++
+		}
+	}
+	return ChatResult{Status: resp.StatusCode, Headers: resp.Header.Clone(), Body: string(data)}
+}
+
+func (p *Proxy) Burst(ctx context.Context, n int, workers int, fn func(context.Context) ChatResult) []ChatResult {
+	if workers < 1 {
+		workers = 1
+	}
+	jobs := make(chan int)
+	results := make([]ChatResult, 0, n)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range jobs {
+				res := fn(ctx)
+				mu.Lock()
+				results = append(results, res)
+				mu.Unlock()
+			}
+		}()
+	}
+	for i := 0; i < n; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	return results
+}
+
+type keyHelper struct {
+	admin *live.AdminClient
+	keys  []string
+}
+
+func newKeyHelper(admin *live.AdminClient) *keyHelper {
+	return &keyHelper{admin: admin}
+}
+
+func (k *keyHelper) create(ctx context.Context, desc string, rpm, tpm int) (string, error) {
+	rec, err := k.admin.CreateKey(ctx, live.FuzzCreateKeyRequest(desc, rpm, tpm))
+	if err != nil {
+		return "", err
+	}
+	k.keys = append(k.keys, rec.Key)
+	return rec.Key, nil
+}
+
+func (k *keyHelper) cleanup(ctx context.Context) {
+	for _, key := range k.keys {
+		_ = k.admin.DeleteKey(ctx, key)
+	}
+}
+
+func waitCostFlush(ctx context.Context, path string, before, want int) ([]CostRecord, error) {
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		after, err := CountLines(path)
+		if err != nil {
+			return nil, err
+		}
+		if after-before >= want {
+			return ReadNewRecords(path, before)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+	return nil, fmt.Errorf("timeout waiting for %d new cost lines in %s", want, path)
+}

--- a/integration/fuzz/report.go
+++ b/integration/fuzz/report.go
@@ -1,0 +1,82 @@
+package fuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type StatusHistogram map[string]int
+
+type ScenarioResult struct {
+	Name    string `json:"name"`
+	Pass    bool   `json:"pass"`
+	Detail  string `json:"detail"`
+	Elapsed string `json:"elapsed"`
+}
+
+type Report struct {
+	Seed              int64             `json:"seed"`
+	Scenarios         []ScenarioResult  `json:"scenarios"`
+	StatusHistogram   StatusHistogram   `json:"status_histogram"`
+	CostLinesDelta    int               `json:"cost_lines_delta"`
+	CostLinesExpected int               `json:"cost_lines_expected"`
+	CostTotalObserved float64           `json:"cost_total_observed"`
+	CostTotalExpected float64           `json:"cost_total_expected"`
+	DegradedResponses int               `json:"degraded_responses"`
+}
+
+func (r *Report) RecordStatus(code int) {
+	key := fmt.Sprintf("%d", code)
+	if code == 0 {
+		key = "error"
+	}
+	r.StatusHistogram[key]++
+}
+
+func (r *Report) RecordError(kind string) {
+	r.StatusHistogram[kind]++
+}
+
+func (r *Report) AddScenario(res ScenarioResult) {
+	r.Scenarios = append(r.Scenarios, res)
+}
+
+func (r *Report) Print() {
+	fmt.Printf("fuzz seed=%d\n", r.Seed)
+	fmt.Printf("status histogram: %v\n", r.StatusHistogram)
+	if r.CostLinesExpected > 0 || r.CostLinesDelta > 0 {
+		fmt.Printf("cost lines: observed_delta=%d expected_delta=%d total_observed=%.6f total_expected=%.6f\n",
+			r.CostLinesDelta, r.CostLinesExpected, r.CostTotalObserved, r.CostTotalExpected)
+	}
+	if r.DegradedResponses > 0 {
+		fmt.Printf("degraded responses: %d\n", r.DegradedResponses)
+	}
+	for _, s := range r.Scenarios {
+		status := "PASS"
+		if !s.Pass {
+			status = "FAIL"
+		}
+		fmt.Printf("[%s] %s (%s) %s\n", status, s.Name, s.Elapsed, s.Detail)
+	}
+}
+
+func (r *Report) WriteJSON(path string) error {
+	if path == "" {
+		return nil
+	}
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+func (r *Report) Failed() bool {
+	for _, s := range r.Scenarios {
+		if !s.Pass {
+			return true
+		}
+	}
+	return false
+}

--- a/integration/fuzz/runner.go
+++ b/integration/fuzz/runner.go
@@ -1,0 +1,572 @@
+package fuzz
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Instawork/llm-proxy-live/live"
+)
+
+type Runner struct {
+	cfg    Config
+	report *Report
+	admin  *live.AdminClient
+	proxy  *Proxy
+}
+
+func NewRunner(cfg Config) (*Runner, error) {
+	report := &Report{Seed: cfg.Seed, StatusHistogram: StatusHistogram{}}
+	admin, err := live.NewAdminClient(cfg.BaseURL, cfg.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &Runner{
+		cfg:    cfg,
+		report: report,
+		admin:  admin,
+		proxy:  NewProxy(cfg.BaseURL, cfg.Timeout, report),
+	}, nil
+}
+
+func (r *Runner) Run(ctx context.Context) (*Report, error) {
+	if r.cfg.ResetCostFile {
+		_ = ResetCostFile(r.cfg.CostFile)
+	}
+	scenarios := ParseScenarioList(r.cfg.Scenario)
+	for _, name := range scenarios {
+		start := time.Now()
+		pass, detail := r.runScenario(ctx, name)
+		r.report.AddScenario(ScenarioResult{
+			Name:    name,
+			Pass:    pass,
+			Detail:  detail,
+			Elapsed: time.Since(start).Round(time.Millisecond).String(),
+		})
+		if !pass {
+			break
+		}
+	}
+	return r.report, nil
+}
+
+func (r *Runner) runScenario(ctx context.Context, name string) (bool, string) {
+	switch name {
+	case "ratelimit-key-rpm":
+		return r.rateLimitKeyRPM(ctx)
+	case "ratelimit-key-tpm":
+		return r.rateLimitKeyTPM(ctx)
+	case "ratelimit-race":
+		return r.rateLimitRace(ctx)
+	case "ratelimit-reconcile":
+		return r.rateLimitReconcile(ctx)
+	case "ratelimit-cancel-5xx":
+		return r.rateLimitCancel5xx(ctx)
+	case "cost-jsonl-count":
+		return r.costJSONLCount(ctx)
+	case "cost-token-math":
+		return r.costTokenMath(ctx)
+	case "cost-fuzzy-model":
+		return r.costFuzzyModel(ctx)
+	case "cost-unknown-model":
+		return r.costUnknownModel(ctx)
+	case "cost-no-charge-429":
+		return r.costNoCharge429(ctx)
+	case "cost-no-charge-degraded":
+		return r.costNoChargeDegraded(ctx)
+	case "cost-concurrent-async":
+		return r.costConcurrentAsync(ctx)
+	case "cost-admin-stats":
+		return r.costAdminStats(ctx)
+	case "circuit-random-trip":
+		return r.circuitRandomTrip(ctx)
+	case "circuit-recovery":
+		return r.circuitRecovery(ctx)
+	case "circuit-mixed":
+		return r.circuitMixed(ctx)
+	case "circuit-transient-retry":
+		return r.circuitTransientRetry(ctx)
+	case "latency-timeout":
+		return r.latencyTimeout(ctx)
+	default:
+		return false, "unknown scenario"
+	}
+}
+
+func (r *Runner) rateLimitKeyRPM(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	const limit = 5
+	key, err := kh.create(ctx, "fuzz-rpm", limit, 50000)
+	if err != nil {
+		return false, err.Error()
+	}
+	zero := 0.0
+	total := r.cfg.Workers * r.cfg.Requests
+	if total < limit+3 {
+		total = limit + 3
+	}
+	results := r.proxy.Burst(ctx, total, r.cfg.Workers, func(c context.Context) ChatResult {
+		return r.proxy.OpenAIChat(c, ChatOpts{APIKey: key, ChaosRate: &zero})
+	})
+	ok, denied := 0, 0
+	for _, res := range results {
+		if res.Status == http.StatusOK {
+			ok++
+		}
+		if res.Status == http.StatusTooManyRequests {
+			denied++
+		}
+	}
+	if ok != limit {
+		return false, fmt.Sprintf("want %d successes got %d (denied=%d total=%d)", limit, ok, denied, total)
+	}
+	if denied == 0 {
+		return false, "expected some 429 responses"
+	}
+	return true, fmt.Sprintf("ok=%d denied=%d", ok, denied)
+}
+
+func (r *Runner) rateLimitKeyTPM(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-tpm", 1000, 50)
+	if err != nil {
+		return false, err.Error()
+	}
+	zero := 0.0
+	big := strings.Repeat("token ", 4000)
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, Content: big, ChaosRate: &zero})
+	if res.Status != http.StatusTooManyRequests {
+		return false, fmt.Sprintf("expected 429 got %d", res.Status)
+	}
+	return true, "token limit 429"
+}
+
+func (r *Runner) rateLimitRace(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-race", 3, 50000)
+	if err != nil {
+		return false, err.Error()
+	}
+	zero := 0.0
+	results := r.proxy.Burst(ctx, 20, 10, func(c context.Context) ChatResult {
+		return r.proxy.OpenAIChat(c, ChatOpts{APIKey: key, ChaosRate: &zero})
+	})
+	var saw429 bool
+	for _, res := range results {
+		if res.Status == http.StatusTooManyRequests {
+			saw429 = true
+			if res.Headers.Get("Retry-After") == "" {
+				return false, "429 missing Retry-After"
+			}
+		}
+	}
+	if !saw429 {
+		return false, "expected at least one 429"
+	}
+	return true, "burst produced 429 with Retry-After"
+}
+
+func (r *Runner) rateLimitReconcile(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-reconcile", 100, 500)
+	if err != nil {
+		return false, err.Error()
+	}
+	zero := 0.0
+	outTok := 100
+	for i := 0; i < 3; i++ {
+		res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero, OutputTok: outTok})
+		if res.Status != http.StatusOK {
+			return false, fmt.Sprintf("request %d status %d", i, res.Status)
+		}
+	}
+	return true, "reconcile path completed without 429"
+}
+
+func (r *Runner) rateLimitCancel5xx(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-cancel-5xx", 5, 50000)
+	if err != nil {
+		return false, err.Error()
+	}
+	one := 1.0
+	failures := 0
+	for i := 0; i < 5; i++ {
+		res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &one})
+		if res.Status >= 500 {
+			failures++
+		}
+	}
+	if failures == 0 {
+		return false, "expected 5xx from chaos-rate 1"
+	}
+	zero := 0.0
+	ok := 0
+	for i := 0; i < 5; i++ {
+		res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero})
+		if res.Status == http.StatusOK {
+			ok++
+		}
+	}
+	if ok != 5 {
+		return false, fmt.Sprintf("after 5xx cancel expected 5 ok got %d", ok)
+	}
+	return true, fmt.Sprintf("failures=%d then rpm budget intact", failures)
+}
+
+func (r *Runner) costJSONLCount(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-cost-count", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	zero := 0.0
+	n := r.cfg.Requests
+	if n < 5 {
+		n = 5
+	}
+	for i := 0; i < n; i++ {
+		res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero, OutputTok: 10})
+		if res.Status != http.StatusOK {
+			return false, fmt.Sprintf("chat %d status %d", i, res.Status)
+		}
+	}
+	recs, err := waitCostFlush(ctx, r.cfg.CostFile, before, n)
+	if err != nil {
+		return false, err.Error()
+	}
+	r.report.CostLinesDelta = len(recs)
+	r.report.CostLinesExpected = n
+	if len(recs) != n {
+		return false, fmt.Sprintf("want %d cost lines got %d", n, len(recs))
+	}
+	return true, fmt.Sprintf("%d jsonl records", len(recs))
+}
+
+func (r *Runner) costTokenMath(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-cost-math", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	zero := 0.0
+	outTok := 32
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero, OutputTok: outTok, Content: "short"})
+	if res.Status != http.StatusOK {
+		return false, fmt.Sprintf("status %d", res.Status)
+	}
+	recs, err := waitCostFlush(ctx, r.cfg.CostFile, before, 1)
+	if err != nil {
+		return false, err.Error()
+	}
+	rec := recs[0]
+	expected := ExpectedOpenAICost(rec.InputTokens, outTok)
+	r.report.CostTotalObserved = rec.TotalCost
+	r.report.CostTotalExpected = expected
+	if rec.OutputTokens != outTok {
+		return false, fmt.Sprintf("output tokens %d want %d", rec.OutputTokens, outTok)
+	}
+	if rec.TotalCost != expected {
+		return false, fmt.Sprintf("total_cost %.6f want %.6f", rec.TotalCost, expected)
+	}
+	return true, fmt.Sprintf("cost=%.6f in=%d out=%d", rec.TotalCost, rec.InputTokens, rec.OutputTokens)
+}
+
+func (r *Runner) costFuzzyModel(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-fuzzy-model", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	zero := 0.0
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{
+		APIKey: key, Model: "gpt-4o-mini-2024-07-18", ChaosRate: &zero, OutputTok: 8,
+	})
+	if res.Status != http.StatusOK {
+		return false, fmt.Sprintf("status %d", res.Status)
+	}
+	recs, err := waitCostFlush(ctx, r.cfg.CostFile, before, 1)
+	if err != nil {
+		return false, err.Error()
+	}
+	rec := recs[0]
+	if !rec.IsEstimate {
+		return false, "expected is_estimate true"
+	}
+	if rec.MatchedModel == "" {
+		return false, "expected matched_model set"
+	}
+	return true, fmt.Sprintf("matched_model=%s cost=%.6f", rec.MatchedModel, rec.TotalCost)
+}
+
+func (r *Runner) costUnknownModel(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-unknown-model", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	zero := 0.0
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{
+		APIKey: key, Model: "not-a-real-model-xyz", ChaosRate: &zero, OutputTok: 4,
+	})
+	if res.Status != http.StatusOK {
+		return false, fmt.Sprintf("status %d", res.Status)
+	}
+	recs, err := waitCostFlush(ctx, r.cfg.CostFile, before, 1)
+	if err != nil {
+		return false, err.Error()
+	}
+	if recs[0].TotalCost != 0 {
+		return false, fmt.Sprintf("expected zero cost got %.6f", recs[0].TotalCost)
+	}
+	return true, "unknown model recorded with zero cost"
+}
+
+func (r *Runner) costNoCharge429(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-no-cost-429", 1, 50000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	zero := 0.0
+	_ = r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero})
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero})
+	if res.Status != http.StatusTooManyRequests {
+		return false, fmt.Sprintf("expected 429 got %d", res.Status)
+	}
+	after, _ := CountLines(r.cfg.CostFile)
+	if after > before {
+		return false, fmt.Sprintf("429 should not add cost lines (before=%d after=%d)", before, after)
+	}
+	return true, "no cost lines on 429"
+}
+
+func (r *Runner) costNoChargeDegraded(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-no-cost-degraded", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, TestMode: "force_degraded"})
+	if res.Status != http.StatusServiceUnavailable {
+		return false, fmt.Sprintf("expected 503 got %d", res.Status)
+	}
+	after, _ := CountLines(r.cfg.CostFile)
+	if after > before {
+		return false, "degraded should not add cost lines"
+	}
+	return true, "no cost on force_degraded"
+}
+
+func (r *Runner) costConcurrentAsync(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-cost-async", 5000, 5_000_000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	zero := 0.0
+	n := r.cfg.Workers * r.cfg.Requests
+	if n < 30 {
+		n = 30
+	}
+	workers := r.cfg.Workers
+	if workers < 10 {
+		workers = 10
+	}
+	results := r.proxy.Burst(ctx, n, workers, func(c context.Context) ChatResult {
+		return r.proxy.OpenAIChat(c, ChatOpts{APIKey: key, ChaosRate: &zero, OutputTok: 4})
+	})
+	ok := 0
+	for _, res := range results {
+		if res.Status == http.StatusOK {
+			ok++
+		}
+	}
+	recs, err := waitCostFlush(ctx, r.cfg.CostFile, before, ok)
+	if err != nil {
+		return false, err.Error()
+	}
+	if len(recs) != ok {
+		return false, fmt.Sprintf("want %d cost records got %d", ok, len(recs))
+	}
+	return true, fmt.Sprintf("ok=%d records=%d", ok, len(recs))
+}
+
+func (r *Runner) costAdminStats(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-admin-stats", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	cfgBefore, _ := r.admin.CostConfig(ctx)
+	spendBefore := live.CostStatsSpendToday(extractStats(cfgBefore))
+	before, _ := CountLines(r.cfg.CostFile)
+	zero := 0.0
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero, OutputTok: 20})
+	if res.Status != http.StatusOK {
+		return false, fmt.Sprintf("status %d", res.Status)
+	}
+	_, _ = waitCostFlush(ctx, r.cfg.CostFile, before, 1)
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		cfg, err := r.admin.CostConfig(ctx)
+		if err != nil {
+			return false, err.Error()
+		}
+		stats := extractStats(cfg)
+		if live.CostStatsAvailable(stats) && live.CostStatsSpendToday(stats) > spendBefore {
+			return true, fmt.Sprintf("spend_today_usd=%.6f", live.CostStatsSpendToday(stats))
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return false, "spend_today_usd did not increase"
+}
+
+func (r *Runner) circuitRandomTrip(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-circuit-trip", 5000, 5_000_000)
+	if err != nil {
+		return false, err.Error()
+	}
+	rate := r.cfg.ChaosRate
+	if rate <= 0 {
+		rate = 1.0
+	}
+	for i := 0; i < 40; i++ {
+		res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &rate})
+		if strings.Contains(res.Body, degradedSignal) {
+			return true, fmt.Sprintf("degraded after %d attempts", i+1)
+		}
+	}
+	return false, "circuit did not fast-fail with degraded signal"
+}
+
+func (r *Runner) circuitRecovery(ctx context.Context) (bool, string) {
+	ok, detail := r.circuitRandomTrip(ctx)
+	if !ok {
+		return false, "prerequisite trip failed: " + detail
+	}
+	time.Sleep(11 * time.Second)
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-circuit-recover", 5000, 5_000_000)
+	if err != nil {
+		return false, err.Error()
+	}
+	zero := 0.0
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, ChaosRate: &zero})
+	if res.Status != http.StatusOK {
+		return false, fmt.Sprintf("post-cooldown want 200 got %d body=%s", res.Status, truncate(res.Body, 120))
+	}
+	return true, "circuit recovered after cooldown"
+}
+
+func (r *Runner) circuitMixed(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-circuit-mixed", 500, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	rate := 0.4
+	if r.cfg.ChaosRate > 0 {
+		rate = r.cfg.ChaosRate
+	}
+	n := r.cfg.Workers * r.cfg.Requests
+	if n < 25 {
+		n = 25
+	}
+	results := r.proxy.Burst(ctx, n, r.cfg.Workers, func(c context.Context) ChatResult {
+		opts := ChatOpts{APIKey: key, ChaosRate: &rate, OutputTok: 6}
+		return r.proxy.OpenAIChat(c, opts)
+	})
+	ok := 0
+	for _, res := range results {
+		if res.Status == http.StatusOK {
+			ok++
+		}
+	}
+	recs, err := waitCostFlush(ctx, r.cfg.CostFile, before, ok)
+	if err != nil && ok > 0 {
+		return false, err.Error()
+	}
+	if len(recs) != ok {
+		return false, fmt.Sprintf("cost lines %d != successes %d", len(recs), ok)
+	}
+	return true, fmt.Sprintf("mixed ok=%d total=%d", ok, n)
+}
+
+func (r *Runner) circuitTransientRetry(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-transient-retry", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	res := r.proxy.OpenAIChat(ctx, ChatOpts{APIKey: key, TestMode: "force_transient_recover"})
+	if res.Status != http.StatusOK {
+		return false, fmt.Sprintf("want 200 after retry got %d body=%s", res.Status, truncate(res.Body, 120))
+	}
+	return true, "force_transient_recover succeeded"
+}
+
+func (r *Runner) latencyTimeout(ctx context.Context) (bool, string) {
+	kh := newKeyHelper(r.admin)
+	defer kh.cleanup(ctx)
+	key, err := kh.create(ctx, "fuzz-latency", 1000, 500000)
+	if err != nil {
+		return false, err.Error()
+	}
+	before, _ := CountLines(r.cfg.CostFile)
+	shortCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	zero := 0.0
+	res := r.proxy.OpenAIChat(shortCtx, ChatOpts{APIKey: key, ChaosRate: &zero, LatencyMS: 500})
+	if res.Err == nil {
+		return false, "expected timeout error"
+	}
+	after, _ := CountLines(r.cfg.CostFile)
+	if after > before {
+		return false, "timeout should not write cost"
+	}
+	return true, "client timeout, no cost line"
+}
+
+func extractStats(cfg map[string]any) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+	stats, _ := cfg["stats"].(map[string]any)
+	return stats
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/integration/live/admin.go
+++ b/integration/live/admin.go
@@ -38,6 +38,17 @@ type createKeyRequest struct {
 	Tags         map[string]string `json:"tags,omitempty"`
 }
 
+// FuzzCreateKeyRequest builds a key create payload for fuzz runs (dummy upstream key).
+func FuzzCreateKeyRequest(description string, rpm, tpm int) createKeyRequest {
+	return createKeyRequest{
+		Provider:     "openai",
+		ActualKey:    "fake-upstream-not-used",
+		Description:  description,
+		RateLimitRPM: rpm,
+		RateLimitTPM: tpm,
+	}
+}
+
 func (a *AdminClient) Me(ctx context.Context) (map[string]any, error) {
 	if err := a.DevLogin(ctx); err != nil {
 		return nil, err
@@ -78,6 +89,21 @@ func (a *AdminClient) RateLimits(ctx context.Context) (map[string]any, error) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET /admin/api/rate-limits status %d", resp.StatusCode)
+	}
+	var out map[string]any
+	return out, jsonDecode(data, &out)
+}
+
+func (a *AdminClient) CircuitActivity(ctx context.Context) (map[string]any, error) {
+	if err := a.DevLogin(ctx); err != nil {
+		return nil, err
+	}
+	resp, data, err := a.Do(ctx, http.MethodGet, "/admin/api/circuit-activity", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET /admin/api/circuit-activity status %d", resp.StatusCode)
 	}
 	var out map[string]any
 	return out, jsonDecode(data, &out)
@@ -268,3 +294,9 @@ func piiLatestRecentEntityTotal(stats map[string]any) float64 {
 func elapsed(start time.Time) string {
 	return time.Since(start).Round(time.Millisecond).String()
 }
+
+// CostStatsAvailable is exported for fuzz/integration helpers.
+func CostStatsAvailable(stats map[string]any) bool { return costStatsAvailable(stats) }
+
+// CostStatsSpendToday is exported for fuzz/integration helpers.
+func CostStatsSpendToday(stats map[string]any) float64 { return costStatsSpendToday(stats) }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ type FeaturesConfig struct {
 	CircuitBreaker   CircuitBreakerConfig   `yaml:"circuit_breaker"`
 	PIIRedact        PIIRedactConfig        `yaml:"pii_redact"`
 	RedactAPI        RedactAPIConfig        `yaml:"redact_api"`
+	FakeUpstream     FakeUpstreamConfig     `yaml:"fake_upstream"`
 	AdminDashboard   AdminDashboardConfig   `yaml:"admin_dashboard"`
 	History          HistoryConfig          `yaml:"history"`
 }
@@ -153,6 +154,16 @@ type RedactAPIConfig struct {
 	// DevAllowUnauthenticated skips iw-* auth on POST /redact. Allowed only when
 	// ENVIRONMENT=dev and features.admin_dashboard.dev_bypass_login is true.
 	DevAllowUnauthenticated bool `yaml:"dev_allow_unauthenticated,omitempty"`
+}
+
+// FakeUpstreamConfig gates synthetic LLM responses for local fuzzing.
+// Requires LLM_PROXY_ALLOW_FAKE_MODE=1 in addition to enabled: true.
+type FakeUpstreamConfig struct {
+	Enabled          bool    `yaml:"enabled"`
+	ChaosFailureRate float64 `yaml:"chaos_failure_rate"`
+	ChaosSeed        int64   `yaml:"chaos_seed"`
+	LatencyMS        int     `yaml:"latency_ms"`
+	JitterMS         int     `yaml:"jitter_ms"`
 }
 
 // AdminDashboardConfig gates the /admin UI and JSON API.

--- a/internal/fake/chaos.go
+++ b/internal/fake/chaos.go
@@ -1,0 +1,81 @@
+package fake
+
+import (
+	"io"
+	"math/rand"
+	"sync"
+)
+
+type Outcome int
+
+const (
+	OutcomeSuccess Outcome = iota
+	Outcome503
+	Outcome429
+	Outcome500
+	OutcomeConnError
+)
+
+type Chaos struct {
+	enabled     bool
+	failureRate float64
+	mu          sync.Mutex
+	rng         *rand.Rand
+}
+
+func NewChaos(enabled bool, failureRate float64, seed int64) *Chaos {
+	if seed == 0 {
+		seed = rand.Int63()
+	}
+	return &Chaos{
+		enabled:     enabled,
+		failureRate: clampRate(failureRate),
+		rng:         rand.New(rand.NewSource(seed)),
+	}
+}
+
+func (c *Chaos) Seed() int64 {
+	if c == nil || c.rng == nil {
+		return 0
+	}
+	return c.rng.Int63()
+}
+
+func (c *Chaos) Pick(requestRate float64) Outcome {
+	rate := c.failureRate
+	if requestRate >= 0 {
+		rate = clampRate(requestRate)
+	}
+	if !c.enabled || rate <= 0 {
+		return OutcomeSuccess
+	}
+	c.mu.Lock()
+	roll := c.rng.Float64()
+	sub := c.rng.Float64()
+	c.mu.Unlock()
+	if roll >= rate {
+		return OutcomeSuccess
+	}
+	switch {
+	case sub < 0.40:
+		return Outcome503
+	case sub < 0.70:
+		return Outcome429
+	case sub < 0.90:
+		return Outcome500
+	default:
+		return OutcomeConnError
+	}
+}
+
+func clampRate(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+var errFakeConn = io.ErrUnexpectedEOF

--- a/internal/fake/headers.go
+++ b/internal/fake/headers.go
@@ -1,0 +1,7 @@
+package fake
+
+const (
+	HeaderOutputTokens = "X-LLM-Proxy-Fake-Output-Tokens"
+	HeaderChaosRate    = "X-LLM-Proxy-Fake-Chaos-Rate"
+	HeaderLatencyMs    = "X-LLM-Proxy-Fake-Latency-Ms"
+)

--- a/internal/fake/responses.go
+++ b/internal/fake/responses.go
@@ -1,0 +1,151 @@
+package fake
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+func successBody(provider, model string, inputTokens, outputTokens int) []byte {
+	switch provider {
+	case "anthropic":
+		return anthropicSuccess(model, inputTokens, outputTokens)
+	case "gemini":
+		return geminiSuccess(model, inputTokens, outputTokens)
+	default:
+		return openAISuccess(model, inputTokens, outputTokens)
+	}
+}
+
+func failureBody(provider string, status int) []byte {
+	switch provider {
+	case "anthropic":
+		return anthropicError(status)
+	case "gemini":
+		return geminiError(status)
+	default:
+		return openAIError(status)
+	}
+}
+
+func openAISuccess(model string, inTok, outTok int) []byte {
+	body := map[string]any{
+		"id":      "chatcmpl-fake",
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]any{
+			{
+				"index": 0,
+				"message": map[string]string{
+					"role":    "assistant",
+					"content": "fake response",
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]int{
+			"prompt_tokens":     inTok,
+			"completion_tokens": outTok,
+			"total_tokens":      inTok + outTok,
+		},
+	}
+	b, _ := json.Marshal(body)
+	return b
+}
+
+func openAIError(status int) []byte {
+	msg := "fake upstream error"
+	typ := "server_error"
+	code := "server_error"
+	switch status {
+	case 503:
+		msg = "Service unavailable"
+		typ = "server_error"
+	case 429:
+		msg = "Rate limit exceeded"
+		typ = "rate_limit_error"
+		code = "rate_limit_exceeded"
+	}
+	body := map[string]any{
+		"error": map[string]any{
+			"message": msg,
+			"type":    typ,
+			"code":    code,
+		},
+	}
+	b, _ := json.Marshal(body)
+	return b
+}
+
+func anthropicSuccess(model string, inTok, outTok int) []byte {
+	body := map[string]any{
+		"id":   "msg_fake",
+		"type": "message",
+		"role": "assistant",
+		"model": model,
+		"content": []map[string]string{
+			{"type": "text", "text": "fake response"},
+		},
+		"stop_reason": "end_turn",
+		"usage": map[string]int{
+			"input_tokens":  inTok,
+			"output_tokens": outTok,
+		},
+	}
+	b, _ := json.Marshal(body)
+	return b
+}
+
+func anthropicError(status int) []byte {
+	typ := "api_error"
+	switch status {
+	case 429:
+		typ = "rate_limit_error"
+	case 503:
+		typ = "overloaded_error"
+	}
+	body := map[string]any{
+		"type": "error",
+		"error": map[string]string{
+			"type":    typ,
+			"message": fmt.Sprintf("fake anthropic %d", status),
+		},
+	}
+	b, _ := json.Marshal(body)
+	return b
+}
+
+func geminiSuccess(model string, inTok, outTok int) []byte {
+	body := map[string]any{
+		"candidates": []map[string]any{
+			{
+				"content": map[string]any{
+					"parts": []map[string]string{{"text": "fake response"}},
+					"role":  "model",
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]int{
+			"promptTokenCount":     inTok,
+			"candidatesTokenCount": outTok,
+			"totalTokenCount":      inTok + outTok,
+		},
+		"modelVersion": model,
+	}
+	b, _ := json.Marshal(body)
+	return b
+}
+
+func geminiError(status int) []byte {
+	body := map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": fmt.Sprintf("fake gemini %d", status),
+			"status":  "UNAVAILABLE",
+		},
+	}
+	b, _ := json.Marshal(body)
+	return b
+}

--- a/internal/fake/transport.go
+++ b/internal/fake/transport.go
@@ -1,0 +1,179 @@
+package fake
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/providers"
+)
+
+const defaultOutputTokens = 16
+
+// Config carries fake-upstream settings from YAML plus runtime gate state.
+type Config struct {
+	Enabled         bool
+	ChaosFailureRate float64
+	ChaosSeed       int64
+	LatencyMS       int
+	JitterMS        int
+	Estimation      providers.YAMLConfigEstimationAdapter
+}
+
+// Transport synthesizes provider responses without calling the inner RoundTripper.
+type Transport struct {
+	inner    http.RoundTripper
+	provider string
+	cfg      Config
+	chaos    *Chaos
+}
+
+func NewTransport(inner http.RoundTripper, provider string, cfg Config) *Transport {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	enabled := cfg.Enabled
+	return &Transport{
+		inner:    inner,
+		provider: provider,
+		cfg:      cfg,
+		chaos:    NewChaos(enabled, cfg.ChaosFailureRate, cfg.ChaosSeed),
+	}
+}
+
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !t.cfg.Enabled {
+		return t.inner.RoundTrip(req)
+	}
+
+	if err := t.sleep(req); err != nil {
+		return nil, err
+	}
+
+	outcome := t.chaos.Pick(parseChaosRate(req))
+	switch outcome {
+	case OutcomeConnError:
+		return nil, errFakeConn
+	case Outcome503:
+		return t.jsonResponse(req, http.StatusServiceUnavailable, failureBody(t.provider, 503)), nil
+	case Outcome429:
+		resp := t.jsonResponse(req, http.StatusTooManyRequests, failureBody(t.provider, 429))
+		resp.Header.Set("Retry-After", "1")
+		return resp, nil
+	case Outcome500:
+		return t.jsonResponse(req, http.StatusInternalServerError, failureBody(t.provider, 500)), nil
+	default:
+		inTok, model := t.estimateTokens(req)
+		outTok := parseOutputTokens(req, defaultOutputTokens)
+		if model == "" {
+			model = defaultModel(t.provider)
+		}
+		body := successBody(t.provider, model, inTok, outTok)
+		return t.jsonResponse(req, http.StatusOK, body), nil
+	}
+}
+
+func (t *Transport) sleep(req *http.Request) error {
+	ms := t.cfg.LatencyMS
+	if hdr := req.Header.Get(HeaderLatencyMs); hdr != "" {
+		if v, err := strconv.Atoi(hdr); err == nil && v >= 0 {
+			ms = v
+		}
+	}
+	if t.cfg.JitterMS > 0 {
+		t.chaos.mu.Lock()
+		jitter := t.chaos.rng.Intn(t.cfg.JitterMS + 1)
+		t.chaos.mu.Unlock()
+		ms += jitter
+	}
+	if ms <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(time.Duration(ms) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-req.Context().Done():
+		return req.Context().Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (t *Transport) estimateTokens(req *http.Request) (int, string) {
+	if req.Body == nil {
+		return 1, ""
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return 1, ""
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	clone := req.Clone(req.Context())
+	clone.Body = io.NopCloser(bytes.NewReader(body))
+	est, model := providers.EstimateRequestTokens(clone, t.cfg.Estimation, nil)
+	if est < 1 {
+		est = 1
+	}
+	if model == "" {
+		model = parseModelFromBody(body)
+	}
+	return est, model
+}
+
+func (t *Transport) jsonResponse(req *http.Request, status int, body []byte) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func parseChaosRate(req *http.Request) float64 {
+	hdr := req.Header.Get(HeaderChaosRate)
+	if hdr == "" {
+		return -1
+	}
+	v, err := strconv.ParseFloat(hdr, 64)
+	if err != nil {
+		return -1
+	}
+	return v
+}
+
+func parseOutputTokens(req *http.Request, fallback int) int {
+	hdr := req.Header.Get(HeaderOutputTokens)
+	if hdr == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(hdr)
+	if err != nil || v < 0 {
+		return fallback
+	}
+	return v
+}
+
+func parseModelFromBody(body []byte) string {
+	var m struct {
+		Model string `json:"model"`
+	}
+	if json.Unmarshal(body, &m) == nil && m.Model != "" {
+		return m.Model
+	}
+	return ""
+}
+
+func defaultModel(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "claude-3-5-haiku-20241022"
+	case "gemini":
+		return "gemini-2.5-flash"
+	default:
+		return "gpt-4o-mini"
+	}
+}

--- a/internal/fake/transport_test.go
+++ b/internal/fake/transport_test.go
@@ -1,0 +1,128 @@
+package fake_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/fake"
+	"github.com/Instawork/llm-proxy/internal/providers"
+)
+
+type countingRT struct {
+	calls int32
+}
+
+func (c *countingRT) RoundTrip(*http.Request) (*http.Response, error) {
+	atomic.AddInt32(&c.calls, 1)
+	return &http.Response{
+		StatusCode: http.StatusTeapot,
+		Body:       io.NopCloser(strings.NewReader("inner")),
+	}, nil
+}
+
+func TestTransport_Success_NoInnerCall(t *testing.T) {
+	inner := &countingRT{}
+	tr := fake.NewTransport(inner, "openai", fake.Config{Enabled: true})
+	body := []byte(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`)
+	req, _ := http.NewRequest(http.MethodPost, "http://proxy/openai/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(body))
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&inner.calls) != 0 {
+		t.Fatal("inner transport must not be called")
+	}
+	data, _ := io.ReadAll(resp.Body)
+	p := providers.NewOpenAIProxy()
+	meta, err := p.ParseResponseMetadata(bytes.NewReader(data), false)
+	if err != nil {
+		t.Fatalf("parse metadata: %v", err)
+	}
+	if meta.InputTokens <= 0 || meta.OutputTokens <= 0 {
+		t.Fatalf("tokens: in=%d out=%d", meta.InputTokens, meta.OutputTokens)
+	}
+}
+
+func TestTransport_Disabled_CallsInner(t *testing.T) {
+	inner := &countingRT{}
+	tr := fake.NewTransport(inner, "openai", fake.Config{Enabled: false})
+	req, _ := http.NewRequest(http.MethodGet, "http://proxy/", nil)
+	_, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if atomic.LoadInt32(&inner.calls) != 1 {
+		t.Fatal("inner must be called when fake disabled")
+	}
+}
+
+func TestTransport_Chaos503(t *testing.T) {
+	tr := fake.NewTransport(&countingRT{}, "openai", fake.Config{
+		Enabled:          true,
+		ChaosFailureRate: 1,
+		ChaosSeed:        1,
+	})
+	body := []byte(`{"model":"gpt-4o-mini","messages":[]}`)
+	req, _ := http.NewRequest(http.MethodPost, "http://proxy/openai/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(body))
+
+	for i := 0; i < 20; i++ {
+		resp, err := tr.RoundTrip(req)
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		if err != nil {
+			if err == io.ErrUnexpectedEOF {
+				continue
+			}
+			t.Fatalf("round trip: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
+			return
+		}
+	}
+	t.Fatal("expected chaos failure status")
+}
+
+func TestTransport_LatencyRespectsContext(t *testing.T) {
+	tr := fake.NewTransport(&countingRT{}, "openai", fake.Config{Enabled: true})
+	body := []byte(`{"model":"gpt-4o-mini","messages":[]}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://proxy/openai/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(fake.HeaderLatencyMs, "500")
+
+	_, err := tr.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected context deadline")
+	}
+}
+
+func TestChaos_PickDeterministicWithSeed(t *testing.T) {
+	c1 := fake.NewChaos(true, 0.5, 42)
+	c2 := fake.NewChaos(true, 0.5, 42)
+	var a, b []fake.Outcome
+	for i := 0; i < 10; i++ {
+		a = append(a, c1.Pick(-1))
+		b = append(b, c2.Pick(-1))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("outcomes diverged at %d: %v vs %v", i, a[i], b[i])
+		}
+	}
+}


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

Adds a security-gated **fake upstream mode** for local fuzzing without real LLM API calls, plus a **Go fuzz CLI** to stress-test rate limiting, cost tracking, and circuit breaking.

## Fake upstream

- `features.fake_upstream` config (`enabled`, `chaos_failure_rate`, `chaos_seed`, `latency_ms`, `jitter_ms`)
- Gate: YAML `enabled: true` **and** `LLM_PROXY_ALLOW_FAKE_MODE=1`
- `internal/fake` transport returns provider-shaped 200/4xx/5xx responses with realistic `usage` metadata
- Fake is the **inner** transport; circuit breaker wraps it
- Per-request overrides: `X-LLM-Proxy-Fake-Chaos-Rate`, `X-LLM-Proxy-Fake-Output-Tokens`, `X-LLM-Proxy-Fake-Latency-Ms`

## Fuzz overlays & CLI

- `configs/fuzz.yml` (Redis backends) and `configs/fuzz-mem.yml` (memory backends)
- `integration/cmd/llm-proxy-fuzz` with scenarios for rate limits, cost invariants, circuit chaos, latency
- Makefile: `make fuzz`, `fuzz-all`, `fuzz-chaos`, `fuzz-matrix`, `fuzz-test`, `fuzz-race`
- CI: `fuzz-tests` job runs `make fuzz-test` + builds fuzz CLI

## How to run locally

```bash
ENVIRONMENT=fuzz LLM_PROXY_ALLOW_FAKE_MODE=1 LLM_PROXY_ALLOW_TEST_MODE=1 docker compose up -d
make fuzz
```

**Never enable fake upstream in production.**