### PR TITLE
Circuit: upstream error detail and provider-specific failure kinds

### DIFF
--- a/internal/circuit/classifier.go
+++ b/internal/circuit/classifier.go
@@ -116,19 +116,106 @@ func classifyOpenAI(status int, resp *http.Response) FailureClass {
 	}
 }
 
-// peekOpenAIErrorCode reads up to openAIPeekBytes from resp.Body, extracts
-// the top-level error.code field, and restores the body so downstream
-// consumers still see the full response.  Returns "" on any read or parse
-// failure (fail-open — caller falls back to header heuristics).
-const openAIPeekBytes = 512
+// responseBodyPeekBytes is how much of an upstream error body we read for
+// classification and observability.  Kept small so we never buffer a full
+// multi-megabyte error page into memory on the hot path.
+const responseBodyPeekBytes = 512
 
+type geminiErrorEnvelope struct {
+	Error struct {
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type anthropicErrorEnvelope struct {
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type openAIErrorEnvelope struct {
+	Error struct {
+		Code    string `json:"code"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// peekOpenAIErrorCode reads up to responseBodyPeekBytes from resp.Body,
+// extracts the top-level error.code field, and restores the body so
+// downstream consumers still see the full response.  Returns "" on any read
+// or parse failure (fail-open — caller falls back to header heuristics).
 func peekOpenAIErrorCode(resp *http.Response) string {
-	if resp == nil || resp.Body == nil {
+	return peekOpenAIErrorField(resp, func(e openAIErrorEnvelope) string { return e.Error.Code })
+}
+
+func peekOpenAIErrorField(resp *http.Response, pick func(openAIErrorEnvelope) string) string {
+	buf := peekResponseBodyPrefix(resp)
+	if len(buf) == 0 {
 		return ""
 	}
+	var envelope openAIErrorEnvelope
+	if err := json.Unmarshal(buf, &envelope); err != nil {
+		return ""
+	}
+	return pick(envelope)
+}
+
+func peekGeminiErrorStatus(resp *http.Response) string {
+	return peekGeminiErrorField(resp, func(e geminiErrorEnvelope) string { return e.Error.Status })
+}
+
+func peekGeminiErrorField(resp *http.Response, pick func(geminiErrorEnvelope) string) string {
+	buf := peekResponseBodyPrefix(resp)
+	if len(buf) == 0 {
+		return ""
+	}
+	var envelope geminiErrorEnvelope
+	if err := json.Unmarshal(buf, &envelope); err != nil {
+		return ""
+	}
+	return pick(envelope)
+}
+
+func peekAnthropicErrorType(resp *http.Response) string {
+	buf := peekResponseBodyPrefix(resp)
+	if len(buf) == 0 {
+		return ""
+	}
+	var envelope anthropicErrorEnvelope
+	if err := json.Unmarshal(buf, &envelope); err != nil {
+		return ""
+	}
+	return envelope.Error.Type
+}
+
+func gemini429IsQuota(resp *http.Response) bool {
+	buf := peekResponseBodyPrefix(resp)
+	if len(buf) == 0 {
+		return false
+	}
+	var envelope geminiErrorEnvelope
+	if err := json.Unmarshal(buf, &envelope); err != nil {
+		return false
+	}
+	if envelope.Error.Status != "RESOURCE_EXHAUSTED" {
+		return false
+	}
+	msg := strings.ToLower(envelope.Error.Message)
+	return strings.Contains(msg, "quota")
+}
+
+// peekResponseBodyPrefix reads up to responseBodyPeekBytes from resp.Body
+// and restores the stream so callers can still forward or drain the full
+// body afterward.  Returns nil when resp / Body is nil.
+func peekResponseBodyPrefix(resp *http.Response) []byte {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
 	orig := resp.Body
-	buf, _ := io.ReadAll(io.LimitReader(orig, openAIPeekBytes))
-	// Restore body: stitch what we read back onto the remaining stream.
+	buf, _ := io.ReadAll(io.LimitReader(orig, responseBodyPeekBytes))
 	// Preserve the original Closer so closing resp.Body still releases the
 	// upstream connection (io.NopCloser would swallow Close and leak it).
 	resp.Body = struct {
@@ -138,18 +225,96 @@ func peekOpenAIErrorCode(resp *http.Response) string {
 		Reader: io.MultiReader(bytes.NewReader(buf), orig),
 		Closer: orig,
 	}
+	return buf
+}
+
+// peekUpstreamErrorDetail extracts a compact, provider-aware summary from
+// an upstream error response body for circuit observability logs.  Safe to
+// call before drainResponseBody; the body is restored for subsequent reads.
+func peekUpstreamErrorDetail(provider string, resp *http.Response) string {
+	buf := peekResponseBodyPrefix(resp)
 	if len(buf) == 0 {
 		return ""
 	}
-	var envelope struct {
-		Error struct {
-			Code string `json:"code"`
-		} `json:"error"`
+	return formatUpstreamErrorDetail(provider, buf)
+}
+
+func formatUpstreamErrorDetail(provider string, buf []byte) string {
+	switch provider {
+	case "gemini":
+		return formatGeminiErrorDetail(buf)
+	case "openai":
+		return formatOpenAIErrorDetail(buf)
+	case "anthropic":
+		return formatAnthropicErrorDetail(buf)
+	default:
+		return formatGenericErrorDetail(buf)
 	}
+}
+
+func formatGeminiErrorDetail(buf []byte) string {
+	var envelope geminiErrorEnvelope
 	if err := json.Unmarshal(buf, &envelope); err != nil {
+		return formatGenericErrorDetail(buf)
+	}
+	return joinUpstreamErrorParts(envelope.Error.Status, envelope.Error.Message)
+}
+
+func formatOpenAIErrorDetail(buf []byte) string {
+	var envelope openAIErrorEnvelope
+	if err := json.Unmarshal(buf, &envelope); err != nil {
+		return formatGenericErrorDetail(buf)
+	}
+	kind := envelope.Error.Code
+	if kind == "" {
+		kind = envelope.Error.Type
+	}
+	return joinUpstreamErrorParts(kind, envelope.Error.Message)
+}
+
+func formatAnthropicErrorDetail(buf []byte) string {
+	var envelope anthropicErrorEnvelope
+	if err := json.Unmarshal(buf, &envelope); err != nil {
+		return formatGenericErrorDetail(buf)
+	}
+	return joinUpstreamErrorParts(envelope.Error.Type, envelope.Error.Message)
+}
+
+func formatGenericErrorDetail(buf []byte) string {
+	s := strings.TrimSpace(string(buf))
+	if s == "" {
 		return ""
 	}
-	return envelope.Error.Code
+	if len(s) > maxErrorStringLength {
+		return s[:maxErrorStringLength] + "...(truncated)"
+	}
+	return s
+}
+
+func joinUpstreamErrorParts(kind, message string) string {
+	kind = strings.TrimSpace(kind)
+	message = strings.TrimSpace(message)
+	switch {
+	case kind != "" && message != "":
+		return truncateString(kind + ": " + message)
+	case kind != "":
+		return truncateString(kind)
+	case message != "":
+		return truncateString(message)
+	default:
+		return ""
+	}
+}
+
+// truncateString bounds free-form upstream error text for slog attributes.
+func truncateString(s string) string {
+	if s == "" {
+		return ""
+	}
+	if len(s) > maxErrorStringLength {
+		return s[:maxErrorStringLength] + "...(truncated)"
+	}
+	return s
 }
 
 func classifyGemini(status int, resp *http.Response) FailureClass {
@@ -158,10 +323,10 @@ func classifyGemini(status int, resp *http.Response) FailureClass {
 		return FailureClassDegraded
 	case 504: // DEADLINE_EXCEEDED
 		return FailureClassDegraded
-	case 429: // RESOURCE_EXHAUSTED
-		// Gemini does not expose granular rate-limit headers the way OpenAI
-		// and Anthropic do, so we treat all 429s as localized for now and let
-		// the escalation window promote them to global/degraded if needed.
+	case 429: // RESOURCE_EXHAUSTED — quota vs transient rate limit
+		if gemini429IsQuota(resp) {
+			return FailureClassGlobalRateLimit
+		}
 		return FailureClassLocalRateLimit
 	case 401, 403:
 		return FailureClassNone
@@ -317,6 +482,22 @@ const (
 	// an upstream signal, so it gets its own kind to avoid showing up
 	// next to provider-degradation events on dashboards.
 	KindBodyTooLarge FailureKind = "body_too_large"
+
+	// Provider-specific kinds parsed from upstream JSON error bodies.
+	// Gemini: https://ai.google.dev/gemini-api/docs/troubleshooting
+	KindGeminiUnavailable       FailureKind = "gemini_unavailable"
+	KindGeminiResourceExhausted FailureKind = "gemini_resource_exhausted"
+	KindGeminiInternal          FailureKind = "gemini_internal"
+	KindGeminiDeadlineExceeded  FailureKind = "gemini_deadline_exceeded"
+
+	// Anthropic: https://docs.anthropic.com/en/api/errors
+	KindAnthropicOverloaded      FailureKind = "anthropic_overloaded"
+	KindAnthropicRateLimit       FailureKind = "anthropic_rate_limit"
+	KindAnthropicAPIError        FailureKind = "anthropic_api_error"
+	KindAnthropicTimeout         FailureKind = "anthropic_timeout"
+	KindAnthropicRequestTooLarge FailureKind = "anthropic_request_too_large"
+
+	KindOpenAIInsufficientQuota FailureKind = "openai_insufficient_quota"
 )
 
 // ClassifyFailureKind returns a string label describing the cause of a
@@ -338,6 +519,12 @@ func ClassifyFailureKind(provider string, resp *http.Response, err error) Failur
 	if status < 400 {
 		return KindNone
 	}
+	base := classifyHTTPFailureKind(provider, resp, err)
+	return refineProviderFailureKind(provider, status, resp, base)
+}
+
+func classifyHTTPFailureKind(provider string, resp *http.Response, err error) FailureKind {
+	status := resp.StatusCode
 	switch status {
 	case 500:
 		return KindHTTP500
@@ -350,9 +537,6 @@ func ClassifyFailureKind(provider string, resp *http.Response, err error) Failur
 	case 529:
 		return KindHTTPOverloaded
 	case 429:
-		// Mirror the LocalRateLimit/GlobalRateLimit split from
-		// ClassifyResponse so dashboards can break 429s out from each
-		// other without re-deriving the global/local bucket.
 		fc := ClassifyResponse(provider, resp, err)
 		switch fc {
 		case FailureClassInsufficientQuota:
@@ -367,6 +551,123 @@ func ClassifyFailureKind(provider string, resp *http.Response, err error) Failur
 		return KindHTTP5xxOther
 	}
 	return KindHTTP4xx
+}
+
+func refineProviderFailureKind(provider string, status int, resp *http.Response, base FailureKind) FailureKind {
+	switch provider {
+	case "gemini":
+		return refineGeminiFailureKind(status, resp, base)
+	case "anthropic":
+		return refineAnthropicFailureKind(status, resp, base)
+	case "openai":
+		return refineOpenAIFailureKind(status, resp, base)
+	default:
+		return base
+	}
+}
+
+func refineGeminiFailureKind(status int, resp *http.Response, base FailureKind) FailureKind {
+	switch status {
+	case 503:
+		if peekGeminiErrorStatus(resp) == "UNAVAILABLE" {
+			return KindGeminiUnavailable
+		}
+	case 429:
+		if peekGeminiErrorStatus(resp) == "RESOURCE_EXHAUSTED" {
+			return KindGeminiResourceExhausted
+		}
+	case 500:
+		if peekGeminiErrorStatus(resp) == "INTERNAL" {
+			return KindGeminiInternal
+		}
+	case 504:
+		if peekGeminiErrorStatus(resp) == "DEADLINE_EXCEEDED" {
+			return KindGeminiDeadlineExceeded
+		}
+	}
+	return base
+}
+
+func refineAnthropicFailureKind(status int, resp *http.Response, base FailureKind) FailureKind {
+	errType := peekAnthropicErrorType(resp)
+	switch status {
+	case 529:
+		if errType == "overloaded_error" || errType == "" {
+			return KindAnthropicOverloaded
+		}
+	case 429:
+		if errType == "rate_limit_error" {
+			return KindAnthropicRateLimit
+		}
+	case 500:
+		if errType == "api_error" {
+			return KindAnthropicAPIError
+		}
+	case 504:
+		if errType == "timeout_error" {
+			return KindAnthropicTimeout
+		}
+	case 413:
+		if errType == "request_too_large" {
+			return KindAnthropicRequestTooLarge
+		}
+	}
+	return base
+}
+
+func refineOpenAIFailureKind(status int, resp *http.Response, base FailureKind) FailureKind {
+	if status == 429 && peekOpenAIErrorCode(resp) == "insufficient_quota" {
+		return KindOpenAIInsufficientQuota
+	}
+	return base
+}
+
+// upstreamDetailCode extracts the provider error code/type prefix from a
+// compact upstream_error log value ("CODE: message" → "CODE").
+func upstreamDetailCode(detail string) string {
+	idx := strings.Index(detail, ":")
+	if idx <= 0 {
+		return strings.TrimSpace(detail)
+	}
+	return strings.TrimSpace(detail[:idx])
+}
+
+// refineFailureKindFromUpstreamDetail maps a captured upstream_error string
+// back to a provider-specific FailureKind when the response body has already
+// been drained and ClassifyFailureKind can no longer peek it.
+func refineFailureKindFromUpstreamDetail(provider string, detail string, base FailureKind) FailureKind {
+	code := upstreamDetailCode(detail)
+	switch provider {
+	case "gemini":
+		switch code {
+		case "UNAVAILABLE":
+			return KindGeminiUnavailable
+		case "RESOURCE_EXHAUSTED":
+			return KindGeminiResourceExhausted
+		case "INTERNAL":
+			return KindGeminiInternal
+		case "DEADLINE_EXCEEDED":
+			return KindGeminiDeadlineExceeded
+		}
+	case "anthropic":
+		switch code {
+		case "overloaded_error":
+			return KindAnthropicOverloaded
+		case "rate_limit_error":
+			return KindAnthropicRateLimit
+		case "api_error":
+			return KindAnthropicAPIError
+		case "timeout_error":
+			return KindAnthropicTimeout
+		case "request_too_large":
+			return KindAnthropicRequestTooLarge
+		}
+	case "openai":
+		if code == "insufficient_quota" {
+			return KindOpenAIInsufficientQuota
+		}
+	}
+	return base
 }
 
 // classifyTransportErrorKind is the network-error sibling of

--- a/internal/circuit/classifier_test.go
+++ b/internal/circuit/classifier_test.go
@@ -207,6 +207,56 @@ func TestClassify_Gemini_503(t *testing.T) {
 	}
 }
 
+func TestPeekUpstreamErrorDetail_Gemini_UNAVAILABLE(t *testing.T) {
+	body := `{"error":{"code":503,"message":"The model is overloaded. Please try again later.","status":"UNAVAILABLE"}}`
+	r := respWithBody(503, nil, body)
+	got := peekUpstreamErrorDetail("gemini", r)
+	want := "UNAVAILABLE: The model is overloaded. Please try again later."
+	if got != want {
+		t.Fatalf("peekUpstreamErrorDetail(gemini) = %q, want %q", got, want)
+	}
+	// Body must remain readable after peek.
+	rest, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(rest) != body {
+		t.Fatalf("restored body = %q, want %q", string(rest), body)
+	}
+}
+
+func TestPeekUpstreamErrorDetail_OpenAI_InsufficientQuota(t *testing.T) {
+	body := `{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","code":"insufficient_quota"}}`
+	r := respWithBody(429, nil, body)
+	got := peekUpstreamErrorDetail("openai", r)
+	want := "insufficient_quota: You exceeded your current quota, please check your plan and billing details."
+	if got != want {
+		t.Fatalf("peekUpstreamErrorDetail(openai) = %q, want %q", got, want)
+	}
+}
+
+func TestPeekUpstreamErrorDetail_Anthropic_Overloaded(t *testing.T) {
+	body := `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`
+	r := respWithBody(529, nil, body)
+	got := peekUpstreamErrorDetail("anthropic", r)
+	want := "overloaded_error: Overloaded"
+	if got != want {
+		t.Fatalf("peekUpstreamErrorDetail(anthropic) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatUpstreamErrorDetail_TruncatesLongMessage(t *testing.T) {
+	longMsg := strings.Repeat("x", maxErrorStringLength+50)
+	body := `{"error":{"status":"UNAVAILABLE","message":"` + longMsg + `"}}`
+	got := formatUpstreamErrorDetail("gemini", []byte(body))
+	if !strings.HasSuffix(got, "...(truncated)") {
+		t.Fatalf("expected truncated suffix, got len=%d tail=%q", len(got), got[len(got)-20:])
+	}
+	if len(got) > maxErrorStringLength+len("...(truncated)") {
+		t.Fatalf("truncated detail too long: %d", len(got))
+	}
+}
+
 func TestClassify_Gemini_504_DeadlineExceeded(t *testing.T) {
 	fc := ClassifyResponse("gemini", resp(504, nil), nil)
 	if fc != FailureClassDegraded {
@@ -319,6 +369,44 @@ func TestClassifyResponse_DefaultBranches(t *testing.T) {
 	assert.Equal(t, FailureClassDegraded, ClassifyResponse("gemini", mkResp(599), nil))
 	assert.Equal(t, FailureClassNone, ClassifyResponse("anthropic", mkResp(418), nil))
 	assert.Equal(t, FailureClassNone, ClassifyResponse("gemini", mkResp(418), nil))
+}
+
+func TestRefineFailureKindFromUpstreamDetail(t *testing.T) {
+	detail := "UNAVAILABLE: The model is overloaded."
+	assert.Equal(t, KindGeminiUnavailable, refineFailureKindFromUpstreamDetail("gemini", detail, KindHTTP503))
+	assert.Equal(t, KindAnthropicOverloaded, refineFailureKindFromUpstreamDetail("anthropic", "overloaded_error: Overloaded", KindHTTPOverloaded))
+	assert.Equal(t, KindOpenAIInsufficientQuota, refineFailureKindFromUpstreamDetail("openai", "insufficient_quota: quota", KindHTTP429Quota))
+}
+
+func TestClassifyFailureKind_ProviderSpecific(t *testing.T) {
+	geminiUnavailable := respWithBody(503, nil, `{"error":{"status":"UNAVAILABLE","message":"The model is overloaded."}}`)
+	assert.Equal(t, KindGeminiUnavailable, ClassifyFailureKind("gemini", geminiUnavailable, nil))
+
+	geminiQuota := respWithBody(429, nil, `{"error":{"status":"RESOURCE_EXHAUSTED","message":"You exceeded your current quota, please check your plan."}}`)
+	assert.Equal(t, KindGeminiResourceExhausted, ClassifyFailureKind("gemini", geminiQuota, nil))
+	assert.Equal(t, FailureClassGlobalRateLimit, ClassifyResponse("gemini", geminiQuota, nil))
+
+	geminiRateLimit := respWithBody(429, nil, `{"error":{"status":"RESOURCE_EXHAUSTED","message":"Too many requests per minute"}}`)
+	assert.Equal(t, KindGeminiResourceExhausted, ClassifyFailureKind("gemini", geminiRateLimit, nil))
+	assert.Equal(t, FailureClassLocalRateLimit, ClassifyResponse("gemini", geminiRateLimit, nil))
+
+	anthropicOverloaded := respWithBody(529, nil, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	assert.Equal(t, KindAnthropicOverloaded, ClassifyFailureKind("anthropic", anthropicOverloaded, nil))
+
+	anthropicRateLimit := respWithBody(429, map[string]string{
+		"anthropic-ratelimit-requests-remaining": "10",
+		"anthropic-ratelimit-tokens-remaining":   "0",
+	}, `{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}`)
+	assert.Equal(t, KindAnthropicRateLimit, ClassifyFailureKind("anthropic", anthropicRateLimit, nil))
+
+	anthropicAPIError := respWithBody(500, nil, `{"type":"error","error":{"type":"api_error","message":"Internal error"}}`)
+	assert.Equal(t, KindAnthropicAPIError, ClassifyFailureKind("anthropic", anthropicAPIError, nil))
+
+	anthropicTimeout := respWithBody(504, nil, `{"type":"error","error":{"type":"timeout_error","message":"Request timed out"}}`)
+	assert.Equal(t, KindAnthropicTimeout, ClassifyFailureKind("anthropic", anthropicTimeout, nil))
+
+	openAIQuota := respWithBody(429, nil, `{"error":{"message":"You exceeded your current quota","type":"insufficient_quota","code":"insufficient_quota"}}`)
+	assert.Equal(t, KindOpenAIInsufficientQuota, ClassifyFailureKind("openai", openAIQuota, nil))
 }
 
 func TestClassifyFailureKind_TransportErrors(t *testing.T) {

--- a/internal/circuit/observability_test.go
+++ b/internal/circuit/observability_test.go
@@ -108,7 +108,7 @@ func TestClassifyFailureKind_HTTPStatuses(t *testing.T) {
 		{"502", "anthropic", 502, KindHTTP502},
 		{"503", "gemini", 503, KindHTTP503},
 		{"504", "openai", 504, KindHTTP504},
-		{"529 Anthropic overloaded", "anthropic", 529, KindHTTPOverloaded},
+		{"529 Anthropic overloaded", "anthropic", 529, KindAnthropicOverloaded},
 		{"507 misc 5xx", "openai", 507, KindHTTP5xxOther},
 		{"400 bad request", "openai", 400, KindHTTP4xx},
 		{"401 auth", "anthropic", 401, KindHTTP4xx},
@@ -145,8 +145,8 @@ func TestClassifyFailureKind_429_LocalVsGlobal(t *testing.T) {
 
 	// Quota: OpenAI 429 whose body carries error.code=insufficient_quota.
 	quota := respWithBody(429, nil, `{"error":{"code":"insufficient_quota"}}`)
-	if got := ClassifyFailureKind("openai", quota, nil); got != KindHTTP429Quota {
-		t.Fatalf("insufficient_quota 429 → want %q, got %q", KindHTTP429Quota, got)
+	if got := ClassifyFailureKind("openai", quota, nil); got != KindOpenAIInsufficientQuota {
+		t.Fatalf("insufficient_quota 429 → want %q, got %q", KindOpenAIInsufficientQuota, got)
 	}
 }
 
@@ -438,6 +438,54 @@ func TestEnforce_HandleTerminalFailure_PreservesLastFailureContext(t *testing.T)
 		if _, ok := tags[want]; !ok {
 			t.Fatalf("missing tag %q on circuit.terminal_failure (tags=%v)", want, terminalCalls[0].Tags)
 		}
+	}
+}
+
+func TestEnforce_HandleTerminalFailure_LogsGeminiUpstreamError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := captureLogs(buf)
+
+	geminiBody := `{"error":{"code":503,"message":"The model is overloaded. Please try again later.","status":"UNAVAILABLE"}}`
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     http.StatusText(http.StatusServiceUnavailable),
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(geminiBody)),
+		}, nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeEnforce,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(
+		inner, store, cfg, "gemini", log,
+		WithModelExtractor(fakeModelFn("gemini-2.5-flash-lite")),
+	)
+
+	resp, err := tr.RoundTrip(dummyOpenAIRequest("gemini-2.5-flash-lite"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+	resp.Body.Close()              //nolint:errcheck
+
+	terminalEntry := findLogLine(t, buf, "terminal failure, returning degraded signal")
+	if terminalEntry == nil {
+		t.Fatalf("expected terminal failure log line; got %s", buf.String())
+	}
+	got, _ := terminalEntry["upstream_error"].(string)
+	want := "UNAVAILABLE: The model is overloaded. Please try again later."
+	if got != want {
+		t.Fatalf("terminal failure upstream_error = %q, want %q", got, want)
+	}
+	if gotKind, _ := terminalEntry["failure_kind"].(string); gotKind != string(KindGeminiUnavailable) {
+		t.Fatalf("terminal failure failure_kind = %q, want %q", gotKind, KindGeminiUnavailable)
 	}
 }
 

--- a/internal/circuit/options.go
+++ b/internal/circuit/options.go
@@ -98,8 +98,8 @@ type ActivityRecorder interface {
 	RecordFastFail(provider, key string)
 	RecordProbe(provider, key string)
 	RecordProbeClosed(provider, key string, statusCode int)
-	RecordProbeReopened(provider, key string, statusCode int, failureKind string)
-	RecordOpened(provider, key, reason string)
+	RecordProbeReopened(provider, key string, statusCode int, failureKind, upstreamError string)
+	RecordOpened(provider, key, reason, failureKind, upstreamError string, statusCode int)
 }
 
 // WithActivityRecorder wires dashboard activity counters/events. Pass nil to

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -107,16 +107,22 @@ const maxErrorStringLength = 256
 // bare `<provider>` fallback) so operators can correlate a log line to a
 // specific Redis hash.  It always equals provider + ":" + model when both
 // are set; we precompute it once instead of inferring it at log time.
+//
+// UpstreamError carries a compact parse of the upstream JSON error body
+// (e.g. Gemini status=UNAVAILABLE, OpenAI code=insufficient_quota).
+// Populated before the response body is drained; omitted from metric tags
+// because message text is high-cardinality.
 type failureContext struct {
-	Provider    string
-	Model       string
-	CBKey       string
-	Caller      string
-	Path        string
-	Method      string
-	StatusCode  int
-	Kind        FailureKind
-	ErrorString string
+	Provider      string
+	Model         string
+	CBKey         string
+	Caller        string
+	Path          string
+	Method        string
+	StatusCode    int
+	Kind          FailureKind
+	ErrorString   string
+	UpstreamError string
 }
 
 // newFailureContext builds the canonical context for a failure event.
@@ -218,10 +224,34 @@ func (fc failureContext) withKind(k FailureKind) failureContext {
 	return fc
 }
 
+func (fc failureContext) withUpstreamError(detail string) failureContext {
+	fc.UpstreamError = truncateString(detail)
+	return fc
+}
+
+// enrichedFailureContext builds failureContext and attaches an upstream
+// error summary.  When capturedDetail is empty and resp.Body is still
+// readable, the detail is peeked from the response body.
+func (t *Transport) enrichedFailureContext(req *http.Request, resp *http.Response, err error, capturedDetail string) failureContext {
+	fc := t.newFailureContext(req, resp, err)
+	if capturedDetail != "" {
+		fc = fc.withUpstreamError(capturedDetail)
+		fc.Kind = refineFailureKindFromUpstreamDetail(t.provider, capturedDetail, fc.Kind)
+		return fc
+	}
+	if err == nil && resp != nil && resp.StatusCode >= 400 && resp.Body != nil {
+		if detail := peekUpstreamErrorDetail(t.provider, resp); detail != "" {
+			fc = fc.withUpstreamError(detail)
+			fc.Kind = refineFailureKindFromUpstreamDetail(t.provider, detail, fc.Kind)
+		}
+	}
+	return fc
+}
+
 // attrs returns a slog-friendly attribute slice with a stable schema.
 // The exact field set is documented on failureContext above.
 func (fc failureContext) attrs() []any {
-	return []any{
+	attrs := []any{
 		"provider", fc.Provider,
 		"model", fc.Model,
 		"cb_key", fc.CBKey,
@@ -232,6 +262,10 @@ func (fc failureContext) attrs() []any {
 		"failure_kind", string(fc.Kind),
 		"error", fc.ErrorString,
 	}
+	if fc.UpstreamError != "" {
+		attrs = append(attrs, "upstream_error", fc.UpstreamError)
+	}
+	return attrs
 }
 
 // metricTags returns the dogstatsd tag set matching attrs().
@@ -704,7 +738,7 @@ func (t *Transport) runObserveOnly(req *http.Request) (*http.Response, error) {
 				"key", key, "error", recErr)
 		}
 		t.maybeRecordRollup(ctx, key, openedNow)
-		fc := t.newFailureContext(req, resp, err)
+		fc := t.enrichedFailureContext(req, resp, err, "")
 		t.log.Info("circuit: log-mode terminal_failure_observed (no synthetic response, passing through)",
 			append(
 				fc.attrs(),
@@ -714,12 +748,12 @@ func (t *Transport) runObserveOnly(req *http.Request) (*http.Response, error) {
 		t.emit("terminal_failure", fc)
 
 	case FailureClassGlobalRateLimit:
-		fc := t.newFailureContext(req, resp, err)
+		fc := t.enrichedFailureContext(req, resp, err, "")
 		t.log.Info("circuit: log-mode global_rate_limit_observed (passing through)", fc.attrs()...)
 		t.emit("global_rate_limit", fc)
 
 	case FailureClassLocalRateLimit:
-		fc := t.newFailureContext(req, resp, err)
+		fc := t.enrichedFailureContext(req, resp, err, "")
 		t.log.Info("circuit: log-mode local_rate_limit_observed (passing through)", fc.attrs()...)
 		t.emit("local_rate_limit", fc)
 	}
@@ -819,7 +853,7 @@ func (t *Transport) runBypass(req *http.Request, reason string) (*http.Response,
 	upstreamDur := time.Since(rtStart)
 
 	class := ClassifyResponse(t.provider, resp, err)
-	fc := t.newFailureContext(req, resp, err)
+	fc := t.enrichedFailureContext(req, resp, err, "")
 	tags := append(fc.metricTags(), "reason:"+reasonTag, "outcome:"+string(class))
 	if t.metrics != nil {
 		_ = t.metrics.Incr("circuit.bypass", tags, 1.0)
@@ -1013,7 +1047,8 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 		// rollup window, at which point traffic is allowed through to re-probe;
 		// if quota is still exhausted the next failure re-arms it.
 		if fc == FailureClassInsufficientQuota {
-			evt := t.newFailureContext(req, resp, err)
+			upstreamDetail := peekUpstreamErrorDetail(t.provider, resp)
+			evt := t.enrichedFailureContext(req, resp, err, upstreamDetail)
 			// Open the BARE-provider breaker so every OpenAI model fast-fails
 			// until recovery.  ForceOpen uses one cooldown period, after which
 			// the breaker auto-promotes to HalfOpen and a single probe re-tests
@@ -1024,7 +1059,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 				t.log.Warn("circuit: ForceOpen (insufficient_quota) error",
 					"provider", t.provider, "error", fErr)
 			} else if t.activity != nil {
-				t.activity.RecordOpened(t.provider, t.provider, "insufficient_quota")
+				t.activity.RecordOpened(t.provider, t.provider, "insufficient_quota", string(evt.Kind), evt.UpstreamError, evt.StatusCode)
 			}
 			t.log.Warn("circuit: insufficient_quota — forcing provider open, passing upstream response through",
 				append(evt.attrs(),
@@ -1034,9 +1069,10 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 			return resp, err
 		}
 
-		// Capture before drain so emitFailureMetric / failureAttrs see
-		// the real upstream status.  Note: lastResp.Body is not safe to
-		// read after the drain below, but lastResp.StatusCode is.
+		// Capture before drain so failure logs retain the upstream error
+		// body (Gemini UNAVAILABLE, OpenAI insufficient_quota, etc.).
+		// lastResp.Body is not safe to read after the drain below.
+		upstreamDetail := peekUpstreamErrorDetail(t.provider, resp)
 		lastResp = resp
 		lastErr = err
 
@@ -1054,6 +1090,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 				firstRateLimitAt:  firstRateLimitAt,
 				lastResp:          lastResp,
 				lastErr:           lastErr,
+				lastUpstreamError: upstreamDetail,
 			}
 			resp2, err2, done := t.handleRateLimitFailure(ctx, req, key, fc, retryAfterSec, st)
 			rateLimitAttempts = st.rateLimitAttempts
@@ -1081,6 +1118,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 				transientAttempts: transientAttempts,
 				lastResp:          lastResp,
 				lastErr:           lastErr,
+				lastUpstreamError: upstreamDetail,
 			}
 			resp2, err2, done := t.handleDegradedFailure(ctx, req, key, resp, err, st)
 			transientAttempts = st.transientAttempts
@@ -1108,6 +1146,7 @@ type retryLoopState struct {
 	firstRateLimitAt  time.Time
 	lastResp          *http.Response // post-drain — only StatusCode / Header safe
 	lastErr           error
+	lastUpstreamError string // parsed from body before drain
 }
 
 // handleRateLimitFailure runs the rate-limit branch of runWithRetries.
@@ -1131,7 +1170,7 @@ func (t *Transport) handleRateLimitFailure(
 	st *retryLoopState,
 ) (*http.Response, error, bool) {
 	if st.rateLimitAttempts >= t.cfg.MaxRateLimitRetries {
-		evt := t.newFailureContext(req, st.lastResp, st.lastErr)
+		evt := t.enrichedFailureContext(req, st.lastResp, st.lastErr, st.lastUpstreamError)
 		t.log.Warn("circuit: rate-limit retries exhausted",
 			append(
 				evt.attrs(),
@@ -1146,7 +1185,7 @@ func (t *Transport) handleRateLimitFailure(
 			if int(elapsed) >= t.cfg.GlobalRateLimitEscalationWindow {
 				t.log.Warn("circuit: global rate-limit escalated to provider_degraded",
 					append(evt.attrs(), "elapsed_seconds", elapsed)...)
-				resp, err := t.handleTerminalFailure(ctx, req, key, st.lastResp, st.lastErr)
+				resp, err := t.handleTerminalFailure(ctx, req, key, st.lastResp, st.lastErr, st.lastUpstreamError)
 				return resp, err, true
 			}
 		}
@@ -1192,21 +1231,21 @@ func (t *Transport) handleDegradedFailure(
 	switch t.cfg.RetryContributionMode {
 	case "on":
 		t.log.Info("circuit: retried failure contributing to degradation score",
-			append(t.newFailureContext(req, resp, err).attrs(),
+			append(t.enrichedFailureContext(req, resp, err, st.lastUpstreamError).attrs(),
 				"attempt", st.transientAttempts)...)
 		_, openedNow, _ := t.store.RecordTerminalFailure(ctx, key)
 		t.maybeRecordRollup(ctx, key, openedNow)
 	case "log":
 		t.log.Info("circuit: retried failure would_have_contributed_to_degradation",
-			append(t.newFailureContext(req, resp, err).attrs(),
+			append(t.enrichedFailureContext(req, resp, err, st.lastUpstreamError).attrs(),
 				"attempt", st.transientAttempts)...)
 	}
 
 	if st.transientAttempts >= t.cfg.MaxTransientRetries {
 		t.log.Warn("circuit: transient retries exhausted, recording terminal failure",
-			append(t.newFailureContext(req, st.lastResp, st.lastErr).attrs(),
+			append(t.enrichedFailureContext(req, st.lastResp, st.lastErr, st.lastUpstreamError).attrs(),
 				"attempts", st.transientAttempts)...)
-		respT, errT := t.handleTerminalFailure(ctx, req, key, st.lastResp, st.lastErr)
+		respT, errT := t.handleTerminalFailure(ctx, req, key, st.lastResp, st.lastErr, st.lastUpstreamError)
 		return respT, errT, true
 	}
 
@@ -1335,7 +1374,7 @@ func (t *Transport) runProbe(req *http.Request, key string) (*http.Response, err
 		errors.Is(err, context.DeadlineExceeded) {
 		t.log.Info("circuit: probe aborted by caller context, releasing probe slot without state change",
 			append(
-				t.newFailureContext(req, resp, err).attrs(),
+				t.enrichedFailureContext(req, resp, err, "").attrs(),
 				"ctx_err", truncateError(ctxErr),
 			)...)
 		drainResponseBody(resp)
@@ -1431,7 +1470,11 @@ func (t *Transport) recordProbeSuccess(ctx context.Context, req *http.Request, r
 // outage stays tripped instead of aging out after the original
 // Closed → Open event expires.
 func (t *Transport) recordProbeFailure(ctx context.Context, req *http.Request, resp *http.Response, err error, key string) (*http.Response, error) {
-	evt := t.newFailureContext(req, resp, err)
+	upstreamDetail := ""
+	if resp != nil {
+		upstreamDetail = peekUpstreamErrorDetail(t.provider, resp)
+	}
+	evt := t.enrichedFailureContext(req, resp, err, upstreamDetail)
 	t.log.Warn("circuit: probe failed, re-opening circuit",
 		append(evt.attrs(), "new_state", StateOpen.String())...)
 	t.emit("probe_failed", evt)
@@ -1440,7 +1483,7 @@ func (t *Transport) recordProbeFailure(ctx context.Context, req *http.Request, r
 		if resp != nil {
 			status = resp.StatusCode
 		}
-		t.activity.RecordProbeReopened(t.provider, key, status, string(evt.Kind))
+		t.activity.RecordProbeReopened(t.provider, key, status, string(evt.Kind), evt.UpstreamError)
 	}
 	drainResponseBody(resp)
 	_ = t.store.RecordProbeFailed(ctx, key)
@@ -1455,23 +1498,19 @@ func (t *Transport) recordProbeFailure(ctx context.Context, req *http.Request, r
 // drain — only StatusCode / Header are safe to read on lastResp) so the
 // emitted log line and dogstatsd counter retain status_code, model,
 // failure_kind, and error context that would otherwise be lost between
-// retry exhaustion and synthetic-response emission.
-//
-// `key` is the per-request breaker key threaded down from runWithRetries
-// so this call lands on the same per-model state machine that the
-// retry loop just exercised; recomputing it here would risk an
-// extractor drift between the two call sites.
-func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request, key string, lastResp *http.Response, lastErr error) (*http.Response, error) {
+// retry exhaustion and synthetic-response emission.  upstreamError was
+// parsed from the response body before drain.
+func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request, key string, lastResp *http.Response, lastErr error, upstreamError string) (*http.Response, error) {
+	evt := t.enrichedFailureContext(req, lastResp, lastErr, upstreamError)
 	newState, openedNow, err := t.store.RecordTerminalFailure(ctx, key)
 	if err != nil {
 		t.log.Error("circuit: RecordTerminalFailure error", "key", key, "error", err)
 	}
 	if openedNow && t.activity != nil {
-		t.activity.RecordOpened(t.provider, key, "threshold")
+		t.activity.RecordOpened(t.provider, key, "threshold", string(evt.Kind), evt.UpstreamError, evt.StatusCode)
 	}
 	t.maybeRecordRollup(ctx, key, openedNow)
 
-	evt := t.newFailureContext(req, lastResp, lastErr)
 	attrs := append(
 		evt.attrs(),
 		"new_state", newState.String(),

--- a/internal/circuitstats/redis_test.go
+++ b/internal/circuitstats/redis_test.go
@@ -28,7 +28,7 @@ func TestRedisRecorder_ProbeLifecycle(t *testing.T) {
 	r.RecordProbe("openai", "openai")
 	r.RecordProbeClosed("openai", "openai", 200)
 	r.RecordProbe("openai", "openai:gpt-4o")
-	r.RecordProbeReopened("openai", "openai:gpt-4o", 429, "http_429_quota")
+	r.RecordProbeReopened("openai", "openai:gpt-4o", 429, "http_429_quota", "")
 
 	// Allow async check increments to settle if any were fired.
 	time.Sleep(10 * time.Millisecond)

--- a/internal/circuitstats/stats.go
+++ b/internal/circuitstats/stats.go
@@ -27,14 +27,15 @@ const (
 )
 
 type activityEvent struct {
-	Time        int64  `json:"time"`
-	Provider    string `json:"provider"`
-	Key         string `json:"key,omitempty"`
-	Kind        string `json:"kind"`
-	NewState    string `json:"new_state,omitempty"`
-	StatusCode  int    `json:"status_code,omitempty"`
-	FailureKind string `json:"failure_kind,omitempty"`
-	Reason      string `json:"reason,omitempty"`
+	Time          int64  `json:"time"`
+	Provider      string `json:"provider"`
+	Key           string `json:"key,omitempty"`
+	Kind          string `json:"kind"`
+	NewState      string `json:"new_state,omitempty"`
+	StatusCode    int    `json:"status_code,omitempty"`
+	FailureKind   string `json:"failure_kind,omitempty"`
+	UpstreamError string `json:"upstream_error,omitempty"`
+	Reason        string `json:"reason,omitempty"`
 }
 
 type activityFlushed struct {
@@ -257,14 +258,15 @@ func (r *Recorder) RecordProbeClosed(provider, key string, statusCode int) {
 }
 
 // RecordProbeReopened records a failed half-open probe (circuit open again).
-func (r *Recorder) RecordProbeReopened(provider, key string, statusCode int, failureKind string) {
+func (r *Recorder) RecordProbeReopened(provider, key string, statusCode int, failureKind, upstreamError string) {
 	e := activityEvent{
-		Provider:    provider,
-		Key:         key,
-		Kind:        EventProbeReopened,
-		NewState:    "open",
-		StatusCode:  statusCode,
-		FailureKind: failureKind,
+		Provider:      provider,
+		Key:           key,
+		Kind:          EventProbeReopened,
+		NewState:      "open",
+		StatusCode:    statusCode,
+		FailureKind:   failureKind,
+		UpstreamError: upstreamError,
 	}
 	r.recordActivity("probes_failed", provider, e, func() {
 		r.probesFailed++
@@ -272,13 +274,16 @@ func (r *Recorder) RecordProbeReopened(provider, key string, statusCode int, fai
 }
 
 // RecordOpened records a circuit trip (failure threshold or force-open).
-func (r *Recorder) RecordOpened(provider, key, reason string) {
+func (r *Recorder) RecordOpened(provider, key, reason, failureKind, upstreamError string, statusCode int) {
 	e := activityEvent{
-		Provider: provider,
-		Key:      key,
-		Kind:     EventOpened,
-		NewState: "open",
-		Reason:   reason,
+		Provider:      provider,
+		Key:           key,
+		Kind:          EventOpened,
+		NewState:      "open",
+		Reason:        reason,
+		FailureKind:   failureKind,
+		UpstreamError: upstreamError,
+		StatusCode:    statusCode,
 	}
 	r.recordActivity("circuits_opened", provider, e, func() {
 		r.circuitsOpened++

--- a/internal/circuitstats/stats_test.go
+++ b/internal/circuitstats/stats_test.go
@@ -12,7 +12,7 @@ func TestRecorder_ProbeLifecycle(t *testing.T) {
 	r.RecordProbe("openai", "openai")
 	r.RecordProbeClosed("openai", "openai", 200)
 	r.RecordProbe("openai", "openai:gpt-4o")
-	r.RecordProbeReopened("openai", "openai:gpt-4o", 429, "http_429_quota")
+	r.RecordProbeReopened("openai", "openai:gpt-4o", 429, "http_429_quota", "insufficient_quota: quota exceeded")
 
 	snap := r.Snapshot()
 	require.Equal(t, true, snap["available"])
@@ -23,6 +23,7 @@ func TestRecorder_ProbeLifecycle(t *testing.T) {
 	events, ok := snap["recent_events"].([]activityEvent)
 	require.True(t, ok)
 	require.Len(t, events, 4)
+	assert.Equal(t, "insufficient_quota: quota exceeded", events[0].UpstreamError)
 	assert.Equal(t, EventProbeReopened, events[0].Kind)
 	assert.Equal(t, "open", events[0].NewState)
 	assert.Equal(t, EventProbe, events[1].Kind)
@@ -38,7 +39,7 @@ func TestRecorder_FastFailAndOpened(t *testing.T) {
 	r.RecordFastFail("gemini", "gemini:gemini-2.5-flash-lite")
 	r.RecordFastFail("gemini", "gemini:gemini-2.5-flash-lite")
 	r.RecordFastFail("openai", "openai")
-	r.RecordOpened("openai", "openai", "insufficient_quota")
+	r.RecordOpened("openai", "openai", "insufficient_quota", "openai_insufficient_quota", "insufficient_quota: quota exceeded", 429)
 
 	snap := r.Snapshot()
 	assert.Equal(t, int64(2), snap["checks_total"])

--- a/web/src/components/tables/misc-tables.tsx
+++ b/web/src/components/tables/misc-tables.tsx
@@ -322,6 +322,9 @@ export function CircuitActivityTable({
             <span className="text-xs text-base-content/70">
               {e.status_code ? `HTTP ${e.status_code}` : null}
               {e.failure_kind ? ` ${e.failure_kind}` : null}
+              {e.upstream_error ? (
+                <span className="block text-base-content/60">{e.upstream_error}</span>
+              ) : null}
               {e.reason ? e.reason : null}
               {scope === "model" && e.key ? (
                 <span className="block font-mono text-base-content/50">{e.key}</span>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -178,6 +178,7 @@ export interface CircuitActivityEvent {
   new_state?: string;
   status_code?: number;
   failure_kind?: string;
+  upstream_error?: string;
   reason?: string;
 }
 


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

- Adds `upstream_error` to circuit failure logs (Datadog) by peeking upstream JSON bodies before drain — works for **Gemini, OpenAI, and Anthropic**, not Google-only
- Introduces provider-specific `failure_kind` labels parsed from official error codes:
  - **Gemini:** `gemini_unavailable` (503/UNAVAILABLE), `gemini_resource_exhausted` (429/RESOURCE_EXHAUSTED), `gemini_internal`, `gemini_deadline_exceeded`
  - **Anthropic:** `anthropic_overloaded` (529/overloaded_error), `anthropic_rate_limit` (429/rate_limit_error), `anthropic_api_error`, `anthropic_timeout`, `anthropic_request_too_large`
  - **OpenAI:** `openai_insufficient_quota` (429/insufficient_quota)
- Gemini 429s with quota-exhaustion messages now classify as global rate limit (not just local)
- Admin circuit activity feed shows `upstream_error` on open/probe events
- **No breaker behavior change** — classification thresholds and retry logic unchanged; this is observability only

## Example log fields after deploy

```
failure_kind=gemini_unavailable
upstream_error="UNAVAILABLE: The model is overloaded. Please try again later."
```

## Test plan

- [x] `go test -race ./internal/circuit/... ./internal/circuitstats/...`
- [x] `make test`
- [ ] Deploy to staging/prod and confirm Datadog `llm-proxy` logs show `upstream_error` on circuit terminal failures
- [ ] Confirm admin circuit activity table shows upstream detail on threshold-crossed events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific failure detection for OpenAI, Gemini, and Anthropic to better distinguish quota exhaustion, rate limits, and overload conditions.
  * Enhanced error detail extraction from upstream responses to provide more actionable error information in logs and activity records.

* **Improvements**
  * Circuit activity table now displays upstream error details alongside other failure information.
  * Improved observability with more granular, provider-aware error classification in logs and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->