### PR TITLE
feat(admin): allow admins to create personal keys

### DIFF
--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -148,8 +148,11 @@ func (h *handler) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if role == adminusers.RoleViewer {
-		if err := h.validateViewerPersonalCreate(r, &req, user.Email); err != nil {
+	// Viewers always create personal keys; higher roles may opt in via the
+	// "personal" flag so an admin can mint a personal testing key for themselves.
+	wantsPersonal := role == adminusers.RoleViewer || req.Personal
+	if wantsPersonal {
+		if err := h.validatePersonalCreate(r, &req, user.Email); err != nil {
 			if errors.Is(err, apikeys.ErrOwnerKeyExists) {
 				writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
 				return

--- a/internal/admin/keys_access.go
+++ b/internal/admin/keys_access.go
@@ -64,10 +64,10 @@ func validateProvisionedKeyOnly(role adminusers.Role, req *CreateKeyRequest) err
 	return nil
 }
 
-func (h *handler) validateViewerPersonalCreate(r *http.Request, req *CreateKeyRequest, userEmail string) error {
+func (h *handler) validatePersonalCreate(r *http.Request, req *CreateKeyRequest, userEmail string) error {
 	req.Provider = strings.ToLower(strings.TrimSpace(req.Provider))
 	if !isViewerPersonalProvider(req.Provider) {
-		return fmt.Errorf("viewers may only create personal keys for openai, anthropic, or gemini")
+		return fmt.Errorf("personal keys may only be created for openai, anthropic, or gemini")
 	}
 	if err := validateProvisionedKeyOnly(adminusers.RoleViewer, req); err != nil {
 		return err

--- a/internal/admin/keys_handlers_test.go
+++ b/internal/admin/keys_handlers_test.go
@@ -335,6 +335,34 @@ func TestViewerPersonalKeys(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, delRec.Code)
 }
 
+func TestAdminCreatePersonalKey(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	h.deps.YAMLConfig.Features.AdminDashboard.ViewerLimits.PersonalMonthlyCostLimitCents = 1000
+	withTestProvisioner(t, h, "openai")
+
+	body, _ := json.Marshal(CreateKeyRequest{
+		Provider:      "openai",
+		Description:   "my personal key",
+		AutoProvision: true,
+		Personal:      true,
+	})
+	createReq := authenticatedRequestAs(t, h, "admin@example.com", http.MethodPost, "/admin/api/keys", body)
+	createRec := httptest.NewRecorder()
+	h.handleCreateKey(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code, createRec.Body.String())
+
+	var created KeyResponse
+	require.NoError(t, json.NewDecoder(createRec.Body).Decode(&created))
+	assert.Equal(t, int64(1000), created.MonthlyCostLimit)
+	assert.Equal(t, "admin@example.com", created.OwnerEmail)
+	assert.Equal(t, int64(0), created.DailyCostLimit)
+
+	dupReq := authenticatedRequestAs(t, h, "admin@example.com", http.MethodPost, "/admin/api/keys", body)
+	dupRec := httptest.NewRecorder()
+	h.handleCreateKey(dupRec, dupReq)
+	assert.Equal(t, http.StatusConflict, dupRec.Code)
+}
+
 func TestEditorCreateKeyRequiresAutoProvision(t *testing.T) {
 	h, _ := testAdminHandler(t)
 	ctx := context.Background()

--- a/internal/admin/types.go
+++ b/internal/admin/types.go
@@ -81,6 +81,7 @@ type CreateKeyRequest struct {
 	Provider       string            `json:"provider"`
 	ActualKey      string            `json:"actual_key,omitempty"`
 	AutoProvision  bool              `json:"auto_provision,omitempty"`
+	Personal       bool              `json:"personal,omitempty"`
 	Description    string            `json:"description,omitempty"`
 	DailyCostLimit int64             `json:"daily_cost_limit"`
 	Tags           map[string]string `json:"tags,omitempty"`

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -10,8 +10,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <script type="module" crossorigin src="/admin/assets/index-DHMnEEwk.js"></script>
-  <link rel="stylesheet" crossorigin href="/admin/assets/index-BA41Fzl8.css">
+  <script type="module" crossorigin src="/admin/assets/index-q7YeGxQs.js"></script>
+  <link rel="stylesheet" crossorigin href="/admin/assets/index-DFC4ijMe.css">
 </head>
 
 <body>

--- a/web/src/pages/keys/index.tsx
+++ b/web/src/pages/keys/index.tsx
@@ -99,9 +99,11 @@ function parseLimitField(value: string): number {
 function formatRateLimits(record: APIKey): string {
   const parts: string[] = [];
   if (record.rate_limit_rpm) parts.push(`${record.rate_limit_rpm} rpm`);
-  if (record.rate_limit_tpm) parts.push(`${record.rate_limit_tpm.toLocaleString()} tpm`);
+  if (record.rate_limit_tpm)
+    parts.push(`${record.rate_limit_tpm.toLocaleString()} tpm`);
   if (record.rate_limit_rpd) parts.push(`${record.rate_limit_rpd} rpd`);
-  if (record.rate_limit_tpd) parts.push(`${record.rate_limit_tpd.toLocaleString()} tpd`);
+  if (record.rate_limit_tpd)
+    parts.push(`${record.rate_limit_tpd.toLocaleString()} tpd`);
   return parts.length ? parts.join(" · ") : "—";
 }
 
@@ -119,14 +121,19 @@ export default function KeysPage() {
   const { data: me } = useMe();
   const { data: config } = useConfig();
   const globalPiiEnabled = Boolean(config?.features?.pii_redact);
-  const canBypassPiiBedrockPolicy = Boolean(me?.can_bypass_pii_off_non_bedrock_policy);
+  const canBypassPiiBedrockPolicy = Boolean(
+    me?.can_bypass_pii_off_non_bedrock_policy,
+  );
   const isViewer = me?.role === "viewer";
   const isAdmin = me?.role === "admin";
   const provisionedKeysOnly = !isAdmin;
   const canDeleteKeys = isViewer || me?.role === "admin";
-  const viewerMonthlyCents = me?.viewer_limits?.personal_monthly_cost_limit_cents ?? 1000;
+  const viewerMonthlyCents =
+    me?.viewer_limits?.personal_monthly_cost_limit_cents ?? 1000;
   const viewerMonthlyLimitLabel =
-    viewerMonthlyCents > 0 ? `$${(viewerMonthlyCents / 100).toFixed(2)}` : "Unlimited";
+    viewerMonthlyCents > 0
+      ? `$${(viewerMonthlyCents / 100).toFixed(2)}`
+      : "Unlimited";
   const editorMaxCents = me?.editor_limits?.max_daily_cost_limit_cents ?? 0;
   const editorMaxDollars = editorMaxCents > 0 ? editorMaxCents / 100 : null;
   const bulkKeyDescription = me?.email?.split("@")[0]?.trim() ?? "";
@@ -136,7 +143,10 @@ export default function KeysPage() {
   const [editingKey, setEditingKey] = useState<APIKey | null>(null);
   const [form, setForm] = useState<KeyFormState>(defaultForm);
   const [manualKeyEntry, setManualKeyEntry] = useState(false);
-  const [shareResult, setShareResult] = useState<ShareCreateResponse | null>(null);
+  const [personalMode, setPersonalMode] = useState(false);
+  const [shareResult, setShareResult] = useState<ShareCreateResponse | null>(
+    null,
+  );
   const [sharingKey, setSharingKey] = useState<string | null>(null);
   const [bulkGenerating, setBulkGenerating] = useState(false);
 
@@ -159,7 +169,12 @@ export default function KeysPage() {
   const anthropicDefaultTier = anthropicProvisioning?.default_tier ?? "metered";
 
   useEffect(() => {
-    if (!modalOpen || editingKey || form.provider !== "anthropic" || anthropicTierOptions.length === 0) {
+    if (
+      !modalOpen ||
+      editingKey ||
+      form.provider !== "anthropic" ||
+      anthropicTierOptions.length === 0
+    ) {
       return;
     }
     if (anthropicTierOptions.includes(form.anthropic_tier)) {
@@ -169,14 +184,43 @@ export default function KeysPage() {
       ...current,
       anthropic_tier: anthropicDefaultTier,
     }));
-  }, [modalOpen, editingKey, form.provider, form.anthropic_tier, anthropicTierOptions, anthropicDefaultTier]);
+  }, [
+    modalOpen,
+    editingKey,
+    form.provider,
+    form.anthropic_tier,
+    anthropicTierOptions,
+    anthropicDefaultTier,
+  ]);
 
   useEffect(() => {
-    if (!modalOpen || editingKey || !piiOffRequiresBedrock || form.provider === "bedrock") {
+    if (
+      !modalOpen ||
+      editingKey ||
+      !piiOffRequiresBedrock ||
+      form.provider === "bedrock"
+    ) {
       return;
     }
     setForm((current) => ({ ...current, provider: "bedrock" }));
   }, [modalOpen, editingKey, piiOffRequiresBedrock, form.provider]);
+
+  const treatAsPersonal = isViewer || (personalMode && !editingKey);
+
+  const myPersonalProviders = useMemo(() => {
+    const set = new Set<Provider>();
+    const email = me?.email?.toLowerCase();
+    if (!email) return set;
+    for (const k of keys) {
+      if (
+        k.tags?.personal === "true" &&
+        k.owner_email?.toLowerCase() === email
+      ) {
+        set.add(k.provider);
+      }
+    }
+    return set;
+  }, [keys, me?.email]);
 
   const availableProviders = useMemo(() => {
     let providers: Provider[];
@@ -185,16 +229,32 @@ export default function KeysPage() {
       providers = VIEWER_PROVIDERS.filter(
         (p) => !owned.has(p) || p === editingKey?.provider,
       );
+    } else if (personalMode) {
+      providers = VIEWER_PROVIDERS.filter((p) => !myPersonalProviders.has(p));
     } else if (!piiOffRequiresBedrock) {
       providers = [...PROVIDERS];
     } else {
       providers = ["bedrock"];
     }
+    if ((isViewer || personalMode) && provisioning?.enabled) {
+      return providers.filter(
+        (p) => provisioning.providers?.[p]?.auto_provision,
+      );
+    }
     if (!provisionedKeysOnly || !provisioning?.enabled) {
       return providers;
     }
     return providers.filter((p) => provisioning.providers?.[p]?.auto_provision);
-  }, [isViewer, keys, editingKey?.provider, piiOffRequiresBedrock, provisionedKeysOnly, provisioning]);
+  }, [
+    isViewer,
+    personalMode,
+    keys,
+    editingKey?.provider,
+    myPersonalProviders,
+    piiOffRequiresBedrock,
+    provisionedKeysOnly,
+    provisioning,
+  ]);
 
   const canCreateKey = availableProviders.length > 0;
 
@@ -206,17 +266,37 @@ export default function KeysPage() {
     return availableProviders.filter((provider) => !owned.has(provider));
   }, [provisionedKeysOnly, keys, availableProviders]);
 
-  const canBulkGeneratePersonalKeys =
-    provisionedKeysOnly && missingProvidersForBulk.length > 0;
+  const missingPersonalProvidersForBulk = useMemo(() => {
+    if (!provisioning?.enabled) {
+      return [];
+    }
+    return VIEWER_PROVIDERS.filter(
+      (provider) =>
+        provisioning.providers?.[provider]?.auto_provision &&
+        !myPersonalProviders.has(provider),
+    );
+  }, [provisioning, myPersonalProviders]);
+
+  const bulkTargetProviders = isViewer
+    ? missingProvidersForBulk
+    : isAdmin
+      ? missingPersonalProvidersForBulk
+      : missingProvidersForBulk;
+
+  const canBulkGeneratePersonalKeys = bulkTargetProviders.length > 0;
 
   const providerAutoProvision = Boolean(
-    provisioning?.enabled && provisioning.providers?.[form.provider]?.auto_provision,
+    provisioning?.enabled &&
+    provisioning.providers?.[form.provider]?.auto_provision,
   );
-  const useAutoProvision = provisionedKeysOnly
-    ? providerAutoProvision
-    : providerAutoProvision && !manualKeyEntry;
+  const useAutoProvision =
+    treatAsPersonal || provisionedKeysOnly
+      ? providerAutoProvision
+      : providerAutoProvision && !manualKeyEntry;
   const showAnthropicTierSelect =
-    form.provider === "anthropic" && useAutoProvision && anthropicTierOptions.length > 0;
+    form.provider === "anthropic" &&
+    useAutoProvision &&
+    anthropicTierOptions.length > 0;
 
   const onShare = async (record: APIKey) => {
     setSharingKey(record.key);
@@ -224,7 +304,10 @@ export default function KeysPage() {
       const result = await createShare.mutateAsync(record.key);
       setShareResult(result);
     } catch (err) {
-      push(err instanceof Error ? err.message : "Failed to create share link", "error");
+      push(
+        err instanceof Error ? err.message : "Failed to create share link",
+        "error",
+      );
     } finally {
       setSharingKey(null);
     }
@@ -233,28 +316,52 @@ export default function KeysPage() {
   const openCreate = () => {
     setEditingKey(null);
     const nextProvider = provisionedKeysOnly
-      ? availableProviders[0] ?? defaultForm.provider
+      ? (availableProviders[0] ?? defaultForm.provider)
       : isViewer
-        ? availableProviders[0] ?? "openai"
+        ? (availableProviders[0] ?? "openai")
         : defaultForm.provider;
     setForm({ ...defaultForm, provider: nextProvider });
     setManualKeyEntry(false);
+    setPersonalMode(false);
     setModalOpen(true);
+  };
+
+  const onTogglePersonalMode = (on: boolean) => {
+    setPersonalMode(on);
+    setManualKeyEntry(false);
+    setForm((current) => ({
+      ...current,
+      provider: on
+        ? (VIEWER_PROVIDERS.find((p) => !myPersonalProviders.has(p)) ??
+          current.provider)
+        : defaultForm.provider,
+    }));
   };
 
   const openEdit = (record: APIKey) => {
     setEditingKey(record);
+    setPersonalMode(false);
     setForm({
       provider: record.provider,
       actual_key: "",
       description: record.description ?? "",
-      daily_cost_limit_dollars: dailyCostLimitFormDollars(record.daily_cost_limit),
+      daily_cost_limit_dollars: dailyCostLimitFormDollars(
+        record.daily_cost_limit,
+      ),
       enabled: record.enabled,
       redact_pii: piiToFormValue(record.redact_pii),
-      rate_limit_rpm: record.rate_limit_rpm ? String(record.rate_limit_rpm) : "",
-      rate_limit_tpm: record.rate_limit_tpm ? String(record.rate_limit_tpm) : "",
-      rate_limit_rpd: record.rate_limit_rpd ? String(record.rate_limit_rpd) : "",
-      rate_limit_tpd: record.rate_limit_tpd ? String(record.rate_limit_tpd) : "",
+      rate_limit_rpm: record.rate_limit_rpm
+        ? String(record.rate_limit_rpm)
+        : "",
+      rate_limit_tpm: record.rate_limit_tpm
+        ? String(record.rate_limit_tpm)
+        : "",
+      rate_limit_rpd: record.rate_limit_rpd
+        ? String(record.rate_limit_rpd)
+        : "",
+      rate_limit_tpd: record.rate_limit_tpd
+        ? String(record.rate_limit_tpd)
+        : "",
       anthropic_tier: record.tags?.tier ?? anthropicDefaultTier,
     });
     setModalOpen(true);
@@ -265,11 +372,14 @@ export default function KeysPage() {
     setEditingKey(null);
     setForm(defaultForm);
     setManualKeyEntry(false);
+    setPersonalMode(false);
   };
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
-    const dailyCostLimit = Math.round(Number(form.daily_cost_limit_dollars || "0") * 100);
+    const dailyCostLimit = Math.round(
+      Number(form.daily_cost_limit_dollars || "0") * 100,
+    );
     if (editorMaxCents > 0 && dailyCostLimit > editorMaxCents) {
       push(`Daily cost limit cannot exceed $${editorMaxDollars}`, "error");
       return;
@@ -297,9 +407,12 @@ export default function KeysPage() {
           });
           push("Key updated", "success");
         }
-      } else if (isViewer) {
+      } else if (treatAsPersonal) {
         if (!useAutoProvision) {
-          push("Automatic key provisioning is not available for this provider", "error");
+          push(
+            "Automatic key provisioning is not available for this provider",
+            "error",
+          );
           return;
         }
         const body: CreateAPIKeyRequest = {
@@ -307,12 +420,18 @@ export default function KeysPage() {
           description: form.description,
           auto_provision: true,
         };
+        if (!isViewer) {
+          body.personal = true;
+        }
         await createKey.mutateAsync(body);
         push("Personal key created", "success");
       } else {
         if (!useAutoProvision) {
           if (provisionedKeysOnly) {
-            push("Automatic key provisioning is not available for this provider", "error");
+            push(
+              "Automatic key provisioning is not available for this provider",
+              "error",
+            );
             return;
           }
           if (!form.actual_key.trim()) {
@@ -357,25 +476,31 @@ export default function KeysPage() {
   };
 
   const onBulkGeneratePersonalKeys = async () => {
-    if (missingProvidersForBulk.length === 0) {
+    if (bulkTargetProviders.length === 0) {
       return;
     }
     setBulkGenerating(true);
     let created = 0;
     let failed = 0;
     try {
-      for (const provider of missingProvidersForBulk) {
+      for (const provider of bulkTargetProviders) {
         try {
-          if (isViewer) {
+          if (isViewer || isAdmin) {
             await createKey.mutateAsync({
               provider,
               description: bulkKeyDescription,
               auto_provision: true,
+              ...(isAdmin ? { personal: true } : {}),
             });
           } else {
-            const dailyCostLimit = Math.round(Number(defaultForm.daily_cost_limit_dollars || "0") * 100);
+            const dailyCostLimit = Math.round(
+              Number(defaultForm.daily_cost_limit_dollars || "0") * 100,
+            );
             if (editorMaxCents > 0 && dailyCostLimit > editorMaxCents) {
-              push(`Daily cost limit cannot exceed $${editorMaxDollars}`, "error");
+              push(
+                `Daily cost limit cannot exceed $${editorMaxDollars}`,
+                "error",
+              );
               return;
             }
             const body: CreateAPIKeyRequest = {
@@ -399,14 +524,17 @@ export default function KeysPage() {
       }
       if (created > 0) {
         push(
-          isViewer
+          isViewer || isAdmin
             ? `Created ${created} personal key${created === 1 ? "" : "s"}`
             : `Created ${created} key${created === 1 ? "" : "s"}`,
           "success",
         );
       }
       if (failed > 0) {
-        push(`Failed to create ${failed} key${failed === 1 ? "" : "s"}`, "error");
+        push(
+          `Failed to create ${failed} key${failed === 1 ? "" : "s"}`,
+          "error",
+        );
       }
     } finally {
       setBulkGenerating(false);
@@ -435,7 +563,9 @@ export default function KeysPage() {
               <select
                 className="select select-bordered select-sm"
                 value={providerFilter}
-                onChange={(event) => setProviderFilter(event.target.value as Provider | "")}
+                onChange={(event) =>
+                  setProviderFilter(event.target.value as Provider | "")
+                }
               >
                 <option value="">All providers</option>
                 {PROVIDERS.map((provider) => (
@@ -457,16 +587,38 @@ export default function KeysPage() {
         }
       />
 
-      {isViewer ? (
+      {isViewer || isAdmin ? (
         <div className="glass-panel border-l-4 border-l-[#4A154B] px-4 py-3 text-sm text-base-content/80">
-          These are meant for local testing. If you are deploying something, request a key for that service in{" "}
-          <span className="rounded bg-[#4A154B]/10 px-1 font-bold text-[#4A154B]">#it-helpdesk</span> in{" "}
-          <span className="rounded bg-[#4A154B]/10 px-1 font-bold text-[#4A154B]">Slack</span>.
+          {isViewer ? (
+            <>
+              These are meant for local testing. If you are deploying something,
+              request a key for that service in{" "}
+              <span className="rounded bg-[#4A154B]/10 px-1 font-bold text-[#4A154B]">
+                #it-helpdesk
+              </span>{" "}
+              in{" "}
+              <span className="rounded bg-[#4A154B]/10 px-1 font-bold text-[#4A154B]">
+                Slack
+              </span>
+              .
+            </>
+          ) : (
+            <>
+              Use <span className="font-medium">Generate Personal Keys</span> below
+              or toggle <span className="font-medium">Personal key</span> in Create
+              key for your own testing keys (one per provider, capped at{" "}
+              {viewerMonthlyLimitLabel}/month). Org-wide service keys stay separate.
+            </>
+          )}
         </div>
       ) : null}
 
       {error ? (
-        <ErrorAlert message={error instanceof Error ? error.message : "Failed to load keys"} />
+        <ErrorAlert
+          message={
+            error instanceof Error ? error.message : "Failed to load keys"
+          }
+        />
       ) : null}
 
       {canBulkGeneratePersonalKeys && visibleKeys.length > 0 ? (
@@ -477,13 +629,15 @@ export default function KeysPage() {
             disabled={bulkGenerateBusy}
             onClick={onBulkGeneratePersonalKeys}
           >
-            {bulkGenerateBusy ? <span className="loading loading-spinner loading-md" /> : null}
+            {bulkGenerateBusy ? (
+              <span className="loading loading-spinner loading-md" />
+            ) : null}
             Generate Personal Keys
           </button>
           <p className="max-w-2xl text-sm text-base-content/60">
-            {isViewer
-              ? `Creates one auto-provisioned personal key for each provider you do not have yet (${missingProvidersForBulk.join(", ")}).`
-              : `Creates one auto-provisioned key for each provider without a key yet (${missingProvidersForBulk.join(", ")}).`}
+            {isViewer || isAdmin
+              ? `Creates one auto-provisioned personal key for each provider you do not have yet (${bulkTargetProviders.join(", ")}).`
+              : `Creates one auto-provisioned key for each provider without a key yet (${bulkTargetProviders.join(", ")}).`}
           </p>
         </div>
       ) : null}
@@ -506,11 +660,17 @@ export default function KeysPage() {
                   disabled={bulkGenerateBusy}
                   onClick={onBulkGeneratePersonalKeys}
                 >
-                  {bulkGenerateBusy ? <span className="loading loading-spinner loading-md" /> : null}
+                  {bulkGenerateBusy ? (
+                    <span className="loading loading-spinner loading-md" />
+                  ) : null}
                   Generate Personal Keys
                 </button>
               ) : canCreateKey ? (
-                <button type="button" className="btn btn-primary btn-sm" onClick={openCreate}>
+                <button
+                  type="button"
+                  className="btn btn-primary btn-sm"
+                  onClick={openCreate}
+                >
                   Create your first key
                 </button>
               ) : undefined
@@ -535,9 +695,33 @@ export default function KeysPage() {
         <dialog className="modal modal-open" open>
           <div className="modal-box max-w-lg">
             <h3 className="text-lg font-semibold">
-              {editingKey ? "Edit API key" : isViewer ? "Create personal key" : "Create API key"}
+              {editingKey
+                ? "Edit API key"
+                : treatAsPersonal
+                  ? "Create personal key"
+                  : "Create API key"}
             </h3>
             <form className="mt-4 space-y-4" onSubmit={onSubmit}>
+              {!editingKey && !isViewer ? (
+                <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-base-300/70 bg-base-200/40 px-3 py-2">
+                  <span className="text-sm">
+                    <span className="font-medium">Personal key</span>
+                    <span className="block text-xs text-base-content/60">
+                      Owned by you, one per provider, capped at{" "}
+                      {viewerMonthlyLimitLabel}/month.
+                    </span>
+                  </span>
+                  <input
+                    type="checkbox"
+                    className="toggle toggle-primary"
+                    checked={personalMode}
+                    onChange={(event) =>
+                      onTogglePersonalMode(event.target.checked)
+                    }
+                  />
+                </label>
+              ) : null}
+
               <label className="form-control w-full">
                 <span className="label-text">Provider</span>
                 <select
@@ -545,7 +729,10 @@ export default function KeysPage() {
                   disabled={Boolean(editingKey)}
                   value={form.provider}
                   onChange={(event) =>
-                    setForm((current) => ({ ...current, provider: event.target.value as Provider }))
+                    setForm((current) => ({
+                      ...current,
+                      provider: event.target.value as Provider,
+                    }))
                   }
                 >
                   {availableProviders.map((provider) => (
@@ -554,7 +741,7 @@ export default function KeysPage() {
                     </option>
                   ))}
                 </select>
-                {piiOffRequiresBedrock && !isViewer ? (
+                {piiOffRequiresBedrock && !treatAsPersonal ? (
                   <span className="label-text-alt text-base-content/60">
                     PII redaction off requires the Bedrock provider.
                   </span>
@@ -563,25 +750,32 @@ export default function KeysPage() {
 
               {!editingKey && useAutoProvision ? (
                 <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm text-base-content/80">
-                  Upstream key will be created automatically for {form.provider}.
+                  Upstream key will be created automatically for {form.provider}
+                  .
                 </div>
               ) : null}
 
-              {!editingKey && provisionedKeysOnly && !providerAutoProvision ? (
+              {!editingKey &&
+                (provisionedKeysOnly || treatAsPersonal) &&
+                !providerAutoProvision ? (
                 <div className="rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-warning">
-                  Automatic key provisioning is not available for {form.provider}. Choose another provider or
-                  contact an administrator.
+                  Automatic key provisioning is not available for{" "}
+                  {form.provider}. Choose another provider or contact an
+                  administrator.
                 </div>
               ) : null}
 
-              {!isViewer && showAnthropicTierSelect ? (
+              {!treatAsPersonal && showAnthropicTierSelect ? (
                 <label className="form-control w-full">
                   <span className="label-text">Anthropic tier</span>
                   <select
                     className="select select-bordered w-full"
                     value={form.anthropic_tier}
                     onChange={(event) =>
-                      setForm((current) => ({ ...current, anthropic_tier: event.target.value }))
+                      setForm((current) => ({
+                        ...current,
+                        anthropic_tier: event.target.value,
+                      }))
                     }
                   >
                     {anthropicTierOptions.map((tier) => (
@@ -591,16 +785,22 @@ export default function KeysPage() {
                     ))}
                   </select>
                   <span className="label-text-alt text-base-content/60">
-                    metered = tight limits; elevated = trusted workloads; unrestricted = administrators only.
+                    metered = tight limits; elevated = trusted workloads;
+                    unrestricted = administrators only.
                   </span>
                 </label>
               ) : null}
 
-              {!editingKey && providerAutoProvision && !provisionedKeysOnly ? (
+              {!editingKey &&
+                providerAutoProvision &&
+                !provisionedKeysOnly &&
+                !treatAsPersonal ? (
                 <details
                   className="rounded-lg border border-base-300 px-3 py-2"
                   open={manualKeyEntry}
-                  onToggle={(event) => setManualKeyEntry(event.currentTarget.open)}
+                  onToggle={(event) =>
+                    setManualKeyEntry(event.currentTarget.open)
+                  }
                 >
                   <summary className="cursor-pointer text-sm font-medium">
                     Advanced: paste provider key
@@ -614,14 +814,20 @@ export default function KeysPage() {
                       placeholder="sk-..."
                       value={form.actual_key}
                       onChange={(event) =>
-                        setForm((current) => ({ ...current, actual_key: event.target.value }))
+                        setForm((current) => ({
+                          ...current,
+                          actual_key: event.target.value,
+                        }))
                       }
                     />
                   </label>
                 </details>
               ) : null}
 
-              {!editingKey && !providerAutoProvision && !provisionedKeysOnly ? (
+              {!editingKey &&
+                !providerAutoProvision &&
+                !provisionedKeysOnly &&
+                !treatAsPersonal ? (
                 <label className="form-control w-full">
                   <span className="label-text">Provider API key</span>
                   <input
@@ -631,7 +837,10 @@ export default function KeysPage() {
                     placeholder="sk-..."
                     value={form.actual_key}
                     onChange={(event) =>
-                      setForm((current) => ({ ...current, actual_key: event.target.value }))
+                      setForm((current) => ({
+                        ...current,
+                        actual_key: event.target.value,
+                      }))
                     }
                   />
                 </label>
@@ -645,19 +854,23 @@ export default function KeysPage() {
                   placeholder="What is this key used for?"
                   value={form.description}
                   onChange={(event) =>
-                    setForm((current) => ({ ...current, description: event.target.value }))
+                    setForm((current) => ({
+                      ...current,
+                      description: event.target.value,
+                    }))
                   }
                 />
               </label>
 
-              {isViewer && !editingKey ? (
+              {treatAsPersonal && !editingKey ? (
                 <div className="rounded-lg border border-base-300/70 bg-base-200/40 px-3 py-2 text-sm text-base-content/80">
                   Monthly spend limit:{" "}
-                  <span className="font-medium">{viewerMonthlyLimitLabel}</span> (set by your organization).
+                  <span className="font-medium">{viewerMonthlyLimitLabel}</span>{" "}
+                  (set by your organization).
                 </div>
               ) : null}
 
-              {!isViewer ? (
+              {!treatAsPersonal ? (
                 <>
                   <div className="grid gap-4 sm:grid-cols-[1fr_auto] sm:items-end">
                     <label className="form-control w-full">
@@ -678,7 +891,9 @@ export default function KeysPage() {
                       />
                       <p className="mt-1.5 text-xs text-base-content/60">
                         Leave at 0 for unlimited
-                        {editorMaxDollars != null ? ` · Editor max $${editorMaxDollars}/day` : null}
+                        {editorMaxDollars != null
+                          ? ` · Editor max $${editorMaxDollars}/day`
+                          : null}
                       </p>
                     </label>
 
@@ -690,10 +905,15 @@ export default function KeysPage() {
                           className="toggle toggle-primary"
                           checked={form.enabled}
                           onChange={(event) =>
-                            setForm((current) => ({ ...current, enabled: event.target.checked }))
+                            setForm((current) => ({
+                              ...current,
+                              enabled: event.target.checked,
+                            }))
                           }
                         />
-                        <span className="text-sm font-medium">{form.enabled ? "Enabled" : "Disabled"}</span>
+                        <span className="text-sm font-medium">
+                          {form.enabled ? "Enabled" : "Disabled"}
+                        </span>
                       </label>
                     </div>
                   </div>
@@ -714,9 +934,12 @@ export default function KeysPage() {
                       <option value="on">On</option>
                       <option value="off">Off</option>
                     </select>
-                    {piiOffRequiresBedrock && editingKey && editingKey.provider !== "bedrock" ? (
+                    {piiOffRequiresBedrock &&
+                      editingKey &&
+                      editingKey.provider !== "bedrock" ? (
                       <p className="mt-1.5 text-xs text-warning">
-                        Turning PII off requires a Bedrock key. Create a new Bedrock key instead.
+                        Turning PII off requires a Bedrock key. Create a new
+                        Bedrock key instead.
                       </p>
                     ) : null}
                   </label>
@@ -724,11 +947,14 @@ export default function KeysPage() {
                   <div className="rounded-xl border border-base-300/70 p-4">
                     <div className="mb-3 text-sm font-medium">Rate limits</div>
                     <p className="mb-3 text-xs text-base-content/60">
-                      Optional per-key overrides. Leave blank to inherit global limits. Zero clears an override.
+                      Optional per-key overrides. Leave blank to inherit global
+                      limits. Zero clears an override.
                     </p>
                     <div className="grid gap-3 sm:grid-cols-2">
                       <label className="form-control">
-                        <span className="label-text text-xs">Requests / minute</span>
+                        <span className="label-text text-xs">
+                          Requests / minute
+                        </span>
                         <input
                           type="number"
                           min="0"
@@ -736,12 +962,17 @@ export default function KeysPage() {
                           placeholder="inherit"
                           value={form.rate_limit_rpm}
                           onChange={(event) =>
-                            setForm((current) => ({ ...current, rate_limit_rpm: event.target.value }))
+                            setForm((current) => ({
+                              ...current,
+                              rate_limit_rpm: event.target.value,
+                            }))
                           }
                         />
                       </label>
                       <label className="form-control">
-                        <span className="label-text text-xs">Tokens / minute</span>
+                        <span className="label-text text-xs">
+                          Tokens / minute
+                        </span>
                         <input
                           type="number"
                           min="0"
@@ -749,12 +980,17 @@ export default function KeysPage() {
                           placeholder="inherit"
                           value={form.rate_limit_tpm}
                           onChange={(event) =>
-                            setForm((current) => ({ ...current, rate_limit_tpm: event.target.value }))
+                            setForm((current) => ({
+                              ...current,
+                              rate_limit_tpm: event.target.value,
+                            }))
                           }
                         />
                       </label>
                       <label className="form-control">
-                        <span className="label-text text-xs">Requests / day</span>
+                        <span className="label-text text-xs">
+                          Requests / day
+                        </span>
                         <input
                           type="number"
                           min="0"
@@ -762,7 +998,10 @@ export default function KeysPage() {
                           placeholder="inherit"
                           value={form.rate_limit_rpd}
                           onChange={(event) =>
-                            setForm((current) => ({ ...current, rate_limit_rpd: event.target.value }))
+                            setForm((current) => ({
+                              ...current,
+                              rate_limit_rpd: event.target.value,
+                            }))
                           }
                         />
                       </label>
@@ -775,7 +1014,10 @@ export default function KeysPage() {
                           placeholder="inherit"
                           value={form.rate_limit_tpd}
                           onChange={(event) =>
-                            setForm((current) => ({ ...current, rate_limit_tpd: event.target.value }))
+                            setForm((current) => ({
+                              ...current,
+                              rate_limit_tpd: event.target.value,
+                            }))
                           }
                         />
                       </label>
@@ -785,15 +1027,26 @@ export default function KeysPage() {
               ) : null}
 
               <div className="modal-action">
-                <button type="button" className="btn btn-ghost" onClick={closeModal}>
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  onClick={closeModal}
+                >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   className="btn btn-primary"
-                  disabled={saving || (!editingKey && provisionedKeysOnly && !useAutoProvision)}
+                  disabled={
+                    saving ||
+                    (!editingKey &&
+                      (provisionedKeysOnly || treatAsPersonal) &&
+                      !useAutoProvision)
+                  }
                 >
-                  {saving ? <span className="loading loading-spinner loading-sm" /> : null}
+                  {saving ? (
+                    <span className="loading loading-spinner loading-sm" />
+                  ) : null}
                   {editingKey ? "Save changes" : "Create key"}
                 </button>
               </div>
@@ -823,12 +1076,12 @@ export default function KeysPage() {
             {shareResult.expires_at ? (
               <p
                 className={`mt-3 text-sm ${formatShareExpiry(shareResult.expires_at).urgent
-                  ? "text-warning"
-                  : "text-base-content/60"
+                    ? "text-warning"
+                    : "text-base-content/60"
                   }`}
               >
-                {formatShareExpiry(shareResult.expires_at).message}. Re-sharing the same key within
-                24 hours reuses this URL.
+                {formatShareExpiry(shareResult.expires_at).message}. Re-sharing
+                the same key within 24 hours reuses this URL.
               </p>
             ) : null}
             <div className="modal-action">
@@ -840,13 +1093,21 @@ export default function KeysPage() {
               >
                 Open
               </a>
-              <button type="button" className="btn btn-primary" onClick={() => setShareResult(null)}>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => setShareResult(null)}
+              >
                 Done
               </button>
             </div>
           </div>
           <form method="dialog" className="modal-backdrop">
-            <button type="button" aria-label="Close" onClick={() => setShareResult(null)} />
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={() => setShareResult(null)}
+            />
           </form>
         </dialog>
       ) : null}
@@ -857,10 +1118,17 @@ export default function KeysPage() {
             <h3 className="text-lg font-semibold">Delete API key?</h3>
             <p className="py-4 text-sm text-base-content/70">
               This will permanently remove{" "}
-              <span className="code-chip font-mono">{deleteTarget ? maskKey(deleteTarget.key) : ""}</span>.
+              <span className="code-chip font-mono">
+                {deleteTarget ? maskKey(deleteTarget.key) : ""}
+              </span>
+              .
             </p>
             <div className="modal-action">
-              <button type="button" className="btn btn-ghost" onClick={() => setDeleteTarget(null)}>
+              <button
+                type="button"
+                className="btn btn-ghost"
+                onClick={() => setDeleteTarget(null)}
+              >
                 Cancel
               </button>
               <button
@@ -874,7 +1142,11 @@ export default function KeysPage() {
             </div>
           </div>
           <form method="dialog" className="modal-backdrop">
-            <button type="button" aria-label="Close" onClick={() => setDeleteTarget(null)} />
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={() => setDeleteTarget(null)}
+            />
           </form>
         </dialog>
       ) : null}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -79,6 +79,7 @@ export interface CreateAPIKeyRequest {
   provider: Provider;
   actual_key?: string;
   auto_provision?: boolean;
+  personal?: boolean;
   description?: string;
   daily_cost_limit?: number;
   enabled?: boolean;
@@ -126,7 +127,12 @@ export interface ConfigSummary {
 
 export interface DailyHistoryRow {
   day: string;
-  [key: string]: string | number | boolean | undefined | Record<string, unknown>;
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | undefined
+    | Record<string, unknown>;
 }
 
 export interface StatsWithDailyHistory {


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

- [ ] AWHR: AI Written, Human Reviewed by me

## Summary

- Adds a `personal` flag to the create-key API so admins (and other non-viewer roles) can mint owner-scoped testing keys with the same constraints as viewers: auto-provisioned, one per provider, monthly-capped.
- Surfaces personal key creation in the admin keys dashboard via a **Generate Personal Keys** bulk action, an admin callout banner, and a **Personal key** toggle in the Create key modal.

## Test plan

- [ ] Log in as admin on the keys page — confirm callout banner and **Generate Personal Keys** button appear when personal keys are missing
- [ ] Bulk-generate personal keys for openai, anthropic, gemini — verify keys are created with `owner_email` set and monthly cap applied
- [ ] Create a single personal key via Create key → Personal key toggle
- [ ] Confirm duplicate provider returns conflict
- [ ] Confirm viewer personal key flow is unchanged
- [ ] `go test ./internal/admin/... -run 'TestAdminCreatePersonalKey|TestViewerPersonalKeys'`