### PR TITLE
feat(apikeys): sk-iw- proxy key prefix with legacy support

### DIFF
--- a/cmd/llm-proxy-keys/main.go
+++ b/cmd/llm-proxy-keys/main.go
@@ -48,10 +48,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Commands:\n")
 		fmt.Fprintf(os.Stderr, "  Create a key:    -provider=openai -key=sk-xxx -desc=\"Production key\" -cost-limit=50000\n")
 		fmt.Fprintf(os.Stderr, "  List keys:       -list\n")
-		fmt.Fprintf(os.Stderr, "  Show key:        -show=iw:xxx\n")
-		fmt.Fprintf(os.Stderr, "  Delete key:      -delete=iw:xxx\n")
-		fmt.Fprintf(os.Stderr, "  Disable key:     -disable=iw:xxx\n")
-		fmt.Fprintf(os.Stderr, "  Enable key:      -enable=iw:xxx\n\n")
+		fmt.Fprintf(os.Stderr, "  Show key:        -show=sk-iw-xxx\n")
+		fmt.Fprintf(os.Stderr, "  Delete key:      -delete=sk-iw-xxx\n")
+		fmt.Fprintf(os.Stderr, "  Disable key:     -disable=sk-iw-xxx\n")
+		fmt.Fprintf(os.Stderr, "  Enable key:      -enable=sk-iw-xxx\n\n")
 		fmt.Fprintf(os.Stderr, "Pool commands:\n")
 		fmt.Fprintf(os.Stderr, "  pool add:        pool add --provider anthropic --key sk-ant-api03-...\n")
 		fmt.Fprintf(os.Stderr, "  pool status:     pool status --provider anthropic\n\n")
@@ -78,6 +78,12 @@ func main() {
 		logger.Error("API key management is not enabled in configuration")
 		os.Exit(1)
 	}
+
+	keyPrefixBase := os.Getenv("LLM_PROXY_API_KEY_PREFIX")
+	if keyPrefixBase == "" {
+		keyPrefixBase = yamlConfig.Features.APIKeyManagement.KeyPrefix
+	}
+	apikeys.SetKeyPrefixBase(keyPrefixBase)
 
 	// Create API key store. The CLI is normally used in local dev where
 	// AutoCreateTable=true is desirable; defer to YAML config so the same

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -794,7 +794,8 @@ func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore 
 
 	// Resolve the proxy key prefix base, env var taking precedence over YAML.
 	// A blank value leaves the apikeys default in place. New keys are minted
-	// as "<base>_<random>"; legacy "<base>:" keys still validate.
+	// as "sk-<base>-<random>"; legacy "<base>-" / "<base>_" / "<base>:" keys
+	// still validate.
 	keyPrefixBase := os.Getenv("LLM_PROXY_API_KEY_PREFIX")
 	if keyPrefixBase == "" {
 		keyPrefixBase = apiKeyConfig.KeyPrefix
@@ -1347,7 +1348,8 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	fakeAllowed := isFakeModeAllowed(yamlConfig)
 	fakeCfg := fakeConfigFromYAML(yamlConfig, fakeAllowed)
 	if fakeAllowed {
-		logger.Warn("🎭 Fake upstream: ENABLED — synthetic LLM responses, no real provider calls",
+		logger.Warn(
+			"🎭 Fake upstream: ENABLED — synthetic LLM responses, no real provider calls",
 			"chaos_failure_rate", yamlConfig.Features.FakeUpstream.ChaosFailureRate,
 		)
 	} else if yamlConfig.Features.FakeUpstream.Enabled {

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -28,7 +28,7 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys-dev"
     region: "us-west-2"
-    # New keys are minted as "iw-<random>"; legacy "iw_" and "iw:" keys still validate.
+    # New keys are minted as "sk-<base>-<random>"; legacy "<base>-" / "<base>_" / "<base>:" keys still validate.
     key_prefix: "iw"
     auto_create_table: true
     provisioning:

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -31,7 +31,7 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys"
     region: "us-west-2"
-    # New keys are minted as "iw-<random>"; legacy "iw_" and "iw:" keys still validate.
+    # New keys are minted as "sk-<base>-<random>"; legacy "<base>-" / "<base>_" / "<base>:" keys still validate.
     key_prefix: "iw"
     provisioning:
       enabled: true

--- a/configs/staging.yml
+++ b/configs/staging.yml
@@ -18,7 +18,7 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys-staging"
     region: "us-west-2"
-    # New keys are minted as "iw-<random>"; legacy "iw_" and "iw:" keys still validate.
+    # New keys are minted as "sk-<base>-<random>"; legacy "<base>-" / "<base>_" / "<base>:" keys still validate.
     key_prefix: "iw"
     provisioning:
       enabled: false

--- a/docs/API_KEY_MANAGEMENT.md
+++ b/docs/API_KEY_MANAGEMENT.md
@@ -4,7 +4,7 @@
 
 The LLM Proxy now supports a custom API key management system that allows you to:
 
-- Generate proxy-specific API keys prefixed with `iw:`
+- Generate proxy-specific API keys prefixed with `sk-<base>-` (default `sk-iw-`)
 - Store actual provider keys securely in DynamoDB
 - Set 24-hour cost limits per key (for future implementation)
 - Enable/disable keys without deleting them
@@ -12,14 +12,14 @@ The LLM Proxy now supports a custom API key management system that allows you to
 
 ## How It Works
 
-1. **Key Generation**: Generate unique keys prefixed with `iw:` that your users will use
+1. **Key Generation**: Generate unique keys prefixed with `sk-<base>-` (configure `<base>` via `key_prefix` in YAML, default `iw`)
 2. **Key Storage**: Actual provider API keys are stored securely in DynamoDB
-3. **Key Validation**: When a request comes in with an `iw:` key, the proxy:
+3. **Key Validation**: When a request comes in with a proxy key, the proxy:
    - Looks up the key in DynamoDB
    - Validates it's enabled and not expired
    - Replaces it with the actual provider key
    - Forwards the request to the provider
-4. **Pass-through**: Regular API keys (not prefixed with `iw:`) pass through unchanged
+4. **Pass-through**: Regular provider API keys (not recognized as proxy keys) pass through unchanged
 
 ## Configuration
 
@@ -31,13 +31,14 @@ features:
     enabled: true
     table_name: "llm-proxy-api-keys"  # DynamoDB table name
     region: "us-west-2"                # AWS region
+    key_prefix: "iw"                   # new keys: sk-iw-<hex>
 ```
 
 ## DynamoDB Table
 
 The system automatically creates a DynamoDB table with the following structure:
 
-- **Primary Key**: `pk` (the `iw:` prefixed key)
+- **Primary Key**: `pk` (the proxy key, e.g. `sk-iw-<hex>`)
 - **Attributes**:
   - `provider`: LLM provider (openai, anthropic, gemini)
   - `actual_key`: The real provider API key
@@ -62,7 +63,7 @@ go build ./cmd/llm-proxy-keys
 ./llm-proxy-keys \
   -env=production \
   -provider=openai \
-  -key="sk-actual-openai-key-here" \
+  -key="YOUR_OPENAI_API_KEY" \
   -desc="Production API key for service X" \
   -cost-limit=50000  # $500/day limit
 ```
@@ -72,13 +73,13 @@ Output:
 ```
 ✅ API Key Created Successfully!
 
-Key:         iw:1234567890abcdef...
+Key:         sk-iw-<hex>
 Provider:    openai
 Description: Production API key for service X
 Cost Limit:  $500.00/day
 Created:     2024-01-15T10:30:00Z
 
-🔑 Use this key in your API requests by replacing your provider key with: iw:1234567890abcdef...
+🔑 Use this key in your API requests by replacing your provider key with the generated sk-iw-<hex> value
 ```
 
 ### Listing Keys
@@ -95,19 +96,21 @@ Created:     2024-01-15T10:30:00Z
 
 ```bash
 # Show key details
-./llm-proxy-keys -env=production -show=iw:1234567890abcdef
+./llm-proxy-keys -env=production -show=YOUR_PROXY_KEY
 
 # Disable a key (temporarily)
-./llm-proxy-keys -env=production -disable=iw:1234567890abcdef
+./llm-proxy-keys -env=production -disable=YOUR_PROXY_KEY
 
 # Enable a key
-./llm-proxy-keys -env=production -enable=iw:1234567890abcdef
+./llm-proxy-keys -env=production -enable=YOUR_PROXY_KEY
 
 # Delete a key (permanent)
-./llm-proxy-keys -env=production -delete=iw:1234567890abcdef
+./llm-proxy-keys -env=production -delete=YOUR_PROXY_KEY
 ```
 
 ## Using Proxy Keys in API Requests
+
+In the examples below, `YOUR_PROXY_KEY` stands in for the generated proxy key (format: `sk-iw-<hex>` by default).
 
 ### OpenAI Example
 
@@ -115,7 +118,7 @@ Instead of:
 
 ```bash
 curl https://proxy.example.com/openai/v1/chat/completions \
-  -H "Authorization: Bearer sk-actual-openai-key" \
+  -H "Authorization: Bearer YOUR_OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model": "gpt-4", "messages": [...]}'
 ```
@@ -124,7 +127,7 @@ Use:
 
 ```bash
 curl https://proxy.example.com/openai/v1/chat/completions \
-  -H "Authorization: Bearer iw:1234567890abcdef..." \
+  -H "Authorization: Bearer YOUR_PROXY_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model": "gpt-4", "messages": [...]}'
 ```
@@ -135,7 +138,7 @@ Instead of:
 
 ```bash
 curl https://proxy.example.com/anthropic/v1/messages \
-  -H "x-api-key: sk-ant-actual-key" \
+  -H "x-api-key: YOUR_ANTHROPIC_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-3-opus", "messages": [...]}'
 ```
@@ -144,7 +147,7 @@ Use:
 
 ```bash
 curl https://proxy.example.com/anthropic/v1/messages \
-  -H "x-api-key: iw:1234567890abcdef..." \
+  -H "x-api-key: YOUR_PROXY_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-3-opus", "messages": [...]}'
 ```
@@ -154,7 +157,7 @@ curl https://proxy.example.com/anthropic/v1/messages \
 Instead of:
 
 ```bash
-curl "https://proxy.example.com/gemini/v1/models/gemini-pro:generateContent?key=actual-gemini-key" \
+curl "https://proxy.example.com/gemini/v1/models/gemini-pro:generateContent?key=YOUR_GEMINI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents": [...]}'
 ```
@@ -162,7 +165,7 @@ curl "https://proxy.example.com/gemini/v1/models/gemini-pro:generateContent?key=
 Use:
 
 ```bash
-curl "https://proxy.example.com/gemini/v1/models/gemini-pro:generateContent?key=iw:1234567890abcdef..." \
+curl "https://proxy.example.com/gemini/v1/models/gemini-pro:generateContent?key=YOUR_PROXY_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents": [...]}'
 ```
@@ -177,7 +180,7 @@ curl "https://proxy.example.com/gemini/v1/models/gemini-pro:generateContent?key=
 
 ## Error Handling
 
-When an invalid or disabled `iw:` key is used, the proxy returns:
+When an invalid or disabled proxy key is used, the proxy returns:
 
 ```json
 {

--- a/integration/fuzz/cost_limit.go
+++ b/integration/fuzz/cost_limit.go
@@ -321,7 +321,8 @@ func (r *Runner) costLimitAtomicityStress(ctx context.Context) (bool, string) {
 	if ok > bound {
 		return false, fmt.Sprintf(
 			"OVERSHOOT: admitted ok=%d > bound=%d (maxAllowed=%d perReq=%.6f cap=%.4f fired=%d) — reservation not atomic",
-			ok, bound, maxAllowed, perReq, capUSD, fired)
+			ok, bound, maxAllowed, perReq, capUSD, fired,
+		)
 	}
 
 	// And recorded spend must also stay bounded once the async tracker flushes.
@@ -337,7 +338,8 @@ func (r *Runner) costLimitAtomicityStress(ctx context.Context) (bool, string) {
 	}
 	return true, fmt.Sprintf(
 		"atomic under load: fired=%d ok=%d blocked=%d other=%d (maxAllowed≈%d perReq=%.6f) spend=%.6f cap=%.4f",
-		fired, ok, blocked, other, maxAllowed, perReq, spent, capUSD)
+		fired, ok, blocked, other, maxAllowed, perReq, spent, capUSD,
+	)
 }
 
 // costRollupAggregation proves the Redis cost rollup (the by_key INCRBYFLOAT

--- a/integration/live/runner.go
+++ b/integration/live/runner.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/Instawork/llm-proxy/internal/apikeys"
 )
 
 type Runner struct {
@@ -180,8 +182,8 @@ func (r *Runner) runAdmin(ctx context.Context) []Result {
 		out = append(out, failResult("admin", "keys-crud", "create: "+err.Error()))
 		return out
 	}
-	if !strings.HasPrefix(key.Key, "iw:") {
-		out = append(out, failResult("admin", "keys-crud", "expected iw: prefix, got "+key.Key))
+	if !apikeys.HasKeyPrefix(key.Key) {
+		out = append(out, failResult("admin", "keys-crud", "expected proxy key prefix, got "+key.Key))
 	} else if err := r.admin.DeleteKey(ctx, key.Key); err != nil {
 		out = append(out, failResult("admin", "keys-crud", "delete: "+err.Error()))
 	} else {

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -186,6 +186,7 @@ func (a *authenticator) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 type devLoginRequest struct {
 	Redirect string `json:"redirect"`
+	Role     string `json:"role"`
 }
 
 func (a *authenticator) handleDevLogin(w http.ResponseWriter, r *http.Request) {
@@ -199,11 +200,24 @@ func (a *authenticator) handleDevLogin(w http.ResponseWriter, r *http.Request) {
 		email = "dev@example.com"
 	}
 
+	var req devLoginRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req)
+	}
+
 	redirectTarget := r.URL.Query().Get("redirect")
-	if redirectTarget == "" && r.Body != nil {
-		var req devLoginRequest
-		if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err == nil {
-			redirectTarget = req.Redirect
+	if redirectTarget == "" {
+		redirectTarget = req.Redirect
+	}
+
+	roleParam := strings.TrimSpace(r.URL.Query().Get("role"))
+	if roleParam == "" {
+		roleParam = strings.TrimSpace(req.Role)
+	}
+	if roleParam != "" {
+		if _, err := adminusers.ParseRole(roleParam); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 	}
 
@@ -213,15 +227,24 @@ func (a *authenticator) handleDevLogin(w http.ResponseWriter, r *http.Request) {
 	session.Values[sessionUserPicture] = devUserPicture("Dev User")
 
 	if a.userStore != nil {
-		user, created, err := a.userStore.EnsureUser(r.Context(), email, "Dev User", devUserPicture("Dev User"))
+		user, _, err := a.userStore.EnsureUser(r.Context(), email, "Dev User", devUserPicture("Dev User"))
 		if err != nil {
 			a.logger.Error("admin auth: dev ensure user failed", "error", err, "email", email)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
-		if user.Role == adminusers.RoleViewer && (created || isDefaultDevBypassEmail(email)) {
-			if err := a.userStore.SetRole(r.Context(), email, adminusers.RoleEditor); err != nil {
-				a.logger.Error("admin auth: dev promote to editor failed", "error", err, "email", email)
+		if roleParam != "" {
+			targetRole, _ := adminusers.ParseRole(roleParam)
+			if user.Role != targetRole {
+				if err := a.userStore.SetRole(r.Context(), email, targetRole); err != nil {
+					a.logger.Error("admin auth: dev set role failed", "error", err, "email", email, "role", targetRole)
+					http.Error(w, "internal error", http.StatusInternalServerError)
+					return
+				}
+			}
+		} else if isDefaultDevBypassEmail(email) && user.Role != adminusers.RoleAdmin {
+			if err := a.userStore.SetRole(r.Context(), email, adminusers.RoleAdmin); err != nil {
+				a.logger.Error("admin auth: dev set role failed", "error", err, "email", email, "role", adminusers.RoleAdmin)
 				http.Error(w, "internal error", http.StatusInternalServerError)
 				return
 			}

--- a/internal/admin/auth_test.go
+++ b/internal/admin/auth_test.go
@@ -2,12 +2,14 @@ package admin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/gorilla/sessions"
 )
@@ -70,6 +72,86 @@ func TestHandleDevLogin_SetsSession(t *testing.T) {
 	}
 	if user.Email != "dev@example.com" {
 		t.Fatalf("session email: %q", user.Email)
+	}
+}
+
+func TestHandleDevLogin_ExplicitRoleInvalid(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
+
+	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
+		DevBypassLogin: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("newAuthenticator: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"role": "superuser"})
+	req := httptest.NewRequest(http.MethodPost, "/admin/auth/dev-login", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	auth.handleDevLogin(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDevLogin_DevEmailDefaultsToAdmin(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
+
+	userStore := testAdminUserStore(t)
+	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
+		DevBypassLogin: true,
+	}, userStore)
+	if err != nil {
+		t.Fatalf("newAuthenticator: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/auth/dev-login", nil)
+	rec := httptest.NewRecorder()
+	auth.handleDevLogin(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	user, err := userStore.GetUser(context.Background(), "dev@example.com")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if user.Role != adminusers.RoleAdmin {
+		t.Fatalf("got %q want admin", user.Role)
+	}
+}
+
+func TestHandleDevLogin_PreservesExistingAdminRole(t *testing.T) {
+	t.Setenv("LLM_PROXY_ADMIN_SESSION_SECRET", "test-secret-at-least-32-bytes-long")
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "admin@example.com")
+
+	userStore := testAdminUserStore(t)
+	_, err := userStore.CreateUser(context.Background(), "admin@example.com", adminusers.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
+		DevBypassLogin: true,
+	}, userStore)
+	if err != nil {
+		t.Fatalf("newAuthenticator: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/auth/dev-login", nil)
+	rec := httptest.NewRecorder()
+	auth.handleDevLogin(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	user, err := userStore.GetUser(context.Background(), "admin@example.com")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if user.Role != adminusers.RoleAdmin {
+		t.Fatalf("got %q want admin", user.Role)
 	}
 }
 

--- a/internal/admin/users_handlers_test.go
+++ b/internal/admin/users_handlers_test.go
@@ -313,5 +313,40 @@ func TestHandleDevLoginEnsuresUser(t *testing.T) {
 
 	user, err := h.deps.UserStore.GetUser(context.Background(), "fresh@example.com")
 	require.NoError(t, err)
-	assert.Equal(t, adminusers.RoleEditor, user.Role)
+	assert.Equal(t, adminusers.RoleViewer, user.Role)
+}
+
+func TestHandleDevLoginDefaultDevEmailIsAdmin(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "dev@example.com")
+
+	loginRec := httptest.NewRecorder()
+	loginBody, _ := json.Marshal(map[string]string{"redirect": "http://localhost:9002/admin/"})
+	loginReq := httptest.NewRequest(http.MethodPost, "/admin/auth/dev-login", bytes.NewReader(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	h.auth.handleDevLogin(loginRec, loginReq)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	user, err := h.deps.UserStore.GetUser(context.Background(), "dev@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, adminusers.RoleAdmin, user.Role)
+}
+
+func TestHandleDevLoginExplicitRoleOverridesDefault(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "dev@example.com")
+
+	loginRec := httptest.NewRecorder()
+	loginBody, _ := json.Marshal(map[string]string{
+		"redirect": "http://localhost:9002/admin/",
+		"role":     "viewer",
+	})
+	loginReq := httptest.NewRequest(http.MethodPost, "/admin/auth/dev-login", bytes.NewReader(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	h.auth.handleDevLogin(loginRec, loginReq)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	user, err := h.deps.UserStore.GetUser(context.Background(), "dev@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, adminusers.RoleViewer, user.Role)
 }

--- a/internal/adminrollup/reservation.go
+++ b/internal/adminrollup/reservation.go
@@ -62,7 +62,8 @@ return 1
 `)
 
 func (b *redisBackend) reserveUnderLimit(ctx context.Context, spendHashKey, spendField, reservedHashKey, reservedField string, estimate float64, limitCents int64, ttl time.Duration) (bool, error) {
-	res, err := reserveUnderLimitScript.Run(ctx, b.rdb,
+	res, err := reserveUnderLimitScript.Run(
+		ctx, b.rdb,
 		[]string{spendHashKey, reservedHashKey},
 		spendField, reservedField,
 		strconv.FormatFloat(estimate, 'f', -1, 64),
@@ -76,7 +77,8 @@ func (b *redisBackend) reserveUnderLimit(ctx context.Context, spendHashKey, spen
 }
 
 func (b *redisBackend) addReserved(ctx context.Context, reservedHashKey, reservedField string, delta float64, ttl time.Duration) error {
-	return addReservedScript.Run(ctx, b.rdb,
+	return addReservedScript.Run(
+		ctx, b.rdb,
 		[]string{reservedHashKey},
 		reservedField,
 		strconv.FormatFloat(delta, 'f', -1, 64),
@@ -157,7 +159,8 @@ func (s *Store) ReserveKeySpend(ctx context.Context, metric, day, keyID string, 
 	if s == nil || s.be == nil || keyID == "" {
 		return true, nil
 	}
-	return s.be.reserveUnderLimit(ctx,
+	return s.be.reserveUnderLimit(
+		ctx,
 		dimKey(metric, day, "by_key"), dimMemberField(keyID, "spend_usd"),
 		dimKey(metric, day, reservedDim), keyID,
 		estimateUSD, limitCents, todayTTL,

--- a/internal/apikeys/prefix_test.go
+++ b/internal/apikeys/prefix_test.go
@@ -1,0 +1,163 @@
+package apikeys
+
+import (
+	"context"
+	"encoding/hex"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetKeyPrefixBase(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { SetKeyPrefixBase(DefaultKeyPrefixBase) })
+	SetKeyPrefixBase(DefaultKeyPrefixBase)
+}
+
+func TestKeyPrefix_DefaultGenerationPrefix(t *testing.T) {
+	resetKeyPrefixBase(t)
+	assert.Equal(t, "sk-iw-", KeyPrefix)
+	assert.Equal(t, "iw", KeyPrefixBase())
+}
+
+func TestGenerateKey_SkPrefixFormat(t *testing.T) {
+	resetKeyPrefixBase(t)
+
+	key, err := GenerateKey()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(key, "sk-iw-"))
+
+	body := strings.TrimPrefix(key, "sk-iw-")
+	assert.Len(t, body, KeyLength*2)
+	assert.True(t, hexRegexp.MatchString(body), "random segment should be lowercase hex")
+	_, err = hex.DecodeString(body)
+	assert.NoError(t, err)
+}
+
+func TestTrimKeyPrefix_SkAndLegacySeparators(t *testing.T) {
+	resetKeyPrefixBase(t)
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"sk-iw-deadbeef", "deadbeef"},
+		{"iw:legacy", "legacy"},
+		{"iw_legacy", "legacy"},
+		{"iw-legacy", "legacy"},
+		{"sk-proj-upstream", "sk-proj-upstream"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, TrimKeyPrefix(tc.in))
+		})
+	}
+}
+
+func TestRedactKey_PreservesSkPrefix(t *testing.T) {
+	resetKeyPrefixBase(t)
+
+	got := RedactKey("sk-iw-" + strings.Repeat("a", 64))
+	assert.True(t, strings.HasPrefix(got, "sk-iw-"))
+	assert.Contains(t, got, "…")
+}
+
+func TestSetKeyPrefixBase_CustomBaseAndSkLead(t *testing.T) {
+	resetKeyPrefixBase(t)
+
+	SetKeyPrefixBase("acme")
+	assert.Equal(t, "sk-acme-", KeyPrefix)
+	assert.True(t, HasKeyPrefix("sk-acme-secret"))
+	assert.False(t, HasKeyPrefix("sk-iw-secret"))
+
+	key, err := GenerateKey()
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(key, "sk-acme-"))
+}
+
+func TestSetKeyPrefixBase_BlankIgnored(t *testing.T) {
+	resetKeyPrefixBase(t)
+
+	SetKeyPrefixBase("   ")
+	assert.Equal(t, "sk-iw-", KeyPrefix)
+}
+
+func TestStore_ValidateAndGetActualKey_LegacyIwColonKey(t *testing.T) {
+	store, fake := newFakeStore(t)
+	ctx := context.Background()
+
+	const legacyPK = "iw:legacy-key-body"
+	fake.InjectItem("test-keys", legacyPK, map[string]any{
+		"pk":         map[string]any{"S": legacyPK},
+		"provider":   map[string]any{"S": "openai"},
+		"actual_key": map[string]any{"S": "upstream-openai"},
+		"enabled":    map[string]any{"BOOL": true},
+		"created_at": map[string]any{"S": time.Now().UTC().Format(time.RFC3339)},
+		"updated_at": map[string]any{"S": time.Now().UTC().Format(time.RFC3339)},
+	})
+
+	actual, provider, err := store.ValidateAndGetActualKey(ctx, legacyPK)
+	require.NoError(t, err)
+	assert.Equal(t, "upstream-openai", actual)
+	assert.Equal(t, "openai", provider)
+}
+
+func TestStore_ValidateAndGetActualKey_PassthroughUpstreamSk(t *testing.T) {
+	store, _ := newFakeStore(t)
+
+	actual, provider, err := store.ValidateAndGetActualKey(
+		context.Background(),
+		"sk-proj-upstream-key-not-ours",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-proj-upstream-key-not-ours", actual)
+	assert.Equal(t, "", provider)
+}
+
+func TestStore_CreateKey_PKUsesSkPrefix(t *testing.T) {
+	resetKeyPrefixBase(t)
+	store, _ := newFakeStore(t)
+
+	created, err := store.CreateKey(context.Background(), "openai", "upstream", "", 0, nil, nil)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(created.PK, "sk-iw-"))
+	assert.True(t, HasKeyPrefix(created.PK))
+}
+
+func TestStore_ListKeys_IncludesSkPrefixedAndLegacyKeys(t *testing.T) {
+	resetKeyPrefixBase(t)
+	store, fake := newFakeStore(t)
+	ctx := context.Background()
+
+	created, err := store.CreateKey(ctx, "openai", "upstream", "", 0, nil, nil)
+	require.NoError(t, err)
+
+	const legacyPK = "iw:listed-legacy"
+	fake.InjectItem("test-keys", legacyPK, map[string]any{
+		"pk":         map[string]any{"S": legacyPK},
+		"provider":   map[string]any{"S": "anthropic"},
+		"actual_key": map[string]any{"S": "upstream-anthropic"},
+		"enabled":    map[string]any{"BOOL": true},
+		"created_at": map[string]any{"S": time.Now().UTC().Format(time.RFC3339)},
+		"updated_at": map[string]any{"S": time.Now().UTC().Format(time.RFC3339)},
+	})
+	_, err = store.CreateShareLink(ctx, created.PK, "admin@example.com")
+	require.NoError(t, err)
+
+	keys, err := store.ListKeys(ctx, "")
+	require.NoError(t, err)
+
+	pks := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pks = append(pks, k.PK)
+	}
+	assert.Contains(t, pks, created.PK)
+	assert.Contains(t, pks, legacyPK)
+	assert.NotContains(t, pks, ShareKeyPrefix)
+}
+
+var hexRegexp = regexp.MustCompile(`^[0-9a-f]+$`)

--- a/internal/apikeys/store.go
+++ b/internal/apikeys/store.go
@@ -23,10 +23,11 @@ const (
 	KeyLength = 32
 
 	// DefaultKeyPrefixBase is the default prefix base (without separator).
-	// New keys are generated as "<base>-<hex>"; legacy "<base>_",
-	// "<base>:", and "<base>-" forms are accepted on lookup.
+	// New keys are generated as "sk-<base>-<hex>"; legacy "<base>-",
+	// "<base>_", and "<base>:" forms are accepted on lookup.
 	DefaultKeyPrefixBase = "iw"
 
+	keyPrefixSkLead              = "sk-"
 	keyPrefixSepNew              = "-"
 	keyPrefixSepLegacyUnderscore = "_"
 	keyPrefixSepLegacyColon      = ":"
@@ -37,24 +38,33 @@ var (
 	// e.g. "iw". Set once at startup via SetKeyPrefixBase.
 	keyPrefixBase = DefaultKeyPrefixBase
 
-	// KeyPrefix is the prefix used to GENERATE new keys ("<base>-").
+	// KeyPrefix is the prefix used to GENERATE new keys ("sk-<base>-").
 	// Exported for backwards compatibility with callers/tests that build
 	// keys as KeyPrefix+"...". Do NOT use it to decide whether a string is
 	// one of our keys — that must accept legacy separators too, so use
 	// HasKeyPrefix / TrimKeyPrefix instead.
-	KeyPrefix = keyPrefixBase + keyPrefixSepNew
+	KeyPrefix = generationKeyPrefix(keyPrefixBase)
 
 	// acceptedKeyPrefixes lists every prefix recognized as one of our proxy
 	// keys, current separator first. Kept in sync by SetKeyPrefixBase.
-	acceptedKeyPrefixes = []string{
-		keyPrefixBase + keyPrefixSepNew,
-		keyPrefixBase + keyPrefixSepLegacyUnderscore,
-		keyPrefixBase + keyPrefixSepLegacyColon,
-	}
+	acceptedKeyPrefixes = acceptedKeyPrefixesForBase(keyPrefixBase)
 )
 
+func generationKeyPrefix(base string) string {
+	return keyPrefixSkLead + base + keyPrefixSepNew
+}
+
+func acceptedKeyPrefixesForBase(base string) []string {
+	return []string{
+		generationKeyPrefix(base),
+		base + keyPrefixSepNew,
+		base + keyPrefixSepLegacyUnderscore,
+		base + keyPrefixSepLegacyColon,
+	}
+}
+
 // SetKeyPrefixBase configures the proxy key prefix base (e.g. "iw"). New
-// keys are then generated as "<base>-<hex>", while lookups continue to
+// keys are then generated as "sk-<base>-<hex>", while lookups continue to
 // accept "<base>-", "<base>_", and "<base>:" for keys minted under older
 // separators. A blank base is ignored so a missing config value falls back
 // to the default. Call once at startup before serving traffic — it is not
@@ -65,19 +75,15 @@ func SetKeyPrefixBase(base string) {
 		return
 	}
 	keyPrefixBase = base
-	KeyPrefix = base + keyPrefixSepNew
-	acceptedKeyPrefixes = []string{
-		base + keyPrefixSepNew,
-		base + keyPrefixSepLegacyUnderscore,
-		base + keyPrefixSepLegacyColon,
-	}
+	KeyPrefix = generationKeyPrefix(base)
+	acceptedKeyPrefixes = acceptedKeyPrefixesForBase(base)
 }
 
 // KeyPrefixBase returns the configured prefix base (without separator).
 func KeyPrefixBase() string { return keyPrefixBase }
 
 // HasKeyPrefix reports whether k carries a recognized proxy-key prefix
-// (current "<base>-" or legacy "<base>_" / "<base>:").
+// (current "sk-<base>-" or legacy "<base>-" / "<base>_" / "<base>:").
 func HasKeyPrefix(k string) bool {
 	_, ok := matchedKeyPrefix(k)
 	return ok
@@ -352,7 +358,7 @@ type KeyCreateMeta struct {
 }
 
 // GenerateKey generates a new API key using the current generation prefix
-// ("<base>-", e.g. "iw-").
+// ("sk-<base>-", e.g. "sk-iw-").
 func GenerateKey() (string, error) {
 	bytes := make([]byte, KeyLength)
 	if _, err := rand.Read(bytes); err != nil {
@@ -607,16 +613,19 @@ func (s *Store) ListKeys(ctx context.Context, provider string) ([]*APIKey, error
 			queryInput.ExclusiveStartKey = result.LastEvaluatedKey
 		}
 	} else {
-		// Scan all keys. Filter on the prefix base (e.g. "iw") so BOTH the
-		// current "iw_" keys and legacy "iw:" keys are returned, while
-		// co-located share-link records (pk "share:<uuid>") never get
-		// unmarshaled into the key list. Paginate so large key sets are
-		// not truncated at DynamoDB's 1 MiB response limit.
+		// Scan all keys. Match current "sk-<base>-" keys and legacy
+		// "<base>-" / "<base>_" / "<base>:" keys, while co-located
+		// share-link records (pk "share:<uuid>") never get unmarshaled
+		// into the key list. Paginate so large key sets are not truncated
+		// at DynamoDB's 1 MiB response limit.
 		scanInput := &dynamodb.ScanInput{
-			TableName:        aws.String(s.tableName),
-			FilterExpression: aws.String("begins_with(pk, :pfx)"),
+			TableName: aws.String(s.tableName),
+			FilterExpression: aws.String(
+				"begins_with(pk, :skPfx) OR begins_with(pk, :legacyPfx)",
+			),
 			ExpressionAttributeValues: map[string]types.AttributeValue{
-				":pfx": &types.AttributeValueMemberS{Value: keyPrefixBase},
+				":skPfx":     &types.AttributeValueMemberS{Value: generationKeyPrefix(keyPrefixBase)},
+				":legacyPfx": &types.AttributeValueMemberS{Value: keyPrefixBase},
 			},
 		}
 		for {
@@ -643,7 +652,7 @@ func (s *Store) ListKeys(ctx context.Context, provider string) ([]*APIKey, error
 }
 
 // LookupProxyKey returns the DynamoDB record for a proxy bearer token
-// (current "<base>_" or legacy "<base>:" form).
+// (current "sk-<base>-" or legacy "<base>-" / "<base>_" / "<base>:" form).
 func (s *Store) LookupProxyKey(ctx context.Context, bearer string) (*APIKey, error) {
 	if !HasKeyPrefix(bearer) {
 		return nil, nil

--- a/internal/apikeys/store_test.go
+++ b/internal/apikeys/store_test.go
@@ -34,11 +34,34 @@ func TestGenerateKey_HasPrefixAndIsRandom(t *testing.T) {
 	a, err := GenerateKey()
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(a, KeyPrefix))
+	assert.True(t, strings.HasPrefix(a, "sk-"))
 	assert.Greater(t, len(a), len(KeyPrefix)+10)
 
 	b, err := GenerateKey()
 	require.NoError(t, err)
 	assert.NotEqual(t, a, b, "two generated keys should differ")
+}
+
+func TestSetKeyPrefixBase_GeneratesSkPrefixedKeys(t *testing.T) {
+	t.Cleanup(func() { SetKeyPrefixBase(DefaultKeyPrefixBase) })
+
+	SetKeyPrefixBase("acme")
+	assert.Equal(t, "sk-acme-", KeyPrefix)
+
+	key, err := GenerateKey()
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(key, "sk-acme-"))
+}
+
+func TestHasKeyPrefix_AcceptsCurrentLegacyAndRejectsUpstreamSk(t *testing.T) {
+	t.Cleanup(func() { SetKeyPrefixBase(DefaultKeyPrefixBase) })
+
+	assert.True(t, HasKeyPrefix(KeyPrefix+"abc123"))
+	assert.True(t, HasKeyPrefix("iw:legacy"))
+	assert.True(t, HasKeyPrefix("iw_legacy"))
+	assert.True(t, HasKeyPrefix("iw-legacy"))
+	assert.False(t, HasKeyPrefix("sk-direct"))
+	assert.False(t, HasKeyPrefix("sk-proj-upstream"))
 }
 
 // ----------------------------------------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -428,10 +428,10 @@ type APIKeyManagementConfig struct {
 	// pre-provision the table via Terraform and leave this false.
 	AutoCreateTable bool `yaml:"auto_create_table"`
 	// KeyPrefix is the prefix base (without separator, e.g. "iw") used for
-	// proxy API keys. New keys are generated as "<base>-<random>", and
-	// "<base>-", "<base>_", and "<base>:" are accepted on lookup. Blank
-	// falls back to apikeys.DefaultKeyPrefixBase. Overridable at runtime
-	// via the LLM_PROXY_API_KEY_PREFIX env var.
+	// proxy API keys. New keys are generated as "sk-<base>-<random>", and
+	// "sk-<base>-", "<base>-", "<base>_", and "<base>:" are accepted on
+	// lookup. Blank falls back to apikeys.DefaultKeyPrefixBase. Overridable
+	// at runtime via the LLM_PROXY_API_KEY_PREFIX env var.
 	KeyPrefix string `yaml:"key_prefix"`
 	// Provisioning configures automatic upstream key minting for the admin UI.
 	Provisioning KeyProvisioningConfig `yaml:"provisioning,omitempty"`

--- a/internal/middleware/apikey_validation_test.go
+++ b/internal/middleware/apikey_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
@@ -87,7 +88,7 @@ func TestAPIKeyValidationMiddleware(t *testing.T) {
 	}
 }
 
-func TestAPIKeyValidationMiddleware_StashesProxyKeyInContext(t *testing.T) {
+func TestAPIKeyValidationMiddleware_StashesSkPrefixedProxyKeyInContext(t *testing.T) {
 	pm := providers.NewProviderManager()
 	pm.RegisterProvider(providers.NewOpenAIProxy())
 
@@ -95,6 +96,9 @@ func TestAPIKeyValidationMiddleware_StashesProxyKeyInContext(t *testing.T) {
 	mw := APIKeyValidationMiddleware(pm, store, false)
 
 	iwKey := apikeys.KeyPrefix + "proxy"
+	if !strings.HasPrefix(iwKey, "sk-") {
+		t.Fatalf("proxy fixture should use sk- generation prefix, got %q", iwKey)
+	}
 	var captured *apikeys.APIKey
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec, ok := apikeys.FromContext(r.Context())

--- a/internal/middleware/cost_limit_test.go
+++ b/internal/middleware/cost_limit_test.go
@@ -231,11 +231,13 @@ func (f *fakeReserver) ReserveKeySpend(_ context.Context, _ string, estimateUSD 
 	}
 	return f.allow, f.active
 }
+
 func (f *fakeReserver) AdjustKeyReservation(_ context.Context, _ string, deltaUSD float64) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.adjustments = append(f.adjustments, deltaUSD)
 }
+
 func (f *fakeReserver) totalAdjust() float64 {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/testhelpers/dynamodbfake/server.go
+++ b/internal/testhelpers/dynamodbfake/server.go
@@ -206,8 +206,24 @@ func (f *Server) handle(w http.ResponseWriter, r *http.Request) {
 			}
 			if filterExpr != "" && strings.Contains(filterExpr, "begins_with") {
 				pkVal := ExtractDDBString(item, "pk")
-				pfx := extractAttrValueString(attrValues, ":pfx")
-				if pfx != "" && !strings.HasPrefix(pkVal, pfx) {
+				prefixes := []string{
+					extractAttrValueString(attrValues, ":pfx"),
+					extractAttrValueString(attrValues, ":skPfx"),
+					extractAttrValueString(attrValues, ":legacyPfx"),
+				}
+				hasPrefixFilter := false
+				matched := false
+				for _, pfx := range prefixes {
+					if pfx == "" {
+						continue
+					}
+					hasPrefixFilter = true
+					if strings.HasPrefix(pkVal, pfx) {
+						matched = true
+						break
+					}
+				}
+				if hasPrefixFilter && !matched {
 					continue
 				}
 			}

--- a/web/src/components/ui/masked-key.tsx
+++ b/web/src/components/ui/masked-key.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { CopyButton } from "./copy-button";
 
 export function maskKey(key: string): string {
-  if (key.length <= 12) return "iw:••••";
+  if (key.length <= 12) return "••••";
   return `${key.slice(0, 7)}${"•".repeat(18)}${key.slice(-4)}`;
 }
 

--- a/web/src/lib/code-examples.ts
+++ b/web/src/lib/code-examples.ts
@@ -355,9 +355,9 @@ export function codeExamples(ctx: Ctx): CodeExample[] {
 }
 
 // Placeholder for the Cursor/Replit prompt — real key stays on the share page only.
-export const PROMPT_KEY_PLACEHOLDER = "iw:YOUR_PROXY_KEY_HERE";
+export const PROMPT_KEY_PLACEHOLDER = "sk-iw-YOUR_PROXY_KEY_HERE";
 
-const IW_KEY_IN_TEXT = /iw:[a-f0-9]{32,}/gi;
+const PROXY_KEY_IN_TEXT = /(?:sk-[a-z0-9]+-|iw[:_-])[a-f0-9]{32,}/gi;
 
 /** Strip proxy keys from text meant for external AI assistants (Cursor, Replit, etc.). */
 export function scrubProxyKeyFromText(text: string, knownKey?: string): string {
@@ -365,7 +365,7 @@ export function scrubProxyKeyFromText(text: string, knownKey?: string): string {
   if (knownKey) {
     out = out.split(knownKey).join(PROMPT_KEY_PLACEHOLDER);
   }
-  return out.replace(IW_KEY_IN_TEXT, PROMPT_KEY_PLACEHOLDER);
+  return out.replace(PROXY_KEY_IN_TEXT, PROMPT_KEY_PLACEHOLDER);
 }
 
 // assistantPrompt returns a ready-to-paste prompt for Cursor / Replit / other
@@ -392,7 +392,7 @@ Please update my project to route all ${provider} calls through it.
 Proxy base URL: ${baseUrl}
 Proxy API key placeholder: ${PROMPT_KEY_PLACEHOLDER}
 
-Important — the real iw: key is NOT in this prompt. Before I can run anything, tell me to open the \
+Important — the real proxy key is NOT in this prompt. Before I can run anything, tell me to open the \
 LLM Proxy share page, copy my API key from the "API key" field, and paste it into ${envKeyName} \
 (or replace ${PROMPT_KEY_PLACEHOLDER} wherever you wire the client). Do not invent or guess a key.
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,3 +1,5 @@
+import { trimProxyKeyPrefix } from "./proxy-key";
+
 const compactFormatter = new Intl.NumberFormat("en-US", {
   notation: "compact",
   maximumFractionDigits: 1,
@@ -42,7 +44,7 @@ export function formatUsd(amount: number | undefined | null, digits = 4): string
   return `$${amount.toFixed(2)}`;
 }
 
-/** Masked iw: key identity matching middleware.MaskKeyID for joining spend stats.
+/** Masked proxy key identity matching middleware.MaskKeyID for joining spend stats.
  * A bare 12-char prefix collides across keys sharing that prefix, so we append
  * an FNV-1a/32 hash of the whole key (mirrors the Go backend byte-for-byte;
  * keys are ASCII so char/byte encodings agree). */
@@ -64,7 +66,7 @@ function fnv1a32Hex(s: string): string {
 const SCOPE_SUFFIX_LEN = 4;
 
 function redactScopeSecret(value: string): string {
-  const body = value.startsWith("iw:") ? value.slice(3) : value;
+  const body = trimProxyKeyPrefix(value);
   if (body.length <= SCOPE_SUFFIX_LEN) return "••••";
   return `••••${body.slice(-SCOPE_SUFFIX_LEN)}`;
 }

--- a/web/src/lib/key-routes.ts
+++ b/web/src/lib/key-routes.ts
@@ -1,4 +1,5 @@
 import { maskKeyId } from "./format";
+import { isProxyKey, trimProxyKeyPrefix } from "./proxy-key";
 import type { APIKey } from "../types";
 
 const REDACTED_SCOPE_SUFFIX = /^••••(.+)$/;
@@ -15,13 +16,11 @@ export function keyDetailPath(key: string): string {
   return `/keys/${encodeKeyRouteParam(key)}`;
 }
 
-export function isProxyKey(value: string | undefined): value is string {
-  return Boolean(value?.startsWith("iw:"));
-}
+export { isProxyKey };
 
-/** Matches admin API rate-limit scope redaction (last 4 of key body after iw:). */
+/** Matches admin API rate-limit scope redaction (last 4 of key body after prefix). */
 export function redactedRateLimitScopeForKey(key: string): string {
-  const body = key.startsWith("iw:") ? key.slice(3) : key;
+  const body = trimProxyKeyPrefix(key);
   if (body.length <= 4) {
     return `key:••••${body}`;
   }
@@ -31,14 +30,11 @@ export function redactedRateLimitScopeForKey(key: string): string {
 /** Resolve suffix from a redacted scope (`••••6e5d`) to a registered key. */
 export function findKeyByScopeSuffix(suffix: string, keys: APIKey[]): APIKey | undefined {
   if (!suffix) return undefined;
-  const matches = keys.filter((k) => {
-    const body = k.key.startsWith("iw:") ? k.key.slice(3) : k.key;
-    return body.endsWith(suffix);
-  });
+  const matches = keys.filter((k) => trimProxyKeyPrefix(k.key).endsWith(suffix));
   return matches.length === 1 ? matches[0] : undefined;
 }
 
-/** Resolve a masked dashboard key_id (iw:abc… ) to a registered API key. */
+/** Resolve a masked dashboard key_id to a registered API key. */
 export function findKeyByMaskedId(maskedId: string, keys: APIKey[]): APIKey | undefined {
   if (!maskedId) return undefined;
   const exact = keys.find((k) => maskKeyId(k.key) === maskedId);
@@ -52,7 +48,7 @@ export function findKeyByMaskedId(maskedId: string, keys: APIKey[]): APIKey | un
 export function keyFromRateLimitScope(scope: string, keys?: APIKey[]): string | undefined {
   if (!scope.startsWith("key:")) return undefined;
   const rest = scope.slice(4);
-  if (rest.startsWith("iw:")) return rest;
+  if (isProxyKey(rest)) return rest;
   const redacted = rest.match(REDACTED_SCOPE_SUFFIX);
   if (redacted) {
     return keys ? findKeyByScopeSuffix(redacted[1], keys)?.key : undefined;

--- a/web/src/lib/proxy-key.ts
+++ b/web/src/lib/proxy-key.ts
@@ -1,0 +1,25 @@
+const DEFAULT_PREFIX_BASE = "iw";
+const SK_LEAD = "sk-";
+
+export function proxyKeyPrefixes(base = DEFAULT_PREFIX_BASE): string[] {
+  return [`${SK_LEAD}${base}-`, `${base}-`, `${base}_`, `${base}:`];
+}
+
+export function matchedProxyKeyPrefix(
+  key: string,
+  base = DEFAULT_PREFIX_BASE,
+): string | null {
+  for (const prefix of proxyKeyPrefixes(base)) {
+    if (key.startsWith(prefix)) return prefix;
+  }
+  return null;
+}
+
+export function isProxyKey(value: string | undefined): value is string {
+  return Boolean(value && matchedProxyKeyPrefix(value));
+}
+
+export function trimProxyKeyPrefix(key: string, base = DEFAULT_PREFIX_BASE): string {
+  const prefix = matchedProxyKeyPrefix(key, base);
+  return prefix ? key.slice(prefix.length) : key;
+}

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -4,10 +4,20 @@ import { useSearchParams } from "react-router-dom";
 import { authBaseUrl, baseUrl } from "../client";
 import LLMProxyLogo from "../components/llm-proxy-logo";
 import { useToast } from "../components/ui/toast";
+import type { AdminRole } from "../types";
+
+const DEV_ROLES: AdminRole[] = ["viewer", "editor", "admin"];
+
+const DEV_ROLE_LABELS: Record<AdminRole, string> = {
+  viewer: "Viewer — monitoring only",
+  editor: "Editor — keys and monitoring",
+  admin: "Admin — full access",
+};
 
 export default function LoginPage() {
   const [params] = useSearchParams();
   const [loading, setLoading] = useState(false);
+  const [devRole, setDevRole] = useState<AdminRole>("admin");
   const { push } = useToast();
 
   const afterLoginPath = () => {
@@ -31,7 +41,7 @@ export default function LoginPage() {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ redirect }),
+        body: JSON.stringify({ redirect, role: devRole }),
       });
       if (!response.ok) {
         throw new Error(await response.text());
@@ -62,14 +72,31 @@ export default function LoginPage() {
 
         <div className="flex flex-col gap-3">
           {import.meta.env.DEV ? (
-            <button
-              type="button"
-              className="btn btn-primary btn-lg"
-              disabled={loading}
-              onClick={onDevLogin}
-            >
-              {loading ? <span className="loading loading-spinner" /> : "Dev login (local session)"}
-            </button>
+            <>
+              <label className="form-control w-full">
+                <span className="label-text text-base-content/70">User type</span>
+                <select
+                  className="select select-bordered w-full"
+                  value={devRole}
+                  disabled={loading}
+                  onChange={(e) => setDevRole(e.target.value as AdminRole)}
+                >
+                  {DEV_ROLES.map((role) => (
+                    <option key={role} value={role}>
+                      {DEV_ROLE_LABELS[role]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                className="btn btn-primary btn-lg"
+                disabled={loading}
+                onClick={onDevLogin}
+              >
+                {loading ? <span className="loading loading-spinner" /> : "Dev login (local session)"}
+              </button>
+            </>
           ) : null}
           <button type="button" className="btn btn-outline btn-lg gap-2" onClick={onGoogleLogin}>
             <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

- New proxy keys are generated as `sk-<base>-<hex>` (default `sk-iw-`) instead of `iw:<hex>`.
- Legacy keys (`iw:`, `iw_`, `iw-`) continue to validate; upstream `sk-proj-*` keys still pass through unchanged.
- Admin UI, CLI help, docs, and masking updated for the new prefix; adds `web/src/lib/proxy-key.ts` helpers.
- Dev login: role dropdown on the login page; `dev@example.com` defaults to admin without downgrading existing users (e.g. test `admin@example.com`).

## Test plan

- [x] `go test ./internal/admin/... ./internal/apikeys/... ./internal/middleware/...`
- [x] `gofumpt` / `gofmt` clean
- [ ] Create a key locally — confirm `sk-iw-…` format
- [ ] Confirm legacy `iw:` keys still work
- [ ] Dev login as viewer/editor/admin via dropdown

## Notes

- Independent of [#17](https://github.com/Instawork/llm-proxy/pull/17) (viewer personal keys); merge order either way, but both touch `store.go` / admin auth.