### PR TITLE
feat(admin): per-key stats from direct Redis reads

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1629,6 +1629,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			RateLimitSummary: rateLimitSummaryFunc(),
 			CircuitActivity:  circuitActivitySummaryFunc(),
 			KeyProvisioner:   globalKeyProvisioner,
+			AdminRollupStore: globalAdminRollupStore,
 		})
 		logger.Info("Admin dashboard: ENABLED")
 	}

--- a/internal/admin/deps.go
+++ b/internal/admin/deps.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/Instawork/llm-proxy/internal/adminrollup"
 	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/config"
@@ -19,6 +20,7 @@ type Deps struct {
 	APIKeyStoreError error
 	UserStore        *adminusers.Store
 	UserStoreError   error
+	AdminRollupStore *adminrollup.Store
 	RateLimiter      ratelimit.RateLimiter
 	HealthFunc       http.HandlerFunc
 	CostSummary      func() map[string]interface{}

--- a/internal/admin/key_stats.go
+++ b/internal/admin/key_stats.go
@@ -124,7 +124,8 @@ func (h *handler) handleKeyStats(w http.ResponseWriter, r *http.Request) {
 	var redisCostOK bool
 	var redisPII int64
 	var redisPIIOK bool
-	var rollupReadsOK bool
+	costRollupOK := false
+	piiRollupOK := false
 	if h.deps.AdminRollupStore != nil {
 		resp.RollupBackend = h.deps.AdminRollupStore.Backend()
 
@@ -137,8 +138,9 @@ func (h *handler) handleKeyStats(w http.ResponseWriter, r *http.Request) {
 		if piiErr != nil {
 			h.deps.Logger.Error("admin: key pii stats read failed", "key", masked, "error", piiErr)
 		}
-		rollupReadsOK = costErr == nil && piiErr == nil
-		resp.RollupAvailable = rollupReadsOK
+		costRollupOK = costErr == nil
+		piiRollupOK = piiErr == nil
+		resp.RollupAvailable = costRollupOK && piiRollupOK
 
 		if costSeries, _, histErr := h.deps.AdminRollupStore.KeyCostDailySeries(ctx, masked, 7); histErr != nil {
 			h.deps.Logger.Error("admin: key cost history read failed", "key", masked, "error", histErr)
@@ -152,8 +154,8 @@ func (h *handler) handleKeyStats(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp.CostToday = mergeKeyCostStats(memCost, redisCost, redisCostOK, rollupReadsOK)
-	resp.PIIToday = mergeKeyPIIStats(memPII, redisPII, redisPIIOK, rollupReadsOK)
+	resp.CostToday = mergeKeyCostStats(memCost, redisCost, redisCostOK, costRollupOK)
+	resp.PIIToday = mergeKeyPIIStats(memPII, redisPII, redisPIIOK, piiRollupOK)
 
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -250,7 +252,7 @@ func sanitizeRecentCost(rows []map[string]interface{}) []keyCostRecentResponse {
 		out = append(out, keyCostRecentResponse{
 			Time:           int64(asFloat(row["time"])),
 			Provider:       asString(row["provider"]),
-			KeyID:          asString(row["key_id"]),
+			KeyID:          middleware.MaskKeyID(asString(row["key_id"])),
 			SpendUSD:       asFloat(row["spend_usd"]),
 			InputSpendUSD:  asFloat(row["input_spend_usd"]),
 			OutputSpendUSD: asFloat(row["output_spend_usd"]),
@@ -274,7 +276,7 @@ func sanitizeRecentPII(rows []map[string]interface{}) []keyPIIRecentResponse {
 		out = append(out, keyPIIRecentResponse{
 			Time:         int64(asFloat(row["time"])),
 			Provider:     asString(row["provider"]),
-			KeyID:        asString(row["key_id"]),
+			KeyID:        middleware.MaskKeyID(asString(row["key_id"])),
 			EntityCounts: entityCounts,
 			EntityTotal:  int(asFloat(row["entity_total"])),
 			DurationMs:   asFloat(row["duration_ms"]),

--- a/internal/admin/key_stats.go
+++ b/internal/admin/key_stats.go
@@ -1,0 +1,377 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/adminrollup"
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/middleware"
+	"github.com/gorilla/mux"
+)
+
+type keyCostStatsResponse struct {
+	Source         string  `json:"source"`
+	SpendUSD       float64 `json:"spend_usd"`
+	InputSpendUSD  float64 `json:"input_spend_usd"`
+	OutputSpendUSD float64 `json:"output_spend_usd"`
+	Requests       int64   `json:"requests"`
+	InputTokens    int64   `json:"input_tokens"`
+	OutputTokens   int64   `json:"output_tokens"`
+}
+
+type keyPIIStatsResponse struct {
+	Source     string `json:"source"`
+	Detections int64  `json:"detections"`
+}
+
+type keyDayPointResponse struct {
+	Day   string  `json:"day"`
+	Value float64 `json:"value"`
+}
+
+type keyCostRecentResponse struct {
+	Time           int64   `json:"time"`
+	Provider       string  `json:"provider"`
+	KeyID          string  `json:"key_id,omitempty"`
+	SpendUSD       float64 `json:"spend_usd"`
+	InputSpendUSD  float64 `json:"input_spend_usd,omitempty"`
+	OutputSpendUSD float64 `json:"output_spend_usd,omitempty"`
+	InputTokens    int     `json:"input_tokens"`
+	OutputTokens   int     `json:"output_tokens"`
+	Model          string  `json:"model,omitempty"`
+}
+
+type keyPIIRecentResponse struct {
+	Time         int64          `json:"time"`
+	Provider     string         `json:"provider"`
+	KeyID        string         `json:"key_id,omitempty"`
+	EntityCounts map[string]int `json:"entity_counts"`
+	EntityTotal  int            `json:"entity_total"`
+	DurationMs   float64        `json:"duration_ms"`
+	Outcome      string         `json:"outcome"`
+}
+
+type keyStatsResponse struct {
+	MaskedKeyID     string                  `json:"masked_key_id"`
+	Day             string                  `json:"day"`
+	RollupAvailable bool                    `json:"rollup_available"`
+	RollupBackend   string                  `json:"rollup_backend,omitempty"`
+	CostToday       keyCostStatsResponse    `json:"cost_today"`
+	PIIToday        keyPIIStatsResponse     `json:"pii_today"`
+	CostHistory     []keyDayPointResponse   `json:"cost_history"`
+	PIIHistory      []keyDayPointResponse   `json:"pii_history"`
+	RecentCost      []keyCostRecentResponse `json:"recent_cost"`
+	RecentPII       []keyPIIRecentResponse  `json:"recent_pii"`
+}
+
+func (h *handler) handleKeyStats(w http.ResponseWriter, r *http.Request) {
+	if h.deps.APIKeyStore == nil {
+		h.writeAPIKeyStoreUnavailable(w)
+		return
+	}
+
+	keyID := strings.TrimSpace(mux.Vars(r)["key"])
+	if !apikeys.HasKeyPrefix(keyID) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid key format"})
+		return
+	}
+
+	user, err := h.auth.currentUser(r)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	role, err := adminusers.ParseRole(user.Role)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+
+	record, err := h.deps.APIKeyStore.GetKeyRecord(r.Context(), keyID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "key not found"})
+			return
+		}
+		h.deps.Logger.Error("admin: key stats lookup failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load key"})
+		return
+	}
+	if !canAccessKey(role, user.Email, record) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+
+	masked := middleware.MaskKeyID(keyID)
+	today := time.Now().UTC().Format("2006-01-02")
+	ctx := r.Context()
+
+	resp := keyStatsResponse{
+		MaskedKeyID: masked,
+		Day:         today,
+	}
+
+	memCost := memoryCostForKey(h.deps.CostSummary, masked, keyID)
+	memPII := memoryPIIForKey(h.deps.PIISummary, masked)
+	resp.RecentCost = sanitizeRecentCost(memoryRecentCostForKey(h.deps.CostSummary, masked, keyID))
+	resp.RecentPII = sanitizeRecentPII(memoryRecentPIIForKey(h.deps.PIISummary, masked))
+
+	var redisCost adminrollup.KeyCostDayStats
+	var redisCostOK bool
+	var redisPII int64
+	var redisPIIOK bool
+	var rollupReadsOK bool
+	if h.deps.AdminRollupStore != nil {
+		resp.RollupBackend = h.deps.AdminRollupStore.Backend()
+
+		var costErr, piiErr error
+		redisCost, redisCostOK, costErr = h.deps.AdminRollupStore.KeyCostDayStats(ctx, today, masked)
+		if costErr != nil {
+			h.deps.Logger.Error("admin: key cost stats read failed", "key", masked, "error", costErr)
+		}
+		redisPII, redisPIIOK, piiErr = h.deps.AdminRollupStore.KeyPIIDayCount(ctx, today, masked)
+		if piiErr != nil {
+			h.deps.Logger.Error("admin: key pii stats read failed", "key", masked, "error", piiErr)
+		}
+		rollupReadsOK = costErr == nil && piiErr == nil
+		resp.RollupAvailable = rollupReadsOK
+
+		if costSeries, _, histErr := h.deps.AdminRollupStore.KeyCostDailySeries(ctx, masked, 7); histErr != nil {
+			h.deps.Logger.Error("admin: key cost history read failed", "key", masked, "error", histErr)
+		} else {
+			resp.CostHistory = toDayPoints(costSeries)
+		}
+		if piiSeries, _, histErr := h.deps.AdminRollupStore.KeyPIIDailySeries(ctx, masked, 7); histErr != nil {
+			h.deps.Logger.Error("admin: key pii history read failed", "key", masked, "error", histErr)
+		} else {
+			resp.PIIHistory = toDayPoints(piiSeries)
+		}
+	}
+
+	resp.CostToday = mergeKeyCostStats(memCost, redisCost, redisCostOK, rollupReadsOK)
+	resp.PIIToday = mergeKeyPIIStats(memPII, redisPII, redisPIIOK, rollupReadsOK)
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type memoryKeyCost struct {
+	SpendUSD       float64
+	InputSpendUSD  float64
+	OutputSpendUSD float64
+	Requests       int64
+	InputTokens    int64
+	OutputTokens   int64
+}
+
+func recentRowsFromSnap(snap map[string]interface{}, field string) []map[string]interface{} {
+	raw, ok := snap[field]
+	if !ok || raw == nil {
+		return nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var rows []map[string]interface{}
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil
+	}
+	return rows
+}
+
+func memoryCostForKey(summary func() map[string]interface{}, masked, rawKey string) memoryKeyCost {
+	snap := safeSummary(summary)
+	for _, row := range recentRowsFromSnap(snap, "by_key") {
+		id := asString(row["key_id"])
+		if id != masked && id != rawKey {
+			continue
+		}
+		return memoryKeyCost{
+			SpendUSD:       asFloat(row["spend_usd"]),
+			InputSpendUSD:  asFloat(row["input_spend_usd"]),
+			OutputSpendUSD: asFloat(row["output_spend_usd"]),
+			Requests:       int64(asFloat(row["requests"])),
+			InputTokens:    int64(asFloat(row["input_tokens"])),
+			OutputTokens:   int64(asFloat(row["output_tokens"])),
+		}
+	}
+	return memoryKeyCost{}
+}
+
+func memoryPIIForKey(summary func() map[string]interface{}, masked string) int64 {
+	snap := safeSummary(summary)
+	for _, row := range recentRowsFromSnap(snap, "top_keys") {
+		if asString(row["name"]) == masked {
+			return int64(asFloat(row["count"]))
+		}
+	}
+	var count int64
+	for _, row := range recentRowsFromSnap(snap, "recent") {
+		if asString(row["key_id"]) != masked {
+			continue
+		}
+		if asFloat(row["entity_total"]) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func memoryRecentCostForKey(summary func() map[string]interface{}, masked, rawKey string) []map[string]interface{} {
+	snap := safeSummary(summary)
+	out := make([]map[string]interface{}, 0)
+	for _, row := range recentRowsFromSnap(snap, "recent") {
+		id := asString(row["key_id"])
+		if id == masked || id == rawKey {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func memoryRecentPIIForKey(summary func() map[string]interface{}, masked string) []map[string]interface{} {
+	snap := safeSummary(summary)
+	out := make([]map[string]interface{}, 0)
+	for _, row := range recentRowsFromSnap(snap, "recent") {
+		if asString(row["key_id"]) == masked {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func sanitizeRecentCost(rows []map[string]interface{}) []keyCostRecentResponse {
+	out := make([]keyCostRecentResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, keyCostRecentResponse{
+			Time:           int64(asFloat(row["time"])),
+			Provider:       asString(row["provider"]),
+			KeyID:          asString(row["key_id"]),
+			SpendUSD:       asFloat(row["spend_usd"]),
+			InputSpendUSD:  asFloat(row["input_spend_usd"]),
+			OutputSpendUSD: asFloat(row["output_spend_usd"]),
+			InputTokens:    int(asFloat(row["input_tokens"])),
+			OutputTokens:   int(asFloat(row["output_tokens"])),
+			Model:          asString(row["model"]),
+		})
+	}
+	return out
+}
+
+func sanitizeRecentPII(rows []map[string]interface{}) []keyPIIRecentResponse {
+	out := make([]keyPIIRecentResponse, 0, len(rows))
+	for _, row := range rows {
+		entityCounts := map[string]int{}
+		if raw, ok := row["entity_counts"].(map[string]interface{}); ok {
+			for k, v := range raw {
+				entityCounts[k] = int(asFloat(v))
+			}
+		}
+		out = append(out, keyPIIRecentResponse{
+			Time:         int64(asFloat(row["time"])),
+			Provider:     asString(row["provider"]),
+			KeyID:        asString(row["key_id"]),
+			EntityCounts: entityCounts,
+			EntityTotal:  int(asFloat(row["entity_total"])),
+			DurationMs:   asFloat(row["duration_ms"]),
+			Outcome:      asString(row["outcome"]),
+		})
+	}
+	return out
+}
+
+func safeSummary(summary func() map[string]interface{}) map[string]interface{} {
+	if summary == nil {
+		return map[string]interface{}{}
+	}
+	snap := summary()
+	if snap == nil {
+		return map[string]interface{}{}
+	}
+	return snap
+}
+
+func asString(v interface{}) string {
+	s, _ := v.(string)
+	return s
+}
+
+func asFloat(v interface{}) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case json.Number:
+		f, _ := n.Float64()
+		return f
+	default:
+		return 0
+	}
+}
+
+func mergeKeyCostStats(mem memoryKeyCost, redis adminrollup.KeyCostDayStats, redisOK, rollupBound bool) keyCostStatsResponse {
+	source := "memory"
+	out := keyCostStatsResponse{
+		Source:         source,
+		SpendUSD:       mem.SpendUSD,
+		InputSpendUSD:  mem.InputSpendUSD,
+		OutputSpendUSD: mem.OutputSpendUSD,
+		Requests:       mem.Requests,
+		InputTokens:    mem.InputTokens,
+		OutputTokens:   mem.OutputTokens,
+	}
+	if !rollupBound {
+		return out
+	}
+	if mem.SpendUSD > 0 {
+		out.Source = "redislive"
+		return out
+	}
+	if redisOK {
+		out.Source = "redis"
+		out.SpendUSD = redis.SpendUSD
+		out.InputSpendUSD = redis.InputSpendUSD
+		out.OutputSpendUSD = redis.OutputSpendUSD
+		out.Requests = redis.Requests
+		out.InputTokens = redis.InputTokens
+		out.OutputTokens = redis.OutputTokens
+		return out
+	}
+	out.Source = "redislive"
+	return out
+}
+
+func mergeKeyPIIStats(mem int64, redis int64, redisOK, rollupBound bool) keyPIIStatsResponse {
+	out := keyPIIStatsResponse{Source: "memory", Detections: mem}
+	if !rollupBound {
+		return out
+	}
+	if mem > redis {
+		out.Source = "redislive"
+		return out
+	}
+	if redisOK {
+		out.Source = "redis"
+		out.Detections = redis
+		return out
+	}
+	out.Source = "redislive"
+	return out
+}
+
+func toDayPoints(series []adminrollup.KeyDayPoint) []keyDayPointResponse {
+	out := make([]keyDayPointResponse, len(series))
+	for i, pt := range series {
+		out[i] = keyDayPointResponse{Day: pt.Day, Value: pt.Value}
+	}
+	return out
+}

--- a/internal/admin/key_stats_test.go
+++ b/internal/admin/key_stats_test.go
@@ -1,0 +1,140 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/adminrollup"
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/coststats"
+	"github.com/Instawork/llm-proxy/internal/middleware"
+	"github.com/Instawork/llm-proxy/internal/pii"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testAdminRollupStore(t *testing.T) *adminrollup.Store {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	store, err := adminrollup.NewStore(adminrollup.Config{
+		Enabled: true,
+		Redis: &config.RedisConfig{
+			Address: mr.Addr(),
+			DB:      6,
+			DBSet:   true,
+		},
+		HistoryDays: 7,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func keyStatsRequest(t *testing.T, h *handler, email, key string) (*httptest.ResponseRecorder, keyStatsResponse) {
+	t.Helper()
+	req := authenticatedRequestAs(t, h, email, http.MethodGet, "/admin/api/keys/"+key+"/stats", nil)
+	req = mux.SetURLVars(req, map[string]string{"key": key})
+	rec := httptest.NewRecorder()
+	h.handleKeyStats(rec, req)
+	var body keyStatsResponse
+	if rec.Code == http.StatusOK {
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	}
+	return rec, body
+}
+
+func TestHandleKeyStats_RedisDirectRead(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+
+	created, err := store.CreateKey(context.Background(), "openai", "upstream", "stats key", 0, nil, nil, apikeys.KeyRateLimits{})
+	require.NoError(t, err)
+
+	rollup := testAdminRollupStore(t)
+	masked := middleware.MaskKeyID(created.PK)
+	require.NoError(t, rollup.ApplyDelta(ctx, adminrollup.MetricCost, day, adminrollup.Delta{
+		Totals: map[string]float64{"spend_usd": 0.42},
+		Dimensions: map[string]map[string]float64{
+			"by_key": {adminrollup.DimMemberField(masked, "spend_usd"): 0.42},
+		},
+	}))
+
+	costRec := coststats.NewRecorder()
+	h.deps.AdminRollupStore = rollup
+	h.deps.CostSummary = costRec.Snapshot
+	h.deps.PIISummary = pii.NewRecorder().Snapshot
+
+	rec, body := keyStatsRequest(t, h, "admin@example.com", created.PK)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, body.RollupAvailable)
+	require.Equal(t, masked, body.MaskedKeyID)
+	require.InDelta(t, 0.42, body.CostToday.SpendUSD, 1e-9)
+	require.Equal(t, "redis", body.CostToday.Source)
+}
+
+func TestHandleKeyStats_ForbiddenForOtherUsersKey(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+	_, err := h.deps.UserStore.CreateUser(ctx, "viewer@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	orgKey, err := store.CreateKey(ctx, "openai", "sk-org", "org", 0, nil, nil)
+	require.NoError(t, err)
+
+	rec, _ := keyStatsRequest(t, h, "viewer@example.com", orgKey.PK)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleKeyStats_NotFoundForMissingKey(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	rec, _ := keyStatsRequest(t, h, "admin@example.com", apikeys.KeyPrefix+"missing")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleKeyStats_StripsUserIDFromRecentCost(t *testing.T) {
+	h, store := testAdminHandler(t)
+	created, err := store.CreateKey(context.Background(), "openai", "upstream", "stats key", 0, nil, nil, apikeys.KeyRateLimits{})
+	require.NoError(t, err)
+
+	masked := middleware.MaskKeyID(created.PK)
+	costRec := coststats.NewRecorder()
+	costRec.RecordRequest("openai", masked, "secret-user", "gpt-4o", 0.01, 0.005, 0.005, 10, 5)
+	h.deps.CostSummary = costRec.Snapshot
+	h.deps.PIISummary = pii.NewRecorder().Snapshot
+
+	req := authenticatedRequestAs(t, h, "admin@example.com", http.MethodGet, "/admin/api/keys/"+created.PK+"/stats", nil)
+	req = mux.SetURLVars(req, map[string]string{"key": created.PK})
+	rec := httptest.NewRecorder()
+	h.handleKeyStats(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rawBody := rec.Body.String()
+	assert.NotContains(t, rawBody, "secret-user")
+	assert.NotContains(t, rawBody, "user_id")
+
+	var body keyStatsResponse
+	require.NoError(t, json.Unmarshal([]byte(rawBody), &body))
+	require.Len(t, body.RecentCost, 1)
+	require.InDelta(t, 0.01, body.RecentCost[0].SpendUSD, 1e-9)
+}
+
+func TestHandleKeyStats_StoreUnavailable(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	h.deps.APIKeyStore = nil
+	rec := httptest.NewRecorder()
+	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/keys/"+apikeys.KeyPrefix+"x/stats", nil)
+	req = mux.SetURLVars(req, map[string]string{"key": apikeys.KeyPrefix + "x"})
+	h.handleKeyStats(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}

--- a/internal/admin/key_stats_test.go
+++ b/internal/admin/key_stats_test.go
@@ -96,6 +96,28 @@ func TestHandleKeyStats_ForbiddenForOtherUsersKey(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestHandleKeyStats_ViewerOwnKey(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+	_, err := h.deps.UserStore.CreateUser(ctx, "viewer@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	personal, err := store.CreatePersonalKey(ctx, "viewer@example.com", "openai", "sk-viewer", "mine", 1000, apikeys.KeyCreateMeta{})
+	require.NoError(t, err)
+
+	costRec := coststats.NewRecorder()
+	masked := middleware.MaskKeyID(personal.PK)
+	costRec.RecordRequest("openai", masked, "secret-user", "gpt-4o", 0.02, 0.01, 0.01, 20, 10)
+	h.deps.CostSummary = costRec.Snapshot
+	h.deps.PIISummary = pii.NewRecorder().Snapshot
+
+	rec, body := keyStatsRequest(t, h, "viewer@example.com", personal.PK)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, masked, body.MaskedKeyID)
+	require.InDelta(t, 0.02, body.CostToday.SpendUSD, 1e-9)
+	require.Len(t, body.RecentCost, 1)
+}
+
 func TestHandleKeyStats_NotFoundForMissingKey(t *testing.T) {
 	h, _ := testAdminHandler(t)
 	rec, _ := keyStatsRequest(t, h, "admin@example.com", apikeys.KeyPrefix+"missing")

--- a/internal/admin/key_stats_test.go
+++ b/internal/admin/key_stats_test.go
@@ -131,7 +131,7 @@ func TestHandleKeyStats_StripsUserIDFromRecentCost(t *testing.T) {
 
 	masked := middleware.MaskKeyID(created.PK)
 	costRec := coststats.NewRecorder()
-	costRec.RecordRequest("openai", masked, "secret-user", "gpt-4o", 0.01, 0.005, 0.005, 10, 5)
+	costRec.RecordRequest("openai", created.PK, "secret-user", "gpt-4o", 0.01, 0.005, 0.005, 10, 5)
 	h.deps.CostSummary = costRec.Snapshot
 	h.deps.PIISummary = pii.NewRecorder().Snapshot
 
@@ -143,12 +143,95 @@ func TestHandleKeyStats_StripsUserIDFromRecentCost(t *testing.T) {
 
 	rawBody := rec.Body.String()
 	assert.NotContains(t, rawBody, "secret-user")
+	assert.NotContains(t, rawBody, created.PK)
 	assert.NotContains(t, rawBody, "user_id")
 
 	var body keyStatsResponse
 	require.NoError(t, json.Unmarshal([]byte(rawBody), &body))
 	require.Len(t, body.RecentCost, 1)
+	require.Equal(t, masked, body.RecentCost[0].KeyID)
 	require.InDelta(t, 0.01, body.RecentCost[0].SpendUSD, 1e-9)
+}
+
+func TestHandleKeyStats_IndependentMetricMerge(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+
+	created, err := store.CreateKey(context.Background(), "openai", "upstream", "stats key", 0, nil, nil, apikeys.KeyRateLimits{})
+	require.NoError(t, err)
+
+	rollup := testAdminRollupStore(t)
+	masked := middleware.MaskKeyID(created.PK)
+	require.NoError(t, rollup.ApplyDelta(ctx, adminrollup.MetricPII, day, adminrollup.Delta{
+		Totals: map[string]float64{"requests_scanned": 2},
+		Dimensions: map[string]map[string]float64{
+			"by_key": {masked: 2},
+		},
+	}))
+
+	h.deps.AdminRollupStore = rollup
+	h.deps.CostSummary = coststats.NewRecorder().Snapshot
+	h.deps.PIISummary = pii.NewRecorder().Snapshot
+
+	rec, body := keyStatsRequest(t, h, "admin@example.com", created.PK)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, body.RollupAvailable)
+	require.Equal(t, "redislive", body.CostToday.Source)
+	require.Equal(t, "redis", body.PIIToday.Source)
+	require.Equal(t, int64(2), body.PIIToday.Detections)
+}
+
+func TestHandleKeyStats_RollupReadFailureFallsBackToMemory(t *testing.T) {
+	h, store := testAdminHandler(t)
+	created, err := store.CreateKey(context.Background(), "openai", "upstream", "stats key", 0, nil, nil, apikeys.KeyRateLimits{})
+	require.NoError(t, err)
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	rollup, err := adminrollup.NewStore(adminrollup.Config{
+		Enabled: true,
+		Redis: &config.RedisConfig{
+			Address: mr.Addr(),
+			DB:      6,
+			DBSet:   true,
+		},
+		HistoryDays: 7,
+	})
+	require.NoError(t, err)
+	mr.Close()
+	t.Cleanup(func() { _ = rollup.Close() })
+
+	costRec := coststats.NewRecorder()
+	masked := middleware.MaskKeyID(created.PK)
+	costRec.RecordRequest("openai", masked, "user", "gpt-4o", 0.05, 0.025, 0.025, 10, 5)
+	h.deps.AdminRollupStore = rollup
+	h.deps.CostSummary = costRec.Snapshot
+	h.deps.PIISummary = pii.NewRecorder().Snapshot
+
+	rec, body := keyStatsRequest(t, h, "admin@example.com", created.PK)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.False(t, body.RollupAvailable)
+	require.Equal(t, "memory", body.CostToday.Source)
+	require.Equal(t, "memory", body.PIIToday.Source)
+	require.InDelta(t, 0.05, body.CostToday.SpendUSD, 1e-9)
+}
+
+func TestMergeKeyStatsRollupBoundIndependent(t *testing.T) {
+	redisCost := adminrollup.KeyCostDayStats{SpendUSD: 1.0}
+	gotCost := mergeKeyCostStats(memoryKeyCost{}, redisCost, true, true)
+	require.Equal(t, "redis", gotCost.Source)
+	require.InDelta(t, 1.0, gotCost.SpendUSD, 1e-9)
+
+	gotCostBound := mergeKeyCostStats(memoryKeyCost{}, redisCost, true, false)
+	require.Equal(t, "memory", gotCostBound.Source)
+
+	gotPII := mergeKeyPIIStats(0, 4, true, true)
+	require.Equal(t, "redis", gotPII.Source)
+	require.Equal(t, int64(4), gotPII.Detections)
+
+	gotPIIBound := mergeKeyPIIStats(0, 4, true, false)
+	require.Equal(t, "memory", gotPIIBound.Source)
 }
 
 func TestHandleKeyStats_StoreUnavailable(t *testing.T) {

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -80,6 +80,7 @@ func RegisterRoutes(r *mux.Router, deps Deps) {
 	api.Handle("/keys", roleHandler(auth, adminusers.RoleViewer, h.handleListKeys)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/keys", roleHandler(auth, adminusers.RoleViewer, h.handleCreateKey)).Methods(http.MethodPost, http.MethodOptions)
 	api.Handle("/provisioning", roleHandler(auth, adminusers.RoleViewer, h.handleProvisioning)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/keys/{key:.+}/stats", roleHandler(auth, adminusers.RoleEditor, h.handleKeyStats)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleViewer, h.handleGetKey)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleViewer, h.handleUpdateKey)).Methods(http.MethodPatch, http.MethodOptions)
 	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleViewer, h.handleDeleteKey)).Methods(http.MethodDelete, http.MethodOptions)

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -80,7 +80,7 @@ func RegisterRoutes(r *mux.Router, deps Deps) {
 	api.Handle("/keys", roleHandler(auth, adminusers.RoleViewer, h.handleListKeys)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/keys", roleHandler(auth, adminusers.RoleViewer, h.handleCreateKey)).Methods(http.MethodPost, http.MethodOptions)
 	api.Handle("/provisioning", roleHandler(auth, adminusers.RoleViewer, h.handleProvisioning)).Methods(http.MethodGet, http.MethodOptions)
-	api.Handle("/keys/{key:.+}/stats", roleHandler(auth, adminusers.RoleEditor, h.handleKeyStats)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/keys/{key:.+}/stats", roleHandler(auth, adminusers.RoleViewer, h.handleKeyStats)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleViewer, h.handleGetKey)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleViewer, h.handleUpdateKey)).Methods(http.MethodPatch, http.MethodOptions)
 	api.Handle("/keys/{key:.+}", roleHandler(auth, adminusers.RoleViewer, h.handleDeleteKey)).Methods(http.MethodDelete, http.MethodOptions)

--- a/internal/adminrollup/key_stats.go
+++ b/internal/adminrollup/key_stats.go
@@ -1,0 +1,210 @@
+package adminrollup
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// KeyCostDayStats holds fleet-wide cost counters for one masked key on one UTC day.
+type KeyCostDayStats struct {
+	SpendUSD       float64 `json:"spend_usd"`
+	InputSpendUSD  float64 `json:"input_spend_usd"`
+	OutputSpendUSD float64 `json:"output_spend_usd"`
+	Requests       int64   `json:"requests"`
+	InputTokens    int64   `json:"input_tokens"`
+	OutputTokens   int64   `json:"output_tokens"`
+}
+
+// KeyDayPoint is one UTC day's scalar for per-key history charts.
+type KeyDayPoint struct {
+	Day   string  `json:"day"`
+	Value float64 `json:"value"`
+}
+
+var costMemberFields = []struct {
+	field string
+	apply func(*KeyCostDayStats, float64)
+}{
+	{"spend_usd", func(s *KeyCostDayStats, v float64) { s.SpendUSD = v }},
+	{"input_spend_usd", func(s *KeyCostDayStats, v float64) { s.InputSpendUSD = v }},
+	{"output_spend_usd", func(s *KeyCostDayStats, v float64) { s.OutputSpendUSD = v }},
+	{"requests", func(s *KeyCostDayStats, v float64) { s.Requests = int64(v) }},
+	{"input_tokens", func(s *KeyCostDayStats, v float64) { s.InputTokens = int64(v) }},
+	{"output_tokens", func(s *KeyCostDayStats, v float64) { s.OutputTokens = int64(v) }},
+}
+
+// KeyCostDayStats reads exact fleet-wide cost counters for one key from today's
+// by_key hash (not the top-N-capped dashboard snapshot).
+func (s *Store) KeyCostDayStats(ctx context.Context, day, keyID string) (KeyCostDayStats, bool, error) {
+	if s == nil || s.be == nil || keyID == "" {
+		return KeyCostDayStats{}, false, nil
+	}
+	hashKey := dimKey(MetricCost, day, "by_key")
+	var out KeyCostDayStats
+	var any bool
+	for _, spec := range costMemberFields {
+		v, err := s.be.hget(ctx, hashKey, dimMemberField(keyID, spec.field))
+		if err != nil {
+			return KeyCostDayStats{}, false, err
+		}
+		if v != 0 {
+			any = true
+			spec.apply(&out, v)
+		}
+	}
+	return out, any, nil
+}
+
+// KeyPIIDayCount reads the fleet-wide PII scan count for one key on a UTC day.
+func (s *Store) KeyPIIDayCount(ctx context.Context, day, keyID string) (int64, bool, error) {
+	if s == nil || s.be == nil || keyID == "" {
+		return 0, false, nil
+	}
+	v, err := s.be.hget(ctx, dimKey(MetricPII, day, "by_key"), keyID)
+	if err != nil {
+		return 0, false, err
+	}
+	if v == 0 {
+		return 0, false, nil
+	}
+	return int64(v), true, nil
+}
+
+// KeyCostDailySeries returns per-day spend for one key over the last days UTC
+// days (inclusive of today). Today is read from the live hash; prior days use
+// archived daily JSON (top-N capped at archive time).
+func (s *Store) KeyCostDailySeries(ctx context.Context, keyID string, days int) ([]KeyDayPoint, bool, error) {
+	return s.keyDailySeries(ctx, MetricCost, keyID, days, costSpendFromDayData)
+}
+
+// KeyPIIDailySeries returns per-day PII detection counts for one key.
+func (s *Store) KeyPIIDailySeries(ctx context.Context, keyID string, days int) ([]KeyDayPoint, bool, error) {
+	return s.keyDailySeries(ctx, MetricPII, keyID, days, piiCountFromDayData)
+}
+
+type dayScalarFn func(map[string]interface{}, string) float64
+
+func (s *Store) keyDailySeries(
+	ctx context.Context,
+	metric, keyID string,
+	days int,
+	scalar dayScalarFn,
+) ([]KeyDayPoint, bool, error) {
+	if s == nil || s.be == nil || keyID == "" || days <= 0 {
+		return nil, false, nil
+	}
+	now := time.Now().UTC()
+	today := now.Format("2006-01-02")
+	out := make([]KeyDayPoint, 0, days)
+	var any bool
+	for i := days - 1; i >= 0; i-- {
+		day := now.AddDate(0, 0, -i).Format("2006-01-02")
+		var value float64
+		if day == today {
+			switch metric {
+			case MetricCost:
+				stats, ok, err := s.KeyCostDayStats(ctx, day, keyID)
+				if err != nil {
+					return nil, false, err
+				}
+				if ok {
+					any = true
+				}
+				value = stats.SpendUSD
+			case MetricPII:
+				count, ok, err := s.KeyPIIDayCount(ctx, day, keyID)
+				if err != nil {
+					return nil, false, err
+				}
+				if ok {
+					any = true
+				}
+				value = float64(count)
+			}
+		} else {
+			data, ok, err := s.loadDailyData(ctx, metric, day)
+			if err != nil {
+				return nil, false, err
+			}
+			if ok {
+				value = scalar(data, keyID)
+				if value > 0 {
+					any = true
+				}
+			}
+		}
+		out = append(out, KeyDayPoint{Day: day, Value: value})
+	}
+	return out, any, nil
+}
+
+func (s *Store) loadDailyData(ctx context.Context, metric, day string) (map[string]interface{}, bool, error) {
+	raw, err := s.be.mget(ctx, []string{dailyKey(metric, day)})
+	if err != nil {
+		return nil, false, err
+	}
+	if len(raw) == 0 || raw[0] == nil {
+		return nil, false, nil
+	}
+	var rec DayRecord
+	if err := json.Unmarshal([]byte(*raw[0]), &rec); err != nil {
+		return nil, false, err
+	}
+	if len(rec.Data) == 0 {
+		return nil, false, nil
+	}
+	return rec.Data, true, nil
+}
+
+func costSpendFromDayData(data map[string]interface{}, keyID string) float64 {
+	rows, ok := data["by_key"].([]interface{})
+	if !ok {
+		return 0
+	}
+	for _, raw := range rows {
+		row, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := row["key_id"].(string)
+		if id != keyID {
+			continue
+		}
+		switch v := row["spend_usd"].(type) {
+		case float64:
+			return v
+		case int:
+			return float64(v)
+		case int64:
+			return float64(v)
+		}
+	}
+	return 0
+}
+
+func piiCountFromDayData(data map[string]interface{}, keyID string) float64 {
+	rows, ok := data["top_keys"].([]interface{})
+	if !ok {
+		return 0
+	}
+	for _, raw := range rows {
+		row, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := row["name"].(string)
+		if name != keyID {
+			continue
+		}
+		switch v := row["count"].(type) {
+		case float64:
+			return v
+		case int:
+			return float64(v)
+		case int64:
+			return float64(v)
+		}
+	}
+	return 0
+}

--- a/internal/adminrollup/key_stats_test.go
+++ b/internal/adminrollup/key_stats_test.go
@@ -77,3 +77,51 @@ func TestKeyCostDailySeriesToday(t *testing.T) {
 	require.Len(t, series, 3)
 	require.InDelta(t, 1.0, series[len(series)-1].Value, 1e-9)
 }
+
+func TestKeyCostDailySeriesArchivedDay(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+	const key = "iw:abc…deadbeef"
+
+	require.NoError(t, store.ArchiveDaily(ctx, MetricCost, yesterday, map[string]interface{}{
+		"by_key": []interface{}{
+			map[string]interface{}{"key_id": key, "spend_usd": 2.5},
+		},
+	}))
+
+	series, ok, err := store.KeyCostDailySeries(ctx, key, 2)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, series, 2)
+	require.Equal(t, yesterday, series[0].Day)
+	require.InDelta(t, 2.5, series[0].Value, 1e-9)
+}
+
+func TestKeyPIIDailySeries(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+	const key = "iw:abc…deadbeef"
+
+	require.NoError(t, store.ApplyDelta(ctx, MetricPII, day, Delta{
+		Totals: map[string]float64{"requests_scanned": 1},
+		Dimensions: map[string]map[string]float64{
+			"by_key": {key: 1},
+		},
+	}))
+	require.NoError(t, store.ArchiveDaily(ctx, MetricPII, yesterday, map[string]interface{}{
+		"top_keys": []interface{}{
+			map[string]interface{}{"name": key, "count": int64(3)},
+		},
+	}))
+
+	series, ok, err := store.KeyPIIDailySeries(ctx, key, 2)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, series, 2)
+	require.Equal(t, yesterday, series[0].Day)
+	require.InDelta(t, 3, series[0].Value, 1e-9)
+	require.InDelta(t, 1, series[len(series)-1].Value, 1e-9)
+}

--- a/internal/adminrollup/key_stats_test.go
+++ b/internal/adminrollup/key_stats_test.go
@@ -1,0 +1,79 @@
+package adminrollup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyCostDayStats(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+	const key = "iw:abc…deadbeef"
+
+	require.NoError(t, store.ApplyDelta(ctx, MetricCost, day, Delta{
+		Totals: map[string]float64{"spend_usd": 0.55},
+		Dimensions: map[string]map[string]float64{
+			"by_key": {
+				dimMemberField(key, "spend_usd"):        0.55,
+				dimMemberField(key, "input_spend_usd"):  0.50,
+				dimMemberField(key, "output_spend_usd"): 0.05,
+				dimMemberField(key, "requests"):         3,
+				dimMemberField(key, "input_tokens"):     1000,
+				dimMemberField(key, "output_tokens"):    50,
+			},
+		},
+	}))
+
+	stats, ok, err := store.KeyCostDayStats(ctx, day, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.InDelta(t, 0.55, stats.SpendUSD, 1e-9)
+	require.InDelta(t, 0.50, stats.InputSpendUSD, 1e-9)
+	require.InDelta(t, 0.05, stats.OutputSpendUSD, 1e-9)
+	require.Equal(t, int64(3), stats.Requests)
+	require.Equal(t, int64(1000), stats.InputTokens)
+	require.Equal(t, int64(50), stats.OutputTokens)
+}
+
+func TestKeyPIIDayCount(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+	const key = "iw:abc…deadbeef"
+
+	require.NoError(t, store.ApplyDelta(ctx, MetricPII, day, Delta{
+		Totals: map[string]float64{"requests_scanned": 2},
+		Dimensions: map[string]map[string]float64{
+			"by_key": {key: 2},
+		},
+	}))
+
+	count, ok, err := store.KeyPIIDayCount(ctx, day, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, int64(2), count)
+}
+
+func TestKeyCostDailySeriesToday(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	day := time.Now().UTC().Format("2006-01-02")
+	const key = "iw:abc…deadbeef"
+
+	require.NoError(t, store.ApplyDelta(ctx, MetricCost, day, Delta{
+		Totals: map[string]float64{"spend_usd": 1.0},
+		Dimensions: map[string]map[string]float64{
+			"by_key": {dimMemberField(key, "spend_usd"): 1.0},
+		},
+	}))
+
+	series, ok, err := store.KeyCostDailySeries(ctx, key, 3)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, series, 3)
+	require.InDelta(t, 1.0, series[len(series)-1].Value, 1e-9)
+}

--- a/web/src/components/keys/key-detail-tables.tsx
+++ b/web/src/components/keys/key-detail-tables.tsx
@@ -4,10 +4,10 @@ import type { ColumnDef } from "@tanstack/react-table";
 import DataTable from "../ui/data-table";
 import { ProviderBadge } from "../ui/page-header";
 import { formatCount, formatUsd } from "../../lib/format";
-import type { CostRecentEvent, PIIRecentEvent } from "../../types";
+import type { KeyCostRecentEvent, KeyPIIRecentEvent } from "../../types";
 
-function piiOutcomeBadge(outcome: PIIRecentEvent["outcome"]) {
-  const map: Record<PIIRecentEvent["outcome"], string> = {
+function piiOutcomeBadge(outcome: KeyPIIRecentEvent["outcome"]) {
+  const map: Record<KeyPIIRecentEvent["outcome"], string> = {
     ok: "badge-success",
     fail_open: "badge-warning",
     fail_closed: "badge-error",
@@ -16,8 +16,8 @@ function piiOutcomeBadge(outcome: PIIRecentEvent["outcome"]) {
   return <span className={`badge badge-sm ${map[outcome]}`}>{outcome}</span>;
 }
 
-export function KeyCostEventsTable({ rows }: { rows: CostRecentEvent[] }) {
-  const columns = useMemo<ColumnDef<CostRecentEvent, unknown>[]>(
+export function KeyCostEventsTable({ rows }: { rows: KeyCostRecentEvent[] }) {
+  const columns = useMemo<ColumnDef<KeyCostRecentEvent, unknown>[]>(
     () => [
       {
         id: "time",
@@ -81,8 +81,8 @@ export function KeyCostEventsTable({ rows }: { rows: CostRecentEvent[] }) {
   );
 }
 
-export function KeyPiiEventsTable({ rows }: { rows: PIIRecentEvent[] }) {
-  const columns = useMemo<ColumnDef<PIIRecentEvent, unknown>[]>(
+export function KeyPiiEventsTable({ rows }: { rows: KeyPIIRecentEvent[] }) {
+  const columns = useMemo<ColumnDef<KeyPIIRecentEvent, unknown>[]>(
     () => [
       {
         id: "time",
@@ -118,7 +118,7 @@ export function KeyPiiEventsTable({ rows }: { rows: PIIRecentEvent[] }) {
         id: "outcome",
         accessorKey: "outcome",
         header: "Outcome",
-        cell: ({ getValue }) => piiOutcomeBadge(getValue<PIIRecentEvent["outcome"]>()),
+        cell: ({ getValue }) => piiOutcomeBadge(getValue<KeyPIIRecentEvent["outcome"]>()),
       },
       {
         id: "latency",

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -76,7 +76,7 @@ export function useKeyStats(key: string | undefined) {
   return useQuery({
     queryKey: queryKeys.keyStats(key ?? ""),
     queryFn: () => apiFetch<KeyStatsResponse>(`/admin/api/keys/${encodeURIComponent(key!)}/stats`),
-    enabled: Boolean(key) && roleAtLeast(role, "editor"),
+    enabled: Boolean(key) && roleAtLeast(role, "viewer"),
     refetchInterval,
     refetchIntervalInBackground: true,
   });

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -11,6 +11,7 @@ import type {
   CreateAdminUserRequest,
   CreateAPIKeyRequest,
   HealthResponse,
+  KeyStatsResponse,
   CircuitActivityResponse,
   PIIResponse,
   ProvisioningStatus,
@@ -28,6 +29,7 @@ export const queryKeys = {
   me: ["admin", "me"] as const,
   keys: (provider?: string) => ["admin", "keys", provider ?? "all"] as const,
   key: (key: string) => ["admin", "keys", "detail", key] as const,
+  keyStats: (key: string) => ["admin", "keys", "stats", key] as const,
   config: ["admin", "config"] as const,
   health: ["admin", "health"] as const,
   circuitActivity: ["admin", "circuit-activity"] as const,
@@ -64,6 +66,19 @@ export function useKey(key: string | undefined) {
     queryKey: queryKeys.key(key ?? ""),
     queryFn: () => apiFetch<APIKey>(`/admin/api/keys/${encodeURIComponent(key!)}`),
     enabled: Boolean(key) && roleAtLeast(role, "viewer"),
+  });
+}
+
+export function useKeyStats(key: string | undefined) {
+  const { data: me } = useMe();
+  const role = me?.role ?? "viewer";
+  const refetchInterval = usePollInterval();
+  return useQuery({
+    queryKey: queryKeys.keyStats(key ?? ""),
+    queryFn: () => apiFetch<KeyStatsResponse>(`/admin/api/keys/${encodeURIComponent(key!)}/stats`),
+    enabled: Boolean(key) && roleAtLeast(role, "editor"),
+    refetchInterval,
+    refetchIntervalInBackground: true,
   });
 }
 

--- a/web/src/lib/daily-history.ts
+++ b/web/src/lib/daily-history.ts
@@ -190,21 +190,6 @@ export function aggCostByProvider(
   return [...acc.values()].sort((a, b) => b.spend_usd - a.spend_usd);
 }
 
-/** Per-day spend for one masked key (for the key-detail sparkline). */
-export function costSeriesForKey(
-  rows: DailyHistoryRow[] | undefined,
-  maskedKey: string,
-  range: RangeKey = "7d",
-): { labels: string[]; values: number[]; available: boolean } {
-  const slice = sliceRange(rows, range === "today" ? "7d" : range);
-  if (!slice.length || !maskedKey) return { labels: [], values: [], available: false };
-  const values = slice.map((row) => {
-    const match = asArray(row.by_key).find((r) => String(r.key_id ?? "") === maskedKey);
-    return match ? asNum(match.spend_usd) : 0;
-  });
-  return { labels: slice.map((r) => r.day.slice(5)), values, available: true };
-}
-
 // --- Usage breakdowns (scope maps) ------------------------------------------
 
 export interface ScopeAgg {

--- a/web/src/lib/key-stats.ts
+++ b/web/src/lib/key-stats.ts
@@ -1,35 +1,6 @@
 import { maskKeyId } from "./format";
 import { redactedRateLimitScopeForKey } from "./key-routes";
-import type {
-  CostRecentEvent,
-  CostStats,
-  PIIRecentEvent,
-  PIIStats,
-  RateLimitConfig,
-  RateLimitsResponse,
-} from "../types";
-
-export function costStatsForKey(stats: CostStats | undefined, key: string) {
-  const masked = maskKeyId(key);
-  return stats?.by_key?.find((row) => row.key_id === masked || row.key_id === key);
-}
-
-export function costRecentForKey(stats: CostStats | undefined, key: string): CostRecentEvent[] {
-  const masked = maskKeyId(key);
-  return (stats?.recent ?? []).filter((ev) => ev.key_id === masked || ev.key_id === key);
-}
-
-export function piiRecentForKey(stats: PIIStats | undefined, key: string): PIIRecentEvent[] {
-  const masked = maskKeyId(key);
-  return (stats?.recent ?? []).filter((ev) => ev.key_id === masked);
-}
-
-export function piiDetectionsForKey(stats: PIIStats | undefined, key: string): number {
-  const masked = maskKeyId(key);
-  const fromTop = stats?.top_keys?.find((row) => row.name === masked)?.count;
-  if (fromTop !== undefined) return fromTop;
-  return piiRecentForKey(stats, key).filter((ev) => ev.entity_total > 0).length;
-}
+import type { RateLimitConfig, RateLimitsResponse } from "../types";
 
 export function rateLimitScopeForKey(key: string): string {
   return `key:${key}`;

--- a/web/src/pages/keys/detail.tsx
+++ b/web/src/pages/keys/detail.tsx
@@ -18,18 +18,12 @@ import {
 } from "../../components/ui/data-source";
 import { BarChart, ChartCard } from "../../components/charts";
 import { chartPalette } from "../../components/charts/chart-setup";
-import { useCost, useKey, useMe, usePII, useRateLimits } from "../../hooks/queries";
-import { aggCostByKey, DAILY_HISTORY_SUBTITLE, costSeriesForKey } from "../../lib/daily-history";
+import { useKey, useKeyStats, useMe, usePII, useRateLimits } from "../../hooks/queries";
+import { DAILY_HISTORY_SUBTITLE } from "../../lib/daily-history";
 import { formatDailyCostLimit, formatUsd, maskKeyId } from "../../lib/format";
 import { decodeKeyRouteParam, isProxyKey } from "../../lib/key-routes";
-import {
-  costRecentForKey,
-  costStatsForKey,
-  piiDetectionsForKey,
-  piiRecentForKey,
-  rateLimitOverrideForKey,
-  rateLimitUsageForKey,
-} from "../../lib/key-stats";
+import { rateLimitOverrideForKey, rateLimitUsageForKey } from "../../lib/key-stats";
+import type { KeyStatsSource } from "../../types";
 
 function formatMonthlyCostLimit(cents?: number): string {
   if (!cents || cents <= 0) {
@@ -48,6 +42,14 @@ function formatLimit(value?: number): string {
   return value && value > 0 ? value.toLocaleString() : "∞";
 }
 
+function statsSource(source: KeyStatsSource): DataSource {
+  return source;
+}
+
+function chartLabels(points: { day: string }[]): string[] {
+  return points.map((p) => p.day.slice(5));
+}
+
 export default function KeyDetailPage() {
   const { key: keyParam } = useParams<{ key: string }>();
   const { data: me } = useMe();
@@ -56,50 +58,38 @@ export default function KeyDetailPage() {
   const validKey = isProxyKey(keyValue) ? keyValue : undefined;
 
   const keyQuery = useKey(validKey);
-  const costQuery = useCost();
+  const statsQuery = useKeyStats(validKey);
   const piiQuery = usePII();
   const rateQuery = useRateLimits();
 
   const keyRecord = keyQuery.data;
   const keyError = keyQuery.error;
+  const stats = statsQuery.data;
 
   const masked = validKey ? maskKeyId(validKey) : "";
-  const costStats = costStatsForKey(costQuery.data?.stats, validKey ?? "");
-  const costRecent = costRecentForKey(costQuery.data?.stats, validKey ?? "");
-  const piiRecent = piiRecentForKey(piiQuery.data?.stats, validKey ?? "");
-  const piiDetections = piiDetectionsForKey(piiQuery.data?.stats, validKey ?? "");
   const rateUsage = rateLimitUsageForKey(rateQuery.data, validKey ?? "");
   const rateOverride = rateLimitOverrideForKey(rateQuery.data, validKey ?? "");
   const rateSource = rateLimitUsageSource(rateQuery.data?.backend);
-  const costHistory = costQuery.data?.stats?.daily_history;
-  const hasCostRedis = Boolean(costQuery.data?.stats?.daily_history_available);
-  const keySpend7d = costSeriesForKey(costHistory, masked, "7d");
-  // Prefer the fleet-wide Redis today rollup for this key over this pod's memory.
-  const keyTodayCost = hasCostRedis
-    ? aggCostByKey(costHistory, "today").find((r) => r.key_id === masked)
-    : undefined;
-  const spendTodayValue = keyTodayCost ? keyTodayCost.spend_usd : (costStats?.spend_usd ?? 0);
-  const requestsTodayValue = keyTodayCost ? keyTodayCost.requests : (costStats?.requests ?? 0);
-  const keyCostSource: DataSource = keyTodayCost ? "redislive" : "memory";
-  // PII detections come from the fleet-wide top_keys rollup (overlaid by
-  // MergeToday) when Redis is on; only falls back to the memory ring buffer for
-  // keys outside the rolled-up top-N.
-  const hasPiiRedis = Boolean(piiQuery.data?.stats?.daily_history_available);
-  const piiSource: DataSource = hasPiiRedis ? "redislive" : "memory";
+
+  const costToday = stats?.cost_today;
+  const piiToday = stats?.pii_today;
+  const costSource = statsSource(costToday?.source ?? "memory");
+  const piiSource = statsSource(piiToday?.source ?? "memory");
+  const costHistory = stats?.cost_history ?? [];
+  const piiHistory = stats?.pii_history ?? [];
+  const recentCost = stats?.recent_cost ?? [];
+  const recentPii = stats?.recent_pii ?? [];
 
   const liveUpdatedAt = Math.max(
-    costQuery.dataUpdatedAt,
-    piiQuery.dataUpdatedAt,
+    statsQuery.dataUpdatedAt,
     rateQuery.dataUpdatedAt,
     keyQuery.dataUpdatedAt,
   );
-  const liveFetching =
-    costQuery.isFetching || piiQuery.isFetching || rateQuery.isFetching || keyQuery.isFetching;
+  const liveFetching = statsQuery.isFetching || rateQuery.isFetching || keyQuery.isFetching;
 
   const refreshAll = () => {
     keyQuery.refetch();
-    costQuery.refetch();
-    piiQuery.refetch();
+    statsQuery.refetch();
     rateQuery.refetch();
   };
 
@@ -118,7 +108,7 @@ export default function KeyDetailPage() {
     );
   }
 
-  if (keyQuery.isLoading && !costQuery.data && !piiQuery.data && !rateQuery.data) {
+  if (keyQuery.isLoading && !statsQuery.data && !rateQuery.data) {
     return <LoadingBlock />;
   }
 
@@ -153,7 +143,7 @@ export default function KeyDetailPage() {
 
       {notFound ? (
         <div className="alert alert-warning">
-          <span>Key metadata unavailable — showing stats for {masked} only.</span>
+          <span>Key metadata unavailable — open this page from a registered key to see stats.</span>
         </div>
       ) : null}
 
@@ -208,80 +198,116 @@ export default function KeyDetailPage() {
 
       {!isViewer ? (
         <>
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <LiveStat title="Spend today" value={formatUsd(spendTodayValue)} hint="tracked cost" source={keyCostSource} />
-        <LiveStat
-          title="Requests"
-          value={requestsTodayValue.toLocaleString()}
-          hint="cost tracker"
-          source={keyCostSource}
-        />
-        <LiveStat
-          title="PII detections"
-          value={piiDetections.toLocaleString()}
-          hint={`${piiRecent.length} recent events`}
-          source={piiSource}
-        />
-        <LiveStat
-          title="Rate usage"
-          value={rateUsage.reduce((s, r) => s + r.requests, 0).toLocaleString()}
-          hint="requests in live windows"
-          source={rateSource}
-        />
-      </div>
-
-      {hasCostRedis && keySpend7d.available ? (
-        <ChartCard
-          title="Spend over time"
-          subtitle={`Last 7 days for this key · ${DAILY_HISTORY_SUBTITLE}`}
-          source="redis"
-        >
-          <BarChart
-            labels={keySpend7d.labels}
-            values={keySpend7d.values}
-            label="Daily spend (USD)"
-            colors={keySpend7d.labels.map(() => chartPalette.primary())}
-          />
-        </ChartCard>
-      ) : null}
-
-      <div className="grid gap-4 lg:grid-cols-2">
-        <Section title="Cost" subtitle="Today's tracked spend for this key" source="memory">
-          <div className="grid gap-4 p-5 sm:grid-cols-2 lg:grid-cols-3">
-            <Meta label="Total spend" value={formatUsd(costStats?.spend_usd ?? 0)} />
-            <Meta label="Input spend" value={formatUsd(costStats?.input_spend_usd ?? 0)} />
-            <Meta label="Output spend" value={formatUsd(costStats?.output_spend_usd ?? 0)} />
-            <Meta label="Requests" value={costStats?.requests ?? 0} />
-            <Meta label="Input tokens" value={(costStats?.input_tokens ?? 0).toLocaleString()} />
-            <Meta label="Output tokens" value={(costStats?.output_tokens ?? 0).toLocaleString()} />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <LiveStat
+              title="Spend today"
+              value={formatUsd(costToday?.spend_usd ?? 0)}
+              hint="tracked cost"
+              source={costSource}
+            />
+            <LiveStat
+              title="Requests"
+              value={(costToday?.requests ?? 0).toLocaleString()}
+              hint="cost tracker"
+              source={costSource}
+            />
+            <LiveStat
+              title="PII detections"
+              value={(piiToday?.detections ?? 0).toLocaleString()}
+              hint={`${recentPii.length} recent events`}
+              source={piiSource}
+            />
+            <LiveStat
+              title="Rate usage"
+              value={rateUsage.reduce((s, r) => s + r.requests, 0).toLocaleString()}
+              hint="requests in live windows"
+              source={rateSource}
+            />
           </div>
-          <KeyCostEventsTable rows={costRecent} />
-        </Section>
 
-        <Section title="PII redaction" subtitle="Recent events are memory-only (last 50)" source="memory">
-          <div className="grid gap-4 p-5 sm:grid-cols-2">
-            <Meta label="Recent events" value={piiRecent.length} />
-            <Meta label="Top-key count" value={piiDetections} />
-            <Meta label="Global fail mode" value={piiQuery.data?.fail_mode ?? "—"} />
-            <Meta label="Per-key override" value={keyRecord ? piiLabel(keyRecord.redact_pii) : "—"} />
+          {stats?.rollup_available && costHistory.length > 0 ? (
+            <ChartCard
+              title="Spend over time"
+              subtitle={`Last 7 days for this key · ${DAILY_HISTORY_SUBTITLE}`}
+              source="redis"
+            >
+              <BarChart
+                labels={chartLabels(costHistory)}
+                values={costHistory.map((p) => p.value)}
+                label="Daily spend (USD)"
+                colors={costHistory.map(() => chartPalette.primary())}
+              />
+            </ChartCard>
+          ) : null}
+
+          {stats?.rollup_available && piiHistory.length > 0 ? (
+            <ChartCard
+              title="PII detections over time"
+              subtitle={`Last 7 days for this key · ${DAILY_HISTORY_SUBTITLE}`}
+              source="redis"
+            >
+              <BarChart
+                labels={chartLabels(piiHistory)}
+                values={piiHistory.map((p) => p.value)}
+                label="Daily detections"
+                colors={piiHistory.map(() => chartPalette.warning())}
+              />
+            </ChartCard>
+          ) : null}
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <Section
+              title="Cost"
+              subtitle={
+                stats?.rollup_available
+                  ? "Today's fleet-wide rollup for this key (direct Redis read) · recent events below are memory-only (last 50)"
+                  : "Today's tracked spend for this key · recent events are memory-only (last 50)"
+              }
+              source={costSource}
+            >
+              <div className="grid gap-4 p-5 sm:grid-cols-2 lg:grid-cols-3">
+                <Meta label="Total spend" value={formatUsd(costToday?.spend_usd ?? 0)} />
+                <Meta label="Input spend" value={formatUsd(costToday?.input_spend_usd ?? 0)} />
+                <Meta label="Output spend" value={formatUsd(costToday?.output_spend_usd ?? 0)} />
+                <Meta label="Requests" value={costToday?.requests ?? 0} />
+                <Meta label="Input tokens" value={(costToday?.input_tokens ?? 0).toLocaleString()} />
+                <Meta label="Output tokens" value={(costToday?.output_tokens ?? 0).toLocaleString()} />
+              </div>
+              <KeyCostEventsTable rows={recentCost} />
+            </Section>
+
+            <Section
+              title="PII redaction"
+              subtitle={
+                stats?.rollup_available
+                  ? "Detection count from fleet-wide Redis (direct read) · recent events below are memory-only (last 50)"
+                  : "Recent events are memory-only (last 50)"
+              }
+              source={piiSource}
+            >
+              <div className="grid gap-4 p-5 sm:grid-cols-2">
+                <Meta label="Recent events" value={recentPii.length} />
+                <Meta label="Top-key count" value={piiToday?.detections ?? 0} />
+                <Meta label="Global fail mode" value={piiQuery.data?.fail_mode ?? "—"} />
+                <Meta label="Per-key override" value={keyRecord ? piiLabel(keyRecord.redact_pii) : "—"} />
+              </div>
+              <KeyPiiEventsTable rows={recentPii} />
+            </Section>
           </div>
-          <KeyPiiEventsTable rows={piiRecent} />
-        </Section>
-      </div>
 
-      <Section
-        title="Rate limits"
-        subtitle="Overrides from key config (DynamoDB); usage from rate-limit backend"
-        source={rateSource}
-      >
-        <div className="grid gap-4 p-5 sm:grid-cols-2 lg:grid-cols-4">
-          <Meta label="RPM override" value={formatLimit(rateOverride?.RequestsPerMinute ?? keyRecord?.rate_limit_rpm)} />
-          <Meta label="TPM override" value={formatLimit(rateOverride?.TokensPerMinute ?? keyRecord?.rate_limit_tpm)} />
-          <Meta label="RPD override" value={formatLimit(rateOverride?.RequestsPerDay ?? keyRecord?.rate_limit_rpd)} />
-          <Meta label="TPD override" value={formatLimit(rateOverride?.TokensPerDay ?? keyRecord?.rate_limit_tpd)} />
-        </div>
-        <KeyRateUsageTable rows={rateUsage} />
-      </Section>
+          <Section
+            title="Rate limits"
+            subtitle="Overrides from key config (DynamoDB); usage from rate-limit backend"
+            source={rateSource}
+          >
+            <div className="grid gap-4 p-5 sm:grid-cols-2 lg:grid-cols-4">
+              <Meta label="RPM override" value={formatLimit(rateOverride?.RequestsPerMinute ?? keyRecord?.rate_limit_rpm)} />
+              <Meta label="TPM override" value={formatLimit(rateOverride?.TokensPerMinute ?? keyRecord?.rate_limit_tpm)} />
+              <Meta label="RPD override" value={formatLimit(rateOverride?.RequestsPerDay ?? keyRecord?.rate_limit_rpd)} />
+              <Meta label="TPD override" value={formatLimit(rateOverride?.TokensPerDay ?? keyRecord?.rate_limit_tpd)} />
+            </div>
+            <KeyRateUsageTable rows={rateUsage} />
+          </Section>
         </>
       ) : null}
     </div>

--- a/web/src/pages/keys/detail.tsx
+++ b/web/src/pages/keys/detail.tsx
@@ -135,9 +135,7 @@ export default function KeyDetailPage() {
                 : "Per-key cost, PII, and rate-limit stats."
         }
         actions={
-          isViewer ? undefined : (
-            <LiveIndicator updatedAt={liveUpdatedAt} fetching={liveFetching} onRefresh={refreshAll} />
-          )
+          <LiveIndicator updatedAt={liveUpdatedAt} fetching={liveFetching} onRefresh={refreshAll} />
         }
       />
 
@@ -196,9 +194,9 @@ export default function KeyDetailPage() {
         </div>
       ) : null}
 
-      {!isViewer ? (
+      {keyRecord ? (
         <>
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className={`grid gap-4 sm:grid-cols-2 ${isViewer ? "xl:grid-cols-3" : "xl:grid-cols-4"}`}>
             <LiveStat
               title="Spend today"
               value={formatUsd(costToday?.spend_usd ?? 0)}
@@ -217,12 +215,14 @@ export default function KeyDetailPage() {
               hint={`${recentPii.length} recent events`}
               source={piiSource}
             />
-            <LiveStat
-              title="Rate usage"
-              value={rateUsage.reduce((s, r) => s + r.requests, 0).toLocaleString()}
-              hint="requests in live windows"
-              source={rateSource}
-            />
+            {!isViewer ? (
+              <LiveStat
+                title="Rate usage"
+                value={rateUsage.reduce((s, r) => s + r.requests, 0).toLocaleString()}
+                hint="requests in live windows"
+                source={rateSource}
+              />
+            ) : null}
           </div>
 
           {stats?.rollup_available && costHistory.length > 0 ? (
@@ -288,26 +288,32 @@ export default function KeyDetailPage() {
               <div className="grid gap-4 p-5 sm:grid-cols-2">
                 <Meta label="Recent events" value={recentPii.length} />
                 <Meta label="Top-key count" value={piiToday?.detections ?? 0} />
-                <Meta label="Global fail mode" value={piiQuery.data?.fail_mode ?? "—"} />
-                <Meta label="Per-key override" value={keyRecord ? piiLabel(keyRecord.redact_pii) : "—"} />
+                {!isViewer ? (
+                  <>
+                    <Meta label="Global fail mode" value={piiQuery.data?.fail_mode ?? "—"} />
+                    <Meta label="Per-key override" value={keyRecord ? piiLabel(keyRecord.redact_pii) : "—"} />
+                  </>
+                ) : null}
               </div>
               <KeyPiiEventsTable rows={recentPii} />
             </Section>
           </div>
 
-          <Section
-            title="Rate limits"
-            subtitle="Overrides from key config (DynamoDB); usage from rate-limit backend"
-            source={rateSource}
-          >
-            <div className="grid gap-4 p-5 sm:grid-cols-2 lg:grid-cols-4">
-              <Meta label="RPM override" value={formatLimit(rateOverride?.RequestsPerMinute ?? keyRecord?.rate_limit_rpm)} />
-              <Meta label="TPM override" value={formatLimit(rateOverride?.TokensPerMinute ?? keyRecord?.rate_limit_tpm)} />
-              <Meta label="RPD override" value={formatLimit(rateOverride?.RequestsPerDay ?? keyRecord?.rate_limit_rpd)} />
-              <Meta label="TPD override" value={formatLimit(rateOverride?.TokensPerDay ?? keyRecord?.rate_limit_tpd)} />
-            </div>
-            <KeyRateUsageTable rows={rateUsage} />
-          </Section>
+          {!isViewer ? (
+            <Section
+              title="Rate limits"
+              subtitle="Overrides from key config (DynamoDB); usage from rate-limit backend"
+              source={rateSource}
+            >
+              <div className="grid gap-4 p-5 sm:grid-cols-2 lg:grid-cols-4">
+                <Meta label="RPM override" value={formatLimit(rateOverride?.RequestsPerMinute ?? keyRecord?.rate_limit_rpm)} />
+                <Meta label="TPM override" value={formatLimit(rateOverride?.TokensPerMinute ?? keyRecord?.rate_limit_tpm)} />
+                <Meta label="RPD override" value={formatLimit(rateOverride?.RequestsPerDay ?? keyRecord?.rate_limit_rpd)} />
+                <Meta label="TPD override" value={formatLimit(rateOverride?.TokensPerDay ?? keyRecord?.rate_limit_tpd)} />
+              </div>
+              <KeyRateUsageTable rows={rateUsage} />
+            </Section>
+          ) : null}
         </>
       ) : null}
     </div>

--- a/web/src/pages/keys/detail.tsx
+++ b/web/src/pages/keys/detail.tsx
@@ -108,7 +108,7 @@ export default function KeyDetailPage() {
     );
   }
 
-  if (keyQuery.isLoading && !statsQuery.data && !rateQuery.data) {
+  if (keyQuery.isPending || statsQuery.isPending || (!isViewer && rateQuery.isPending)) {
     return <LoadingBlock />;
   }
 
@@ -145,7 +145,7 @@ export default function KeyDetailPage() {
         </div>
       ) : null}
 
-      {keyRecord ? (
+      {keyRecord && !notFound ? (
         <div className="glass-panel p-5">
           <div className="mb-3 flex flex-wrap items-center gap-2">
             <span className="text-sm font-medium text-base-content/70">Key metadata</span>
@@ -194,7 +194,7 @@ export default function KeyDetailPage() {
         </div>
       ) : null}
 
-      {keyRecord ? (
+      {keyRecord && !notFound ? (
         <>
           <div className={`grid gap-4 sm:grid-cols-2 ${isViewer ? "xl:grid-cols-3" : "xl:grid-cols-4"}`}>
             <LiveStat

--- a/web/src/pages/keys/index.tsx
+++ b/web/src/pages/keys/index.tsx
@@ -13,11 +13,13 @@ import { formatShareExpiry } from "../../lib/share-expiry";
 import { dailyCostLimitFormDollars } from "../../lib/format";
 import {
   useConfig,
+  useCost,
   useCreateKey,
   useCreateShare,
   useDeleteKey,
   useKeys,
   useMe,
+  usePII,
   useProvisioning,
   useUpdateKey,
 } from "../../hooks/queries";
@@ -116,10 +118,27 @@ function rateLimitsFromForm(form: KeyFormState) {
   };
 }
 
+function keyStatsDescription(hasCostRedis: boolean, hasPiiRedis: boolean): string {
+  if (hasCostRedis && hasPiiRedis) {
+    return "Key registry is DynamoDB. Per-key spend and PII stats use Redis rollups (today updates live).";
+  }
+  if (hasCostRedis) {
+    return "Key registry is DynamoDB. Per-key spend uses Redis rollups; PII stats are in-memory (today only).";
+  }
+  if (hasPiiRedis) {
+    return "Key registry is DynamoDB. Per-key PII stats use Redis rollups; spend is in-memory (today only).";
+  }
+  return "Key registry is DynamoDB. Spend and PII stats on each key are in-memory (today only).";
+}
+
 export default function KeysPage() {
   const { push } = useToast();
   const { data: me } = useMe();
   const { data: config } = useConfig();
+  const { data: costData } = useCost();
+  const { data: piiData } = usePII();
+  const hasCostRedis = Boolean(costData?.stats?.daily_history_available);
+  const hasPiiRedis = Boolean(piiData?.stats?.daily_history_available);
   const globalPiiEnabled = Boolean(config?.features?.pii_redact);
   const canBypassPiiBedrockPolicy = Boolean(
     me?.can_bypass_pii_off_non_bedrock_policy,
@@ -555,7 +574,7 @@ export default function KeysPage() {
             ? viewerMonthlyCents > 0
               ? `Personal proxy keys (one per provider). Monthly spend is capped at ${viewerMonthlyLimitLabel}.`
               : "Personal proxy keys (one per provider). Monthly spend is unlimited."
-            : "Key registry is DynamoDB. Spend and PII stats on each key are in-memory (today only)."
+            : keyStatsDescription(hasCostRedis, hasPiiRedis)
         }
         actions={
           <>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -128,11 +128,11 @@ export interface ConfigSummary {
 export interface DailyHistoryRow {
   day: string;
   [key: string]:
-    | string
-    | number
-    | boolean
-    | undefined
-    | Record<string, unknown>;
+  | string
+  | number
+  | boolean
+  | undefined
+  | Record<string, unknown>;
 }
 
 export interface StatsWithDailyHistory {
@@ -395,4 +395,61 @@ export interface ShareInfo {
 
 export interface APIError {
   error: string;
+}
+
+export type KeyStatsSource = "memory" | "redis" | "redislive";
+
+export interface KeyCostStats {
+  source: KeyStatsSource;
+  spend_usd: number;
+  input_spend_usd: number;
+  output_spend_usd: number;
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+export interface KeyPIIStats {
+  source: KeyStatsSource;
+  detections: number;
+}
+
+export interface KeyDayPoint {
+  day: string;
+  value: number;
+}
+
+export interface KeyCostRecentEvent {
+  time: number;
+  provider: string;
+  key_id?: string;
+  spend_usd: number;
+  input_spend_usd?: number;
+  output_spend_usd?: number;
+  input_tokens: number;
+  output_tokens: number;
+  model?: string;
+}
+
+export interface KeyPIIRecentEvent {
+  time: number;
+  provider: string;
+  key_id?: string;
+  entity_counts: Record<string, number>;
+  entity_total: number;
+  duration_ms: number;
+  outcome: "ok" | "fail_open" | "fail_closed" | "oversize";
+}
+
+export interface KeyStatsResponse {
+  masked_key_id: string;
+  day: string;
+  rollup_available: boolean;
+  rollup_backend?: string;
+  cost_today: KeyCostStats;
+  pii_today: KeyPIIStats;
+  cost_history: KeyDayPoint[];
+  pii_history: KeyDayPoint[];
+  recent_cost: KeyCostRecentEvent[];
+  recent_pii: KeyPIIRecentEvent[];
 }


### PR DESCRIPTION
Add an editor-only stats endpoint that reads cost and PII rollups for a registered key directly from Redis instead of capped fleet summaries, and wire the key detail UI to it with sanitized recent-event payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an admin endpoint for viewing per-API-key cost and PII statistics, including UTC daily breakdowns and recent event history, with safe key masking.
  * Enhanced the dashboard to use Redis rollups when available for more complete “today” and historical data.

* **UI Improvements**
  * Streamlined the key details page to fetch and render cost and PII stats together, with clear labeling for rollup-backed versus memory-only data.

* **Tests**
  * Expanded admin and rollup unit tests for stats reads, authorization, sanitization, rollup fallback behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->