### PR TITLE
feat(config): model audit Jun 2026 — retired-model middleware and config updates

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -144,6 +144,9 @@ var globalCircuitStore circuit.Store
 // In-process circuit activity (checks, probes, fast-fails) for the admin UI.
 var globalCircuitStatsRecorder *circuitstats.Recorder
 
+// In-process model status (retired, deprecated, unknown) for the admin UI.
+var globalModelStatusRecorder *modelstatusstats.Recorder
+
 // Resolved circuit-breaker config after Defaults() is applied.  Captured at
 // startup so /health can surface the effective mode / backend / thresholds
 // without re-reading YAML.
@@ -954,6 +957,13 @@ func circuitActivitySummaryFunc() func() map[string]interface{} {
 	return globalCircuitStatsRecorder.Snapshot
 }
 
+func modelStatusSummaryFunc() func() map[string]interface{} {
+	if globalModelStatusRecorder == nil {
+		return nil
+	}
+	return globalModelStatusRecorder.Snapshot
+}
+
 func initHistory(yamlConfig *config.YAMLConfig) {
 	hc := yamlConfig.Features.History
 	if hc.Backend == "" || strings.EqualFold(hc.Backend, "none") {
@@ -1018,6 +1028,9 @@ func initAdminRollups(yamlConfig *config.YAMLConfig) {
 	}
 	if globalCircuitStatsRecorder != nil {
 		globalCircuitStatsRecorder.BindRollup(store, adminrollup.NewPersister(store, adminrollup.MetricCircuitActivity))
+	}
+	if globalModelStatusRecorder != nil {
+		globalModelStatusRecorder.BindRollup(store, adminrollup.NewPersister(store, adminrollup.MetricModelStatus))
 	}
 	if globalCircuitStore != nil {
 		globalAdminRollupStop = make(chan struct{})
@@ -1421,14 +1434,9 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		r.Use(middleware.APIKeyValidationMiddleware(globalProviderManager, globalAPIKeyStore, yamlConfig.Features.PIIRedact.Enabled))
 	}
 
-	var modelStatusRecorder *modelstatusstats.Recorder
-	if rs, ok := globalCircuitStore.(*circuit.RedisStore); ok {
-		modelStatusRecorder = modelstatusstats.NewRecorder(rs.RedisClient())
-	} else {
-		modelStatusRecorder = modelstatusstats.NewRecorder(nil)
-	}
+	globalModelStatusRecorder = modelstatusstats.NewRecorder()
 	modelStatusMetrics := initializeCircuitMetrics(yamlConfig)
-	r.Use(middleware.ModelStatusMiddleware(globalProviderManager, yamlConfig, modelStatusRecorder, modelStatusMetrics))
+	r.Use(middleware.ModelStatusMiddleware(globalProviderManager, yamlConfig, globalModelStatusRecorder, modelStatusMetrics))
 
 	if globalCostStatsRecorder != nil && yamlConfig.Features.CostTracking.Enabled {
 		costLimitOpts := middleware.CostLimitOptions{
@@ -1626,21 +1634,22 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			keyStore = s
 		}
 		admin.RegisterRoutes(r, admin.Deps{
-			Logger:           logger,
-			YAMLConfig:       yamlConfig,
-			APIKeyStore:      keyStore,
-			APIKeyStoreError: globalAPIKeyStoreInitError,
-			UserStore:        globalAdminUserStore,
-			UserStoreError:   globalAdminUserStoreError,
-			RateLimiter:      globalRateLimiter,
-			HealthFunc:       healthHandler,
-			PIISummary:       piiSummaryFunc(),
-			CostSummary:      costSummaryFunc(),
-			UsageSummary:     usageSummaryFunc(),
-			RateLimitSummary: rateLimitSummaryFunc(),
-			CircuitActivity:  circuitActivitySummaryFunc(),
-			KeyProvisioner:   globalKeyProvisioner,
-			AdminRollupStore: globalAdminRollupStore,
+			Logger:             logger,
+			YAMLConfig:         yamlConfig,
+			APIKeyStore:        keyStore,
+			APIKeyStoreError:   globalAPIKeyStoreInitError,
+			UserStore:          globalAdminUserStore,
+			UserStoreError:     globalAdminUserStoreError,
+			RateLimiter:        globalRateLimiter,
+			HealthFunc:         healthHandler,
+			PIISummary:         piiSummaryFunc(),
+			CostSummary:        costSummaryFunc(),
+			UsageSummary:       usageSummaryFunc(),
+			RateLimitSummary:   rateLimitSummaryFunc(),
+			CircuitActivity:    circuitActivitySummaryFunc(),
+			ModelStatusSummary: modelStatusSummaryFunc(),
+			KeyProvisioner:     globalKeyProvisioner,
+			AdminRollupStore:   globalAdminRollupStore,
 		})
 		logger.Info("Admin dashboard: ENABLED")
 	}
@@ -1776,6 +1785,9 @@ func gracefulShutdown(server *http.Server) {
 	}
 	if globalCircuitStatsRecorder != nil {
 		globalCircuitStatsRecorder.FlushRollup()
+	}
+	if globalModelStatusRecorder != nil {
+		globalModelStatusRecorder.FlushRollup()
 	}
 	if globalHistorySink != nil {
 		logger.Info("🔄 Flushing history sink...")

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/fake"
 	"github.com/Instawork/llm-proxy/internal/history"
 	"github.com/Instawork/llm-proxy/internal/middleware"
+	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
 	"github.com/Instawork/llm-proxy/internal/pii"
 	"github.com/Instawork/llm-proxy/internal/providers"
 	"github.com/Instawork/llm-proxy/internal/provision"
@@ -1419,6 +1420,16 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	if globalAPIKeyStore != nil {
 		r.Use(middleware.APIKeyValidationMiddleware(globalProviderManager, globalAPIKeyStore, yamlConfig.Features.PIIRedact.Enabled))
 	}
+
+	var modelStatusRecorder *modelstatusstats.Recorder
+	if rs, ok := globalCircuitStore.(*circuit.RedisStore); ok {
+		modelStatusRecorder = modelstatusstats.NewRecorder(rs.RedisClient())
+	} else {
+		modelStatusRecorder = modelstatusstats.NewRecorder(nil)
+	}
+	modelStatusMetrics := initializeCircuitMetrics(yamlConfig)
+	r.Use(middleware.ModelStatusMiddleware(globalProviderManager, yamlConfig, modelStatusRecorder, modelStatusMetrics))
+
 	if globalCostStatsRecorder != nil && yamlConfig.Features.CostTracking.Enabled {
 		costLimitOpts := middleware.CostLimitOptions{
 			FailClosedOnReadError: yamlConfig.Features.CostTracking.FailClosedOnReadError,

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -143,7 +143,7 @@ retired_models:
         - claude-sonnet-4-20250514
     "claude-opus-4-0":
       retired_date: "2026-06-15"
-      replacement: claude-opus-4-8
+      replacement: claude-opus-4-7
       aliases:
         - claude-opus-4
         - claude-opus-4-20250514

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -143,7 +143,7 @@ retired_models:
         - claude-sonnet-4-20250514
     "claude-opus-4-0":
       retired_date: "2026-06-15"
-      replacement: claude-opus-4-7
+      replacement: claude-opus-4-8
       aliases:
         - claude-opus-4
         - claude-opus-4-20250514
@@ -618,6 +618,19 @@ providers:
       burst_requests: 100
 
     models:
+      "claude-opus-4-8":
+        enabled: true
+        aliases: ["claude-opus-4.8", "claude-opus-4-8-20260528"]
+        limits:
+          tokens_per_minute: 40_000
+          requests_per_minute: 1_000
+          tokens_per_day: 960_000
+          requests_per_day: 1_440_000
+          burst_tokens: 4_000
+          burst_requests: 100
+        pricing:
+          input: 5.00
+          output: 25.00
       "claude-opus-4-7":
         enabled: true
         aliases: ["claude-opus-4.7", "claude-opus-4-7-20260416"]
@@ -690,7 +703,7 @@ providers:
       "claude-opus-4-1":
         enabled: true
         deprecated: true
-        replacement: "claude-opus-4-7"
+        replacement: "claude-opus-4-8"
         aliases: ["claude-opus-4-1-20250805", "claude-opus-4.1"]
         limits:
           tokens_per_minute: 40_000

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -119,7 +119,7 @@ features:
   #     # endpoint_url: http://localhost:4566  # MinIO/localstack
 
 # =============================================================================
-# RETIRED MODELS (short-circuited at proxy — 410 Gone)
+# RETIRED MODELS (short-circuited at proxy — vendor-shaped 404)
 # =============================================================================
 
 retired_models:
@@ -127,131 +127,80 @@ retired_models:
     "o1-mini":
       retired_date: "2025-10-27"
       replacement: o4-mini
-    "o1-mini-2024-09-12":
-      retired_date: "2025-10-27"
-      replacement: o4-mini
+      aliases:
+        - o1-mini-2024-09-12
     "o1-preview":
       retired_date: "2025-07-28"
       replacement: o3
-    "o1-preview-2024-09-12":
-      retired_date: "2025-07-28"
-      replacement: o3
+      aliases:
+        - o1-preview-2024-09-12
   anthropic:
     "claude-sonnet-4-0":
       retired_date: "2026-06-15"
       replacement: claude-sonnet-4-6
-    "claude-sonnet-4":
-      retired_date: "2026-06-15"
-      replacement: claude-sonnet-4-6
-    "claude-sonnet-4-20250514":
-      retired_date: "2026-06-15"
-      replacement: claude-sonnet-4-6
+      aliases:
+        - claude-sonnet-4
+        - claude-sonnet-4-20250514
     "claude-opus-4-0":
       retired_date: "2026-06-15"
       replacement: claude-opus-4-8
-    "claude-opus-4":
-      retired_date: "2026-06-15"
-      replacement: claude-opus-4-8
-    "claude-opus-4-20250514":
-      retired_date: "2026-06-15"
-      replacement: claude-opus-4-8
+      aliases:
+        - claude-opus-4
+        - claude-opus-4-20250514
     "claude-3-7-sonnet":
       retired_date: "2026-02-19"
       replacement: claude-sonnet-4-6
-    "claude-3-7-sonnet-latest":
-      retired_date: "2026-02-19"
-      replacement: claude-sonnet-4-6
-    "claude-3.7-sonnet":
-      retired_date: "2026-02-19"
-      replacement: claude-sonnet-4-6
-    "claude-sonnet-3.7":
-      retired_date: "2026-02-19"
-      replacement: claude-sonnet-4-6
-    "claude-3-7-sonnet-20250219":
-      retired_date: "2026-02-19"
-      replacement: claude-sonnet-4-6
+      aliases:
+        - claude-3-7-sonnet-latest
+        - claude-3.7-sonnet
+        - claude-sonnet-3.7
+        - claude-3-7-sonnet-20250219
     "claude-3-5-sonnet":
       retired_date: "2025-10-28"
       replacement: claude-sonnet-4-6
-    "claude-3-5-sonnet-latest":
-      retired_date: "2025-10-28"
-      replacement: claude-sonnet-4-6
-    "claude-3.5-sonnet":
-      retired_date: "2025-10-28"
-      replacement: claude-sonnet-4-6
-    "claude-sonnet-3.5":
-      retired_date: "2025-10-28"
-      replacement: claude-sonnet-4-6
-    "claude-3-5-sonnet-20241022":
-      retired_date: "2025-10-28"
-      replacement: claude-sonnet-4-6
-    "claude-3-5-sonnet-20240628":
-      retired_date: "2025-10-28"
-      replacement: claude-sonnet-4-6
+      aliases:
+        - claude-3-5-sonnet-latest
+        - claude-3.5-sonnet
+        - claude-sonnet-3.5
+        - claude-3-5-sonnet-20241022
+        - claude-3-5-sonnet-20240628
     "claude-3-5-haiku":
       retired_date: "2026-02-19"
       replacement: claude-haiku-4-5
-    "claude-3-5-haiku-latest":
-      retired_date: "2026-02-19"
-      replacement: claude-haiku-4-5
-    "claude-3.5-haiku":
-      retired_date: "2026-02-19"
-      replacement: claude-haiku-4-5
-    "claude-haiku-3.5":
-      retired_date: "2026-02-19"
-      replacement: claude-haiku-4-5
-    "claude-3-5-haiku-20241022":
-      retired_date: "2026-02-19"
-      replacement: claude-haiku-4-5
-    "claude-3-haiku-20240307":
-      retired_date: "2026-04-20"
-      replacement: claude-haiku-4-5
+      aliases:
+        - claude-3-5-haiku-latest
+        - claude-3.5-haiku
+        - claude-haiku-3.5
+        - claude-3-5-haiku-20241022
     "claude-3-haiku":
       retired_date: "2026-04-20"
       replacement: claude-haiku-4-5
-    "claude-haiku":
-      retired_date: "2026-04-20"
-      replacement: claude-haiku-4-5
+      aliases:
+        - claude-3-haiku-20240307
+        - claude-haiku
   gemini:
     "gemini-2.0-flash":
       retired_date: "2026-06-01"
       replacement: gemini-3.5-flash
-    "gemini-flash-2.0":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.5-flash
-    "gemini-2-0-flash":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.5-flash
-    "gemini-2.0-flash-001":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.5-flash
-    "gemini-2.0-flash-exp":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.5-flash
+      aliases:
+        - gemini-flash-2.0
+        - gemini-2-0-flash
+        - gemini-2.0-flash-001
+        - gemini-2.0-flash-exp
     "gemini-2.0-flash-lite":
       retired_date: "2026-06-01"
       replacement: gemini-3.1-flash-lite
-    "gemini-flash-lite-2.0":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.1-flash-lite
-    "gemini-2-0-flash-lite":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.1-flash-lite
-    "gemini-2.0-flash-lite-001":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.1-flash-lite
-    "gemini-2.0-flash-lite-exp":
-      retired_date: "2026-06-01"
-      replacement: gemini-3.1-flash-lite
+      aliases:
+        - gemini-flash-lite-2.0
+        - gemini-2-0-flash-lite
+        - gemini-2.0-flash-lite-001
+        - gemini-2.0-flash-lite-exp
     "gemini-3-pro":
       retired_date: "2026-03-09"
       replacement: gemini-3.1-pro
-    "gemini-3-pro-preview":
-      retired_date: "2026-03-09"
-      replacement: gemini-3.1-pro
-    "gemini-3-0-pro":
-      retired_date: "2026-03-09"
-      replacement: gemini-3.1-pro
+      aliases:
+        - gemini-3-pro-preview
+        - gemini-3-0-pro
   bedrock: {}
 
 # =============================================================================

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -124,50 +124,134 @@ features:
 
 retired_models:
   openai:
-    "o1-mini": { retired_date: "2025-10-27", replacement: "o4-mini" }
-    "o1-mini-2024-09-12": { retired_date: "2025-10-27", replacement: "o4-mini" }
-    "o1-preview": { retired_date: "2025-07-28", replacement: "o3" }
-    "o1-preview-2024-09-12": { retired_date: "2025-07-28", replacement: "o3" }
+    "o1-mini":
+      retired_date: "2025-10-27"
+      replacement: o4-mini
+    "o1-mini-2024-09-12":
+      retired_date: "2025-10-27"
+      replacement: o4-mini
+    "o1-preview":
+      retired_date: "2025-07-28"
+      replacement: o3
+    "o1-preview-2024-09-12":
+      retired_date: "2025-07-28"
+      replacement: o3
   anthropic:
-    "claude-sonnet-4-0": { retired_date: "2026-06-15", replacement: "claude-sonnet-4-6" }
-    "claude-sonnet-4": { retired_date: "2026-06-15", replacement: "claude-sonnet-4-6" }
-    "claude-sonnet-4-20250514": { retired_date: "2026-06-15", replacement: "claude-sonnet-4-6" }
-    "claude-opus-4-0": { retired_date: "2026-06-15", replacement: "claude-opus-4-8" }
-    "claude-opus-4": { retired_date: "2026-06-15", replacement: "claude-opus-4-8" }
-    "claude-opus-4-20250514": { retired_date: "2026-06-15", replacement: "claude-opus-4-8" }
-    "claude-3-7-sonnet": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
-    "claude-3-7-sonnet-latest": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
-    "claude-3.7-sonnet": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
-    "claude-sonnet-3.7": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
-    "claude-3-7-sonnet-20250219": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
-    "claude-3-5-sonnet": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
-    "claude-3-5-sonnet-latest": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
-    "claude-3.5-sonnet": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
-    "claude-sonnet-3.5": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
-    "claude-3-5-sonnet-20241022": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
-    "claude-3-5-sonnet-20240628": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
-    "claude-3-5-haiku": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
-    "claude-3-5-haiku-latest": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
-    "claude-3.5-haiku": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
-    "claude-haiku-3.5": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
-    "claude-3-5-haiku-20241022": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
-    "claude-3-haiku-20240307": { retired_date: "2026-04-20", replacement: "claude-haiku-4-5" }
-    "claude-3-haiku": { retired_date: "2026-04-20", replacement: "claude-haiku-4-5" }
-    "claude-haiku": { retired_date: "2026-04-20", replacement: "claude-haiku-4-5" }
+    "claude-sonnet-4-0":
+      retired_date: "2026-06-15"
+      replacement: claude-sonnet-4-6
+    "claude-sonnet-4":
+      retired_date: "2026-06-15"
+      replacement: claude-sonnet-4-6
+    "claude-sonnet-4-20250514":
+      retired_date: "2026-06-15"
+      replacement: claude-sonnet-4-6
+    "claude-opus-4-0":
+      retired_date: "2026-06-15"
+      replacement: claude-opus-4-8
+    "claude-opus-4":
+      retired_date: "2026-06-15"
+      replacement: claude-opus-4-8
+    "claude-opus-4-20250514":
+      retired_date: "2026-06-15"
+      replacement: claude-opus-4-8
+    "claude-3-7-sonnet":
+      retired_date: "2026-02-19"
+      replacement: claude-sonnet-4-6
+    "claude-3-7-sonnet-latest":
+      retired_date: "2026-02-19"
+      replacement: claude-sonnet-4-6
+    "claude-3.7-sonnet":
+      retired_date: "2026-02-19"
+      replacement: claude-sonnet-4-6
+    "claude-sonnet-3.7":
+      retired_date: "2026-02-19"
+      replacement: claude-sonnet-4-6
+    "claude-3-7-sonnet-20250219":
+      retired_date: "2026-02-19"
+      replacement: claude-sonnet-4-6
+    "claude-3-5-sonnet":
+      retired_date: "2025-10-28"
+      replacement: claude-sonnet-4-6
+    "claude-3-5-sonnet-latest":
+      retired_date: "2025-10-28"
+      replacement: claude-sonnet-4-6
+    "claude-3.5-sonnet":
+      retired_date: "2025-10-28"
+      replacement: claude-sonnet-4-6
+    "claude-sonnet-3.5":
+      retired_date: "2025-10-28"
+      replacement: claude-sonnet-4-6
+    "claude-3-5-sonnet-20241022":
+      retired_date: "2025-10-28"
+      replacement: claude-sonnet-4-6
+    "claude-3-5-sonnet-20240628":
+      retired_date: "2025-10-28"
+      replacement: claude-sonnet-4-6
+    "claude-3-5-haiku":
+      retired_date: "2026-02-19"
+      replacement: claude-haiku-4-5
+    "claude-3-5-haiku-latest":
+      retired_date: "2026-02-19"
+      replacement: claude-haiku-4-5
+    "claude-3.5-haiku":
+      retired_date: "2026-02-19"
+      replacement: claude-haiku-4-5
+    "claude-haiku-3.5":
+      retired_date: "2026-02-19"
+      replacement: claude-haiku-4-5
+    "claude-3-5-haiku-20241022":
+      retired_date: "2026-02-19"
+      replacement: claude-haiku-4-5
+    "claude-3-haiku-20240307":
+      retired_date: "2026-04-20"
+      replacement: claude-haiku-4-5
+    "claude-3-haiku":
+      retired_date: "2026-04-20"
+      replacement: claude-haiku-4-5
+    "claude-haiku":
+      retired_date: "2026-04-20"
+      replacement: claude-haiku-4-5
   gemini:
-    "gemini-2.0-flash": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
-    "gemini-flash-2.0": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
-    "gemini-2-0-flash": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
-    "gemini-2.0-flash-001": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
-    "gemini-2.0-flash-exp": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
-    "gemini-2.0-flash-lite": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
-    "gemini-flash-lite-2.0": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
-    "gemini-2-0-flash-lite": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
-    "gemini-2.0-flash-lite-001": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
-    "gemini-2.0-flash-lite-exp": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
-    "gemini-3-pro": { retired_date: "2026-03-09", replacement: "gemini-3.1-pro" }
-    "gemini-3-pro-preview": { retired_date: "2026-03-09", replacement: "gemini-3.1-pro" }
-    "gemini-3-0-pro": { retired_date: "2026-03-09", replacement: "gemini-3.1-pro" }
+    "gemini-2.0-flash":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.5-flash
+    "gemini-flash-2.0":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.5-flash
+    "gemini-2-0-flash":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.5-flash
+    "gemini-2.0-flash-001":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.5-flash
+    "gemini-2.0-flash-exp":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.5-flash
+    "gemini-2.0-flash-lite":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.1-flash-lite
+    "gemini-flash-lite-2.0":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.1-flash-lite
+    "gemini-2-0-flash-lite":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.1-flash-lite
+    "gemini-2.0-flash-lite-001":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.1-flash-lite
+    "gemini-2.0-flash-lite-exp":
+      retired_date: "2026-06-01"
+      replacement: gemini-3.1-flash-lite
+    "gemini-3-pro":
+      retired_date: "2026-03-09"
+      replacement: gemini-3.1-pro
+    "gemini-3-pro-preview":
+      retired_date: "2026-03-09"
+      replacement: gemini-3.1-pro
+    "gemini-3-0-pro":
+      retired_date: "2026-03-09"
+      replacement: gemini-3.1-pro
   bedrock: {}
 
 # =============================================================================

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -119,6 +119,58 @@ features:
   #     # endpoint_url: http://localhost:4566  # MinIO/localstack
 
 # =============================================================================
+# RETIRED MODELS (short-circuited at proxy — 410 Gone)
+# =============================================================================
+
+retired_models:
+  openai:
+    "o1-mini": { retired_date: "2025-10-27", replacement: "o4-mini" }
+    "o1-mini-2024-09-12": { retired_date: "2025-10-27", replacement: "o4-mini" }
+    "o1-preview": { retired_date: "2025-07-28", replacement: "o3" }
+    "o1-preview-2024-09-12": { retired_date: "2025-07-28", replacement: "o3" }
+  anthropic:
+    "claude-sonnet-4-0": { retired_date: "2026-06-15", replacement: "claude-sonnet-4-6" }
+    "claude-sonnet-4": { retired_date: "2026-06-15", replacement: "claude-sonnet-4-6" }
+    "claude-sonnet-4-20250514": { retired_date: "2026-06-15", replacement: "claude-sonnet-4-6" }
+    "claude-opus-4-0": { retired_date: "2026-06-15", replacement: "claude-opus-4-8" }
+    "claude-opus-4": { retired_date: "2026-06-15", replacement: "claude-opus-4-8" }
+    "claude-opus-4-20250514": { retired_date: "2026-06-15", replacement: "claude-opus-4-8" }
+    "claude-3-7-sonnet": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
+    "claude-3-7-sonnet-latest": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
+    "claude-3.7-sonnet": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
+    "claude-sonnet-3.7": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
+    "claude-3-7-sonnet-20250219": { retired_date: "2026-02-19", replacement: "claude-sonnet-4-6" }
+    "claude-3-5-sonnet": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
+    "claude-3-5-sonnet-latest": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
+    "claude-3.5-sonnet": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
+    "claude-sonnet-3.5": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
+    "claude-3-5-sonnet-20241022": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
+    "claude-3-5-sonnet-20240628": { retired_date: "2025-10-28", replacement: "claude-sonnet-4-6" }
+    "claude-3-5-haiku": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
+    "claude-3-5-haiku-latest": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
+    "claude-3.5-haiku": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
+    "claude-haiku-3.5": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
+    "claude-3-5-haiku-20241022": { retired_date: "2026-02-19", replacement: "claude-haiku-4-5" }
+    "claude-3-haiku-20240307": { retired_date: "2026-04-20", replacement: "claude-haiku-4-5" }
+    "claude-3-haiku": { retired_date: "2026-04-20", replacement: "claude-haiku-4-5" }
+    "claude-haiku": { retired_date: "2026-04-20", replacement: "claude-haiku-4-5" }
+  gemini:
+    "gemini-2.0-flash": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
+    "gemini-flash-2.0": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
+    "gemini-2-0-flash": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
+    "gemini-2.0-flash-001": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
+    "gemini-2.0-flash-exp": { retired_date: "2026-06-01", replacement: "gemini-3.5-flash" }
+    "gemini-2.0-flash-lite": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
+    "gemini-flash-lite-2.0": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
+    "gemini-2-0-flash-lite": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
+    "gemini-2.0-flash-lite-001": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
+    "gemini-2.0-flash-lite-exp": { retired_date: "2026-06-01", replacement: "gemini-3.1-flash-lite" }
+    "gemini-3-pro": { retired_date: "2026-03-09", replacement: "gemini-3.1-pro" }
+    "gemini-3-pro-preview": { retired_date: "2026-03-09", replacement: "gemini-3.1-pro" }
+    "gemini-3-0-pro": { retired_date: "2026-03-09", replacement: "gemini-3.1-pro" }
+  bedrock: {}
+
+# =============================================================================
 # PROVIDER CONFIGURATIONS
 # =============================================================================
 
@@ -284,7 +336,7 @@ providers:
           output: 1.50
       "o1":
         enabled: true
-        aliases: ["o1-2024-12-17", "o1-preview", "o1-preview-2024-09-12"]
+        aliases: ["o1-2024-12-17"]
         limits:
           tokens_per_minute: 450_000
           requests_per_minute: 5_000
@@ -295,19 +347,6 @@ providers:
         pricing:
           input: 15.00
           output: 60.00
-      "o1-mini":
-        enabled: true
-        aliases: ["o1-mini-2024-09-12"]
-        limits:
-          tokens_per_minute: 200_000
-          requests_per_minute: 2_000
-          tokens_per_day: 4_800_000
-          requests_per_day: 2_880_000
-          burst_tokens: 20_000
-          burst_requests: 200
-        pricing:
-          input: 1.10
-          output: 4.40
       "o3-mini":
         enabled: true
         aliases: ["o3-mini-2025-01-31"]
@@ -323,12 +362,7 @@ providers:
           output: 4.40
       "o4-mini":
         enabled: true
-        aliases:
-          [
-            "o4-mini-2025-04-16",
-            "o4-mini-deep-research",
-            "o4-mini-deep-research-2025-06-26",
-          ]
+        aliases: ["o4-mini-2025-04-16"]
         limits:
           tokens_per_minute: 200_000
           requests_per_minute: 2_000
@@ -341,8 +375,7 @@ providers:
           output: 4.40
       "o3":
         enabled: true
-        aliases:
-          ["o3-2025-04-16", "o3-deep-research", "o3-deep-research-2025-06-26"]
+        aliases: ["o3-2025-04-16"]
         limits:
           tokens_per_minute: 40_000
           requests_per_minute: 1_000
@@ -431,6 +464,58 @@ providers:
         pricing:
           input: 30.00
           output: 180.00
+      "gpt-5.5":
+        enabled: true
+        aliases: ["gpt-5.5-2026-04-23"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 5.00
+          output: 30.00
+      "gpt-5.5-pro":
+        enabled: true
+        aliases: ["gpt-5.5-pro-2026-04-23"]
+        limits:
+          tokens_per_minute: 450_000
+          requests_per_minute: 5_000
+          tokens_per_day: 10_800_000
+          requests_per_day: 7_200_000
+          burst_tokens: 45_000
+          burst_requests: 500
+        pricing:
+          input: 30.00
+          output: 180.00
+      "o3-deep-research":
+        enabled: true
+        aliases: ["o3-deep-research-2025-06-26"]
+        limits:
+          tokens_per_minute: 40_000
+          requests_per_minute: 1_000
+          tokens_per_day: 960_000
+          requests_per_day: 1_440_000
+          burst_tokens: 4_000
+          burst_requests: 100
+        pricing:
+          input: 10.00
+          output: 40.00
+      "o4-mini-deep-research":
+        enabled: true
+        aliases: ["o4-mini-deep-research-2025-06-26"]
+        limits:
+          tokens_per_minute: 200_000
+          requests_per_minute: 2_000
+          tokens_per_day: 4_800_000
+          requests_per_day: 2_880_000
+          burst_tokens: 20_000
+          burst_requests: 200
+        pricing:
+          input: 2.00
+          output: 8.00
       "gpt-5.2":
         enabled: true
         aliases: ["gpt-5.2-2025-12-11"]
@@ -539,19 +624,6 @@ providers:
         pricing:
           input: 5.00
           output: 25.00
-      "claude-opus-4-0":
-        enabled: true
-        aliases: ["claude-opus-4", "claude-opus-4-20250514"]
-        limits:
-          tokens_per_minute: 40_000
-          requests_per_minute: 1_000
-          tokens_per_day: 960_000
-          requests_per_day: 1_440_000
-          burst_tokens: 4_000
-          burst_requests: 100
-        pricing:
-          input: 15.00
-          output: 75.00
       "claude-sonnet-4-6":
         enabled: true
         aliases: ["claude-sonnet-4.6", "claude-sonnet-4-6-20260217"]
@@ -563,29 +635,8 @@ providers:
           burst_tokens: 8_000
           burst_requests: 100
         pricing:
-          - threshold: 200_000
-            input: 3.00
-            output: 15.00
-          - threshold: 0
-            input: 6.00
-            output: 22.50
-      "claude-sonnet-4-0":
-        enabled: true
-        aliases: ["claude-sonnet-4", "claude-sonnet-4-20250514"]
-        limits:
-          tokens_per_minute: 80_000
-          requests_per_minute: 1_000
-          tokens_per_day: 1_920_000
-          requests_per_day: 1_440_000
-          burst_tokens: 8_000
-          burst_requests: 100
-        pricing:
-          - threshold: 200_000
-            input: 3.00
-            output: 15.00
-          - threshold: 0
-            input: 6.00
-            output: 22.50
+          input: 3.00
+          output: 15.00
       "claude-sonnet-4-5":
         enabled: true
         aliases: ["claude-sonnet-4-5-20250929", "claude-sonnet-4.5"]
@@ -603,28 +654,10 @@ providers:
           - threshold: 0
             input: 6.00
             output: 22.50
-      "claude-3-7-sonnet":
-        enabled: true
-        aliases:
-          [
-            "claude-3-7-sonnet-latest",
-            "claude-3.7-sonnet",
-            "claude-sonnet-3.7",
-            "claude-3-7-sonnet-20250219",
-          ]
-        limits:
-          tokens_per_minute: 80_000
-          requests_per_minute: 1_000
-          tokens_per_day: 1_920_000
-          requests_per_day: 1_440_000
-          burst_tokens: 8_000
-          burst_requests: 100
-        pricing:
-          input: 3.00
-          output: 15.00
-
       "claude-opus-4-1":
         enabled: true
+        deprecated: true
+        replacement: "claude-opus-4-7"
         aliases: ["claude-opus-4-1-20250805", "claude-opus-4.1"]
         limits:
           tokens_per_minute: 40_000
@@ -636,26 +669,6 @@ providers:
         pricing:
           input: 15.00
           output: 75.00
-      "claude-3-5-sonnet":
-        enabled: true
-        aliases:
-          [
-            "claude-3-5-sonnet-latest",
-            "claude-3.5-sonnet",
-            "claude-sonnet-3.5",
-            "claude-3-5-sonnet-20241022",
-            "claude-3-5-sonnet-20240628",
-          ]
-        limits:
-          tokens_per_minute: 80_000
-          requests_per_minute: 1_000
-          tokens_per_day: 1_920_000
-          requests_per_day: 1_440_000
-          burst_tokens: 8_000
-          burst_requests: 100
-        pricing:
-          input: 3.00
-          output: 15.00
       "claude-haiku-4-5":
         enabled: true
         aliases: ["claude-haiku-4.5", "claude-haiku-4-5-20251001", "claude-haiku-4-5-20251015"]
@@ -669,38 +682,6 @@ providers:
         pricing:
           input: 1.00
           output: 5.00
-      "claude-3-5-haiku":
-        enabled: true
-        aliases:
-          [
-            "claude-3-5-haiku-latest",
-            "claude-3.5-haiku",
-            "claude-haiku-3.5",
-            "claude-3-5-haiku-20241022",
-          ]
-        limits:
-          tokens_per_minute: 100_000
-          requests_per_minute: 1_000
-          tokens_per_day: 2_400_000
-          requests_per_day: 1_440_000
-          burst_tokens: 10_000
-          burst_requests: 100
-        pricing:
-          input: 0.80
-          output: 4.00
-      "claude-3-haiku-20240307":
-        enabled: true
-        aliases: ["claude-3-haiku", "claude-haiku"]
-        limits:
-          tokens_per_minute: 100_000
-          requests_per_minute: 1_000
-          tokens_per_day: 2_400_000
-          requests_per_day: 1_440_000
-          burst_tokens: 10_000
-          burst_requests: 100
-        pricing:
-          input: 0.25
-          output: 1.25
 
   # ---------------------------------------------------------------------------
   # AWS BEDROCK PROVIDER (transparent SigV4 passthrough)
@@ -820,23 +801,6 @@ providers:
           - threshold: 0
             input: 4.00
             output: 18.00
-      "gemini-3-pro":
-        enabled: true
-        aliases: ["gemini-3-pro-preview", "gemini-3-0-pro"]
-        limits:
-          tokens_per_minute: 5_000_000
-          requests_per_minute: 1_000
-          tokens_per_day: 120_000_000
-          requests_per_day: 1_440_000
-          burst_tokens: 500_000
-          burst_requests: 100
-        pricing:
-          - threshold: 200_000
-            input: 2.00
-            output: 12.00
-          - threshold: 0
-            input: 4.00
-            output: 18.00
       "gemini-3-flash":
         enabled: true
         aliases: ["gemini-3-flash-preview", "gemini-3-0-flash"]
@@ -850,6 +814,19 @@ providers:
         pricing:
           input: 0.50
           output: 3.00
+      "gemini-3.5-flash":
+        enabled: true
+        aliases: ["gemini-flash-3.5"]
+        limits:
+          tokens_per_minute: 3_000_000
+          requests_per_minute: 2_000
+          tokens_per_day: 72_000_000
+          requests_per_day: 2_880_000
+          burst_tokens: 300_000
+          burst_requests: 200
+        pricing:
+          input: 1.50
+          output: 9.00
       "gemini-3.1-flash-lite":
         enabled: true
         aliases: ["gemini-3.1-flash-lite-preview", "gemini-3-1-flash-lite"]
@@ -865,6 +842,8 @@ providers:
           output: 1.50
       "gemini-2.5-pro":
         enabled: true
+        deprecated: true
+        replacement: "gemini-3.1-pro"
         aliases: ["gemini-pro-2.5", "gemini-2-5-pro"]
         limits:
           tokens_per_minute: 5_000_000
@@ -942,43 +921,6 @@ providers:
         pricing:
           input: 0.30
           output: 2.50
-      "gemini-2.0-flash":
-        enabled: true
-        aliases:
-          [
-            "gemini-flash-2.0",
-            "gemini-2-0-flash",
-            "gemini-2.0-flash-001",
-            "gemini-2.0-flash-exp",
-          ]
-        limits:
-          tokens_per_minute: 10_000_000
-          requests_per_minute: 10_000
-          tokens_per_day: 240_000_000
-          requests_per_day: 14_400_000
-          burst_tokens: 1_000_000
-          burst_requests: 1_000
-        pricing:
-          input: 0.10
-          output: 0.40
-      "gemini-2.0-flash-lite":
-        enabled: true
-        aliases:
-          [
-            "gemini-flash-lite-2.0",
-            "gemini-2.0-flash-lite-001",
-            "gemini-2.0-flash-lite-exp",
-          ]
-        limits:
-          tokens_per_minute: 10_000_000
-          requests_per_minute: 10_000
-          tokens_per_day: 240_000_000
-          requests_per_day: 14_400_000
-          burst_tokens: 1_000_000
-          burst_requests: 1_000
-        pricing:
-          input: 0.075
-          output: 0.30
       "gemini-1.5-pro":
         enabled: true
         aliases:

--- a/internal/admin/dashboard_handlers_test.go
+++ b/internal/admin/dashboard_handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/coststats"
 	"github.com/Instawork/llm-proxy/internal/pii"
+	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/Instawork/llm-proxy/internal/usagestats"
 	"github.com/gorilla/mux"
@@ -30,17 +31,29 @@ func testDashboardHandler(t *testing.T) (*handler, *apikeys.Store) {
 	usageRec := usagestats.NewRecorder()
 	piiRec := pii.NewRecorder()
 	circuitRec := circuitstats.NewRecorder()
+	modelStatusRec := modelstatusstats.NewRecorder()
 	costRec.RecordRequest("openai", "iw:abc1234", "user-1", "gpt-4", 0.01, 0.005, 0.005, 100, 50)
 	usageRec.RecordRequest("openai", "gpt-4", "iw:abc1234", "user-1", 100, 50)
 	piiRec.RecordRedaction("openai", "iw:secret-key", nil, 0, time.Millisecond, pii.OutcomeOK)
 	circuitRec.RecordProbe("openai", "openai")
 	circuitRec.RecordProbeClosed("openai", "openai", 200)
+	modelStatusRec.RecordRetired("openai", "o1-mini")
+	modelStatusRec.RecordUnknown("openai", "typo-model")
 
 	h.deps.YAMLConfig.Features.PIIRedact.Enabled = true
+	h.deps.YAMLConfig.RetiredModels = map[string]map[string]config.RetiredModelEntry{
+		"openai": {
+			"o1-mini": {
+				RetiredDate: "2025-10-27",
+				Replacement: "o4-mini",
+			},
+		},
+	}
 	h.deps.CostSummary = costRec.Snapshot
 	h.deps.UsageSummary = usageRec.Snapshot
 	h.deps.PIISummary = piiRec.Snapshot
 	h.deps.CircuitActivity = circuitRec.Snapshot
+	h.deps.ModelStatusSummary = modelStatusRec.Snapshot
 	h.deps.RateLimiter = ratelimit.NewMemoryLimiter(h.deps.YAMLConfig)
 	h.deps.HealthFunc = func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
@@ -209,6 +222,36 @@ func TestHandleCircuitActivity_Unavailable(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	body := decodeJSONBody(t, rec)
 	assert.Equal(t, false, body["available"])
+}
+
+func TestHandleModelStatus(t *testing.T) {
+	h, _ := testDashboardHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleModelStatus(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/model-status", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := decodeJSONBody(t, rec)
+	stats, ok := body["stats"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, stats["available"])
+	assert.Equal(t, float64(1), stats["retired_total"])
+	assert.Equal(t, float64(1), stats["unknown_total"])
+
+	registry, ok := body["registry"].(map[string]interface{})
+	require.True(t, ok)
+	retired, ok := registry["retired"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, retired)
+}
+
+func TestHandleModelStatus_Unavailable(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	rec := httptest.NewRecorder()
+	h.handleModelStatus(rec, authenticatedRequest(t, h, http.MethodGet, "/admin/api/model-status", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeJSONBody(t, rec)
+	stats := body["stats"].(map[string]interface{})
+	assert.Equal(t, false, stats["available"])
 }
 
 func TestHandleRateLimits_WithSnapshotAndRedactedOverrides(t *testing.T) {

--- a/internal/admin/deps.go
+++ b/internal/admin/deps.go
@@ -14,19 +14,20 @@ import (
 
 // Deps bundles dependencies for the admin dashboard API.
 type Deps struct {
-	Logger           *slog.Logger
-	YAMLConfig       *config.YAMLConfig
-	APIKeyStore      *apikeys.Store
-	APIKeyStoreError error
-	UserStore        *adminusers.Store
-	UserStoreError   error
-	AdminRollupStore *adminrollup.Store
-	RateLimiter      ratelimit.RateLimiter
-	HealthFunc       http.HandlerFunc
-	CostSummary      func() map[string]interface{}
-	PIISummary       func() map[string]interface{}
-	UsageSummary     func() map[string]interface{}
-	RateLimitSummary func() map[string]interface{}
-	CircuitActivity  func() map[string]interface{}
-	KeyProvisioner   *provision.Manager
+	Logger             *slog.Logger
+	YAMLConfig         *config.YAMLConfig
+	APIKeyStore        *apikeys.Store
+	APIKeyStoreError   error
+	UserStore          *adminusers.Store
+	UserStoreError     error
+	AdminRollupStore   *adminrollup.Store
+	RateLimiter        ratelimit.RateLimiter
+	HealthFunc         http.HandlerFunc
+	CostSummary        func() map[string]interface{}
+	PIISummary         func() map[string]interface{}
+	UsageSummary       func() map[string]interface{}
+	RateLimitSummary   func() map[string]interface{}
+	CircuitActivity    func() map[string]interface{}
+	ModelStatusSummary func() map[string]interface{}
+	KeyProvisioner     *provision.Manager
 }

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/provision"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/gorilla/mux"
@@ -902,6 +904,69 @@ func (h *handler) handleCircuitActivity(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, http.StatusOK, h.deps.CircuitActivity())
+}
+
+func (h *handler) handleModelStatus(w http.ResponseWriter, r *http.Request) {
+	resp := map[string]interface{}{
+		"registry": modelStatusRegistry(h.deps.YAMLConfig),
+	}
+	if h.deps.ModelStatusSummary != nil {
+		resp["stats"] = h.deps.ModelStatusSummary()
+	} else {
+		resp["stats"] = map[string]interface{}{"available": false}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func modelStatusRegistry(cfg *config.YAMLConfig) map[string]interface{} {
+	retired := make([]map[string]interface{}, 0)
+	deprecated := make([]map[string]interface{}, 0)
+	if cfg == nil {
+		return map[string]interface{}{
+			"retired":    retired,
+			"deprecated": deprecated,
+		}
+	}
+	for provider, models := range cfg.RetiredModels {
+		for canonical, entry := range models {
+			retired = append(retired, map[string]interface{}{
+				"provider":     provider,
+				"model":        canonical,
+				"retired_date": entry.RetiredDate,
+				"replacement":  entry.Replacement,
+				"aliases":      entry.Aliases,
+			})
+		}
+	}
+	sort.Slice(retired, func(i, j int) bool {
+		if retired[i]["provider"] != retired[j]["provider"] {
+			return retired[i]["provider"].(string) < retired[j]["provider"].(string)
+		}
+		return retired[i]["model"].(string) < retired[j]["model"].(string)
+	})
+	for provider, pcfg := range cfg.Providers {
+		for canonical, mc := range pcfg.Models {
+			if !mc.Deprecated {
+				continue
+			}
+			deprecated = append(deprecated, map[string]interface{}{
+				"provider":    provider,
+				"model":       canonical,
+				"replacement": mc.Replacement,
+				"aliases":     mc.Aliases,
+			})
+		}
+	}
+	sort.Slice(deprecated, func(i, j int) bool {
+		if deprecated[i]["provider"] != deprecated[j]["provider"] {
+			return deprecated[i]["provider"].(string) < deprecated[j]["provider"].(string)
+		}
+		return deprecated[i]["model"].(string) < deprecated[j]["model"].(string)
+	})
+	return map[string]interface{}{
+		"retired":    retired,
+		"deprecated": deprecated,
+	}
 }
 
 func (h *handler) handleRateLimits(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -75,6 +75,7 @@ func RegisterRoutes(r *mux.Router, deps Deps) {
 	api.Handle("/cost", roleHandler(auth, adminusers.RoleEditor, h.handleCost)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/usage", roleHandler(auth, adminusers.RoleEditor, h.handleUsage)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/pii", roleHandler(auth, adminusers.RoleEditor, h.handlePII)).Methods(http.MethodGet, http.MethodOptions)
+	api.Handle("/model-status", roleHandler(auth, adminusers.RoleEditor, h.handleModelStatus)).Methods(http.MethodGet, http.MethodOptions)
 
 	api.Handle("/config", roleHandler(auth, adminusers.RoleEditor, h.handleConfig)).Methods(http.MethodGet, http.MethodOptions)
 	api.Handle("/keys", roleHandler(auth, adminusers.RoleViewer, h.handleListKeys)).Methods(http.MethodGet, http.MethodOptions)

--- a/internal/adminrollup/aggregate.go
+++ b/internal/adminrollup/aggregate.go
@@ -323,6 +323,39 @@ func kvFromNameVals(vals []nameVal) []map[string]interface{} {
 	return out
 }
 
+func modelStatusDataFromAggregates(
+	totals map[string]float64,
+	byRetired, byDeprecated, byUnknown map[string]float64,
+	_ TopNCaps,
+) map[string]interface{} {
+	const limit = 100
+	return map[string]interface{}{
+		"retired_total":    int64(totals["retired_total"]),
+		"deprecated_total": int64(totals["deprecated_total"]),
+		"unknown_total":    int64(totals["unknown_total"]),
+		"by_retired":       kvFromNameVals(topNMap(byRetired, limit)),
+		"by_deprecated":    kvFromNameVals(topNMap(byDeprecated, limit)),
+		"by_unknown":       kvFromNameVals(topNMap(byUnknown, limit)),
+	}
+}
+
+func topNMap(m map[string]float64, n int) []nameVal {
+	out := make([]nameVal, 0, len(m))
+	for k, v := range m {
+		out = append(out, nameVal{Name: k, Val: v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Val != out[j].Val {
+			return out[i].Val > out[j].Val
+		}
+		return out[i].Name < out[j].Name
+	})
+	if n > 0 && len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
 func circuitActivityDataFromAggregates(totals map[string]float64, byProvider, byKey map[string]float64) map[string]interface{} {
 	byProvOut := make(map[string]int64, len(byProvider))
 	for k, v := range byProvider {

--- a/internal/adminrollup/model_status_test.go
+++ b/internal/adminrollup/model_status_test.go
@@ -1,0 +1,38 @@
+package adminrollup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelStatusMergeToday(t *testing.T) {
+	store, err := NewStore(Config{Enabled: true, Backend: "memory"})
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	ctx := context.Background()
+	day := "2026-06-22"
+	err = store.ApplyDelta(ctx, MetricModelStatus, day, Delta{
+		Totals: map[string]float64{
+			"retired_total":    2,
+			"deprecated_total": 1,
+			"unknown_total":    3,
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_retired":    {"openai:o1-mini": 2},
+			"by_deprecated": {"anthropic:claude-2": 1},
+			"by_unknown":    {"gemini:typo": 3},
+		},
+	})
+	require.NoError(t, err)
+
+	snap := map[string]interface{}{"available": true}
+	store.MergeToday(ctx, MetricModelStatus, day, snap, TopNCaps{})
+
+	assert.Equal(t, int64(2), snap["retired_total"])
+	assert.Equal(t, int64(1), snap["deprecated_total"])
+	assert.Equal(t, int64(3), snap["unknown_total"])
+}

--- a/internal/adminrollup/store.go
+++ b/internal/adminrollup/store.go
@@ -25,6 +25,7 @@ const (
 	MetricCircuit         = "circuit"
 	MetricCircuitActivity = "circuit_activity"
 	MetricRateLimit       = "ratelimit"
+	MetricModelStatus     = "model_status"
 
 	keyPrefix = "llm:admin:"
 
@@ -219,6 +220,11 @@ func (s *Store) buildTodayData(ctx context.Context, metric, day string, caps Top
 		byProv, _ := s.loadHash(ctx, dimKey(metric, day, "by_provider"))
 		byKey, _ := s.loadHash(ctx, dimKey(metric, day, "by_key"))
 		return circuitActivityDataFromAggregates(totals, byProv, byKey), true
+	case MetricModelStatus:
+		byRetired, _ := s.loadHash(ctx, dimKey(metric, day, "by_retired"))
+		byDeprecated, _ := s.loadHash(ctx, dimKey(metric, day, "by_deprecated"))
+		byUnknown, _ := s.loadHash(ctx, dimKey(metric, day, "by_unknown"))
+		return modelStatusDataFromAggregates(totals, byRetired, byDeprecated, byUnknown, caps), true
 	default:
 		return nil, false
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1429,6 +1429,9 @@ func parseModelPricing(pricingData interface{}) (*ModelPricing, error) {
 // GetModelConfig returns the model configuration for a provider and model name,
 // resolving aliases to the canonical model entry.
 func (c *YAMLConfig) GetModelConfig(provider, model string) (*ModelConfig, string) {
+	if c == nil || model == "" {
+		return nil, ""
+	}
 	providerConfig, exists := c.Providers[provider]
 	if !exists {
 		return nil, ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,10 +48,13 @@ type YAMLConfig struct {
 	RetiredModels map[string]map[string]RetiredModelEntry `yaml:"retired_models"`
 }
 
-// RetiredModelEntry describes a single retired model.
+// RetiredModelEntry describes a single retired model. The map key in
+// retired_models is the canonical slug; Aliases lists alternate slugs that
+// resolve to the same retirement metadata.
 type RetiredModelEntry struct {
-	RetiredDate string `yaml:"retired_date"`
-	Replacement string `yaml:"replacement"`
+	RetiredDate string   `yaml:"retired_date"`
+	Replacement string   `yaml:"replacement"`
+	Aliases     []string `yaml:"aliases,omitempty"`
 }
 
 // FeaturesConfig represents feature toggle configuration
@@ -1022,6 +1025,50 @@ func (c *YAMLConfig) Validate() error {
 		return fmt.Errorf("invalid admin_dashboard configuration: viewer_limits.personal_monthly_cost_limit_cents cannot be negative")
 	}
 
+	if err := c.validateRetiredModels(); err != nil {
+		return fmt.Errorf("invalid retired_models configuration: %w", err)
+	}
+
+	return nil
+}
+
+func (c *YAMLConfig) validateRetiredModels() error {
+	if c == nil || len(c.RetiredModels) == 0 {
+		return nil
+	}
+	for provider, models := range c.RetiredModels {
+		if len(models) == 0 {
+			continue
+		}
+		seen := make(map[string]string)
+		for canonical, entry := range models {
+			if canonical == "" {
+				return fmt.Errorf("provider %q has an empty retired model key", provider)
+			}
+			if entry.RetiredDate == "" {
+				return fmt.Errorf("provider %q retired model %q: retired_date is required", provider, canonical)
+			}
+			if entry.Replacement == "" {
+				return fmt.Errorf("provider %q retired model %q: replacement is required", provider, canonical)
+			}
+			if other, ok := seen[canonical]; ok {
+				return fmt.Errorf("provider %q: duplicate retired slug %q (also listed under %q)", provider, canonical, other)
+			}
+			seen[canonical] = canonical
+			for _, alias := range entry.Aliases {
+				if alias == "" {
+					return fmt.Errorf("provider %q retired model %q: empty alias", provider, canonical)
+				}
+				if alias == canonical {
+					return fmt.Errorf("provider %q retired model %q: alias duplicates canonical name", provider, canonical)
+				}
+				if other, ok := seen[alias]; ok {
+					return fmt.Errorf("provider %q: retired slug %q is listed twice (under %q and %q)", provider, alias, other, canonical)
+				}
+				seen[alias] = canonical
+			}
+		}
+	}
 	return nil
 }
 
@@ -1400,7 +1447,7 @@ func (c *YAMLConfig) GetModelConfig(provider, model string) (*ModelConfig, strin
 }
 
 // LookupRetiredModel returns retirement metadata when the provider/model slug
-// is listed in retired_models.
+// is listed in retired_models (canonical name or alias).
 func (c *YAMLConfig) LookupRetiredModel(provider, model string) (RetiredModelEntry, bool) {
 	if c == nil || model == "" {
 		return RetiredModelEntry{}, false
@@ -1409,8 +1456,17 @@ func (c *YAMLConfig) LookupRetiredModel(provider, model string) (RetiredModelEnt
 	if !ok {
 		return RetiredModelEntry{}, false
 	}
-	entry, ok := providerModels[model]
-	return entry, ok
+	if entry, ok := providerModels[model]; ok {
+		return entry, true
+	}
+	for _, entry := range providerModels {
+		for _, alias := range entry.Aliases {
+			if alias == model {
+				return entry, true
+			}
+		}
+	}
+	return RetiredModelEntry{}, false
 }
 
 // GetModelPricing returns the pricing information for a specific provider and model

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,16 @@ type YAMLConfig struct {
 
 	// Providers configuration
 	Providers map[string]ProviderConfig `yaml:"providers"`
+
+	// RetiredModels maps provider -> model slug -> retirement metadata for
+	// request-time short-circuiting before upstream calls.
+	RetiredModels map[string]map[string]RetiredModelEntry `yaml:"retired_models"`
+}
+
+// RetiredModelEntry describes a single retired model.
+type RetiredModelEntry struct {
+	RetiredDate string `yaml:"retired_date"`
+	Replacement string `yaml:"replacement"`
 }
 
 // FeaturesConfig represents feature toggle configuration
@@ -634,8 +644,10 @@ type ProviderConfig struct {
 
 // ModelConfig represents configuration for a specific model
 type ModelConfig struct {
-	Enabled bool     `yaml:"enabled"`
-	Aliases []string `yaml:"aliases,omitempty"` // Alternative model names
+	Enabled     bool     `yaml:"enabled"`
+	Deprecated  bool     `yaml:"deprecated,omitempty"`
+	Replacement string   `yaml:"replacement,omitempty"`
+	Aliases     []string `yaml:"aliases,omitempty"` // Alternative model names
 	// Pricing can be a single price, or a list of tiers.
 	Pricing interface{} `yaml:"pricing,omitempty"`
 }
@@ -1365,6 +1377,40 @@ func parseModelPricing(pricingData interface{}) (*ModelPricing, error) {
 	}
 
 	return mp, nil
+}
+
+// GetModelConfig returns the model configuration for a provider and model name,
+// resolving aliases to the canonical model entry.
+func (c *YAMLConfig) GetModelConfig(provider, model string) (*ModelConfig, string) {
+	providerConfig, exists := c.Providers[provider]
+	if !exists {
+		return nil, ""
+	}
+	if mc, ok := providerConfig.Models[model]; ok {
+		return &mc, model
+	}
+	for canonicalName, mc := range providerConfig.Models {
+		for _, alias := range mc.Aliases {
+			if alias == model {
+				return &mc, canonicalName
+			}
+		}
+	}
+	return nil, ""
+}
+
+// LookupRetiredModel returns retirement metadata when the provider/model slug
+// is listed in retired_models.
+func (c *YAMLConfig) LookupRetiredModel(provider, model string) (RetiredModelEntry, bool) {
+	if c == nil || model == "" {
+		return RetiredModelEntry{}, false
+	}
+	providerModels, ok := c.RetiredModels[provider]
+	if !ok {
+		return RetiredModelEntry{}, false
+	}
+	entry, ok := providerModels[model]
+	return entry, ok
 }
 
 // GetModelPricing returns the pricing information for a specific provider and model

--- a/internal/config/retired_models_test.go
+++ b/internal/config/retired_models_test.go
@@ -1,0 +1,50 @@
+package config
+
+import "testing"
+
+func TestLookupRetiredModel_Alias(t *testing.T) {
+	cfg := &YAMLConfig{
+		RetiredModels: map[string]map[string]RetiredModelEntry{
+			"gemini": {
+				"gemini-2.0-flash": {
+					RetiredDate: "2026-06-01",
+					Replacement: "gemini-3.5-flash",
+					Aliases:     []string{"gemini-flash-2.0", "gemini-2.0-flash-exp"},
+				},
+			},
+		},
+	}
+
+	entry, ok := cfg.LookupRetiredModel("gemini", "gemini-2.0-flash-exp")
+	if !ok {
+		t.Fatal("expected alias match")
+	}
+	if entry.Replacement != "gemini-3.5-flash" {
+		t.Fatalf("replacement=%q", entry.Replacement)
+	}
+
+	if _, ok := cfg.LookupRetiredModel("gemini", "gemini-2.5-flash"); ok {
+		t.Fatal("unexpected match")
+	}
+}
+
+func TestValidateRetiredModels_DuplicateAlias(t *testing.T) {
+	cfg := &YAMLConfig{
+		RetiredModels: map[string]map[string]RetiredModelEntry{
+			"openai": {
+				"o1-mini": {
+					RetiredDate: "2025-10-27",
+					Replacement: "o4-mini",
+					Aliases:     []string{"o1-preview"},
+				},
+				"o1-preview": {
+					RetiredDate: "2025-07-28",
+					Replacement: "o3",
+				},
+			},
+		},
+	}
+	if err := cfg.validateRetiredModels(); err == nil {
+		t.Fatal("expected duplicate slug error")
+	}
+}

--- a/internal/middleware/model_status.go
+++ b/internal/middleware/model_status.go
@@ -55,6 +55,7 @@ func ModelStatusMiddleware(
 				recorder.RecordDeprecated(providerName, model)
 				emitModelMetric(metrics, "model.deprecated_call", providerName, model)
 			} else if modelCfg == nil {
+				recorder.RecordUnknown(providerName, model)
 				log.Printf("model status: unrecognized model %q for provider %q", model, providerName)
 				emitModelMetric(metrics, "model.unknown_call", providerName, model)
 			}

--- a/internal/middleware/model_status.go
+++ b/internal/middleware/model_status.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -44,7 +43,10 @@ func ModelStatusMiddleware(
 			if entry, retired := cfg.LookupRetiredModel(providerName, model); retired {
 				recorder.RecordRetired(providerName, model)
 				emitModelMetric(metrics, "model.retired_call", providerName, model)
-				writeRetiredResponse(w, providerName, model, entry)
+				if err := providers.WriteRetiredModelResponse(w, provider, model, entry); err != nil {
+					log.Printf("model status: failed to encode retired response: %v", err)
+					fmt.Fprintf(w, `{"error":"model retired"}`)
+				}
 				return
 			}
 
@@ -71,67 +73,4 @@ func emitModelMetric(metrics circuit.MetricsSink, name, provider, model string) 
 		"model:" + model,
 	}
 	_ = metrics.Incr(name, tags, 1)
-}
-
-func retiredMessage(model string, entry config.RetiredModelEntry) string {
-	msg := fmt.Sprintf("The model '%s' has been retired", model)
-	if entry.RetiredDate != "" {
-		msg += fmt.Sprintf(" as of %s", entry.RetiredDate)
-	}
-	if entry.Replacement != "" {
-		msg += fmt.Sprintf(". Migrate to '%s'", entry.Replacement)
-	}
-	msg += "."
-	return msg
-}
-
-func writeRetiredResponse(w http.ResponseWriter, providerName, model string, entry config.RetiredModelEntry) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusGone)
-	body, err := formatRetiredError(providerName, model, entry)
-	if err != nil {
-		log.Printf("model status: failed to encode retired response: %v", err)
-		fmt.Fprintf(w, `{"error":"model retired"}`)
-		return
-	}
-	_, _ = w.Write(body)
-}
-
-func formatRetiredError(providerName, model string, entry config.RetiredModelEntry) ([]byte, error) {
-	msg := retiredMessage(model, entry)
-	switch providerName {
-	case "anthropic":
-		return json.Marshal(map[string]interface{}{
-			"type": "error",
-			"error": map[string]string{
-				"type":    "not_found_error",
-				"message": msg,
-			},
-		})
-	case "gemini":
-		return json.Marshal(map[string]interface{}{
-			"error": map[string]interface{}{
-				"code":    410,
-				"message": msg,
-				"status":  "GONE",
-			},
-		})
-	case "bedrock":
-		return json.Marshal(map[string]string{
-			"message": msg,
-		})
-	default:
-		payload := map[string]interface{}{
-			"error": map[string]interface{}{
-				"message": msg,
-				"type":    "invalid_request_error",
-				"param":   "model",
-				"code":    "model_retired",
-			},
-		}
-		if entry.Replacement != "" {
-			payload["error"].(map[string]interface{})["replacement"] = entry.Replacement
-		}
-		return json.Marshal(payload)
-	}
 }

--- a/internal/middleware/model_status.go
+++ b/internal/middleware/model_status.go
@@ -45,6 +45,9 @@ func ModelStatusMiddleware(
 				emitModelMetric(metrics, "model.retired_call", providerName, model)
 				if err := providers.WriteRetiredModelResponse(w, provider, model, entry); err != nil {
 					log.Printf("model status: failed to encode retired response: %v", err)
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set(providers.HeaderModelRetired, "model_retired")
+					w.WriteHeader(http.StatusNotFound)
 					fmt.Fprintf(w, `{"error":"model retired"}`)
 				}
 				return
@@ -57,7 +60,7 @@ func ModelStatusMiddleware(
 			} else if modelCfg == nil {
 				recorder.RecordUnknown(providerName, model)
 				log.Printf("model status: unrecognized model %q for provider %q", model, providerName)
-				emitModelMetric(metrics, "model.unknown_call", providerName, model)
+				emitModelMetric(metrics, "model.unknown_call", providerName, "__unknown__")
 			}
 
 			next.ServeHTTP(w, r)

--- a/internal/middleware/model_status.go
+++ b/internal/middleware/model_status.go
@@ -1,0 +1,137 @@
+package middleware
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/Instawork/llm-proxy/internal/circuit"
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
+	"github.com/Instawork/llm-proxy/internal/providers"
+)
+
+// ModelStatusMiddleware short-circuits requests to retired models and records
+// deprecated-model usage before forwarding to upstream providers.
+func ModelStatusMiddleware(
+	pm *providers.ProviderManager,
+	cfg *config.YAMLConfig,
+	recorder *modelstatusstats.Recorder,
+	metrics circuit.MetricsSink,
+) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" || r.URL.Path == "/redact" || strings.HasPrefix(r.URL.Path, "/admin/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			provider := GetProviderFromRequest(pm, r)
+			if provider == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			model, _ := provider.ExtractRequestModelAndMessages(r)
+			if model == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			providerName := provider.GetName()
+			if entry, retired := cfg.LookupRetiredModel(providerName, model); retired {
+				recorder.RecordRetired(providerName, model)
+				emitModelMetric(metrics, "model.retired_call", providerName, model)
+				writeRetiredResponse(w, providerName, model, entry)
+				return
+			}
+
+			modelCfg, _ := cfg.GetModelConfig(providerName, model)
+			if modelCfg != nil && modelCfg.Deprecated {
+				recorder.RecordDeprecated(providerName, model)
+				emitModelMetric(metrics, "model.deprecated_call", providerName, model)
+			} else if modelCfg == nil {
+				log.Printf("model status: unrecognized model %q for provider %q", model, providerName)
+				emitModelMetric(metrics, "model.unknown_call", providerName, model)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func emitModelMetric(metrics circuit.MetricsSink, name, provider, model string) {
+	if metrics == nil {
+		return
+	}
+	tags := []string{
+		"provider:" + provider,
+		"model:" + model,
+	}
+	_ = metrics.Incr(name, tags, 1)
+}
+
+func retiredMessage(model string, entry config.RetiredModelEntry) string {
+	msg := fmt.Sprintf("The model '%s' has been retired", model)
+	if entry.RetiredDate != "" {
+		msg += fmt.Sprintf(" as of %s", entry.RetiredDate)
+	}
+	if entry.Replacement != "" {
+		msg += fmt.Sprintf(". Migrate to '%s'", entry.Replacement)
+	}
+	msg += "."
+	return msg
+}
+
+func writeRetiredResponse(w http.ResponseWriter, providerName, model string, entry config.RetiredModelEntry) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusGone)
+	body, err := formatRetiredError(providerName, model, entry)
+	if err != nil {
+		log.Printf("model status: failed to encode retired response: %v", err)
+		fmt.Fprintf(w, `{"error":"model retired"}`)
+		return
+	}
+	_, _ = w.Write(body)
+}
+
+func formatRetiredError(providerName, model string, entry config.RetiredModelEntry) ([]byte, error) {
+	msg := retiredMessage(model, entry)
+	switch providerName {
+	case "anthropic":
+		return json.Marshal(map[string]interface{}{
+			"type": "error",
+			"error": map[string]string{
+				"type":    "not_found_error",
+				"message": msg,
+			},
+		})
+	case "gemini":
+		return json.Marshal(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    410,
+				"message": msg,
+				"status":  "GONE",
+			},
+		})
+	case "bedrock":
+		return json.Marshal(map[string]string{
+			"message": msg,
+		})
+	default:
+		payload := map[string]interface{}{
+			"error": map[string]interface{}{
+				"message": msg,
+				"type":    "invalid_request_error",
+				"param":   "model",
+				"code":    "model_retired",
+			},
+		}
+		if entry.Replacement != "" {
+			payload["error"].(map[string]interface{})["replacement"] = entry.Replacement
+		}
+		return json.Marshal(payload)
+	}
+}

--- a/internal/middleware/model_status_test.go
+++ b/internal/middleware/model_status_test.go
@@ -33,7 +33,7 @@ func TestModelStatusMiddleware_RetiredModelShortCircuits(t *testing.T) {
 		called = true
 	})
 
-	chain := ModelStatusMiddleware(pm, cfg, modelstatusstats.NewRecorder(nil), nil)(next)
+	chain := ModelStatusMiddleware(pm, cfg, modelstatusstats.NewRecorder(), nil)(next)
 
 	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(`{"model":"o1-mini","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -81,7 +81,7 @@ func TestModelStatusMiddleware_RetiredModelAliasShortCircuits(t *testing.T) {
 		called = true
 	})
 
-	chain := ModelStatusMiddleware(pm, cfg, modelstatusstats.NewRecorder(nil), nil)(next)
+	chain := ModelStatusMiddleware(pm, cfg, modelstatusstats.NewRecorder(), nil)(next)
 
 	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(`{"model":"o1-mini-2024-09-12","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/middleware/model_status_test.go
+++ b/internal/middleware/model_status_test.go
@@ -22,6 +22,7 @@ func TestModelStatusMiddleware_RetiredModelShortCircuits(t *testing.T) {
 				"o1-mini": {
 					RetiredDate: "2025-10-27",
 					Replacement: "o4-mini",
+					Aliases:     []string{"o1-mini-2024-09-12"},
 				},
 			},
 		},
@@ -56,5 +57,41 @@ func TestModelStatusMiddleware_RetiredModelShortCircuits(t *testing.T) {
 	errObj := body["error"].(map[string]any)
 	if errObj["code"] != "model_not_found" {
 		t.Fatalf("code=%v", errObj["code"])
+	}
+}
+
+func TestModelStatusMiddleware_RetiredModelAliasShortCircuits(t *testing.T) {
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(providers.NewOpenAIProxy())
+
+	cfg := &config.YAMLConfig{
+		RetiredModels: map[string]map[string]config.RetiredModelEntry{
+			"openai": {
+				"o1-mini": {
+					RetiredDate: "2025-10-27",
+					Replacement: "o4-mini",
+					Aliases:     []string{"o1-mini-2024-09-12"},
+				},
+			},
+		},
+	}
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	chain := ModelStatusMiddleware(pm, cfg, modelstatusstats.NewRecorder(nil), nil)(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(`{"model":"o1-mini-2024-09-12","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	if called {
+		t.Fatal("next handler should not run for retired alias")
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", rec.Code)
 	}
 }

--- a/internal/middleware/model_status_test.go
+++ b/internal/middleware/model_status_test.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
+	"github.com/Instawork/llm-proxy/internal/providers"
+)
+
+func TestModelStatusMiddleware_RetiredModelShortCircuits(t *testing.T) {
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(providers.NewOpenAIProxy())
+
+	cfg := &config.YAMLConfig{
+		RetiredModels: map[string]map[string]config.RetiredModelEntry{
+			"openai": {
+				"o1-mini": {
+					RetiredDate: "2025-10-27",
+					Replacement: "o4-mini",
+				},
+			},
+		},
+	}
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	chain := ModelStatusMiddleware(pm, cfg, modelstatusstats.NewRecorder(nil), nil)(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(`{"model":"o1-mini","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	if called {
+		t.Fatal("next handler should not run for retired model")
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", rec.Code)
+	}
+	if got := rec.Header().Get(providers.HeaderModelRetired); got != "model_retired" {
+		t.Fatalf("header=%q", got)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	errObj := body["error"].(map[string]any)
+	if errObj["code"] != "model_not_found" {
+		t.Fatalf("code=%v", errObj["code"])
+	}
+}

--- a/internal/middleware/model_status_unknown_test.go
+++ b/internal/middleware/model_status_unknown_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
+	"github.com/Instawork/llm-proxy/internal/providers"
+)
+
+func TestModelStatusMiddleware_UnknownModelRecorded(t *testing.T) {
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(providers.NewOpenAIProxy())
+
+	cfg := &config.YAMLConfig{
+		Providers: map[string]config.ProviderConfig{
+			"openai": {
+				Enabled: true,
+				Models: map[string]config.ModelConfig{
+					"gpt-4o": {Enabled: true},
+				},
+			},
+		},
+	}
+
+	recorder := modelstatusstats.NewRecorder()
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	chain := ModelStatusMiddleware(pm, cfg, recorder, nil)(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(`{"model":"not-a-real-model","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("next handler should run for unknown model")
+	}
+	snap := recorder.Snapshot()
+	if snap["unknown_total"] != int64(1) {
+		t.Fatalf("unknown_total=%v want 1", snap["unknown_total"])
+	}
+}

--- a/internal/modelstatusstats/stats.go
+++ b/internal/modelstatusstats/stats.go
@@ -1,39 +1,58 @@
 package modelstatusstats
 
 import (
-	"context"
-	"fmt"
+	"sort"
 	"sync"
 	"time"
 
-	redis "github.com/redis/go-redis/v9"
+	"github.com/Instawork/llm-proxy/internal/adminrollup"
 )
 
-const redisOpTimeout = 500 * time.Millisecond
-const redisKeyTTL = 48 * time.Hour
+var modelStatusRollupCaps = adminrollup.TopNCaps{}
 
-// Snapshot holds in-process counters for retired and deprecated model calls.
-type Snapshot struct {
-	Retired    map[string]int64 `json:"retired"`
-	Deprecated map[string]int64 `json:"deprecated"`
+type kv struct {
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
 }
 
-// Recorder accumulates retired and deprecated model call counts in-process,
-// with optional Redis mirroring for fleet-wide visibility.
+type statusFlushed struct {
+	retiredTotal    int64
+	deprecatedTotal int64
+	unknownTotal    int64
+	retired         map[string]int64
+	deprecated      map[string]int64
+	unknown         map[string]int64
+}
+
+// Recorder accumulates retired, deprecated, and unknown model call counts
+// in-process and publishes deltas to admin rollups for fleet-wide visibility.
 type Recorder struct {
-	mu         sync.RWMutex
+	mu        sync.RWMutex
+	startedAt time.Time
+	dayKey    string
+
+	retiredTotal    int64
+	deprecatedTotal int64
+	unknownTotal    int64
+
 	retired    map[string]int64
 	deprecated map[string]int64
-	rdb        *redis.Client
+	unknown    map[string]int64
+
+	flushed statusFlushed
+
+	adminrollup.RecorderBinding
 }
 
-// NewRecorder returns a recorder. The Redis client is optional; when nil only
-// in-process counters are updated.
-func NewRecorder(rdb *redis.Client) *Recorder {
+// NewRecorder returns a ready-to-use recorder.
+func NewRecorder() *Recorder {
+	now := time.Now().UTC()
 	return &Recorder{
+		startedAt:  now,
+		dayKey:     now.Format("2006-01-02"),
 		retired:    make(map[string]int64),
 		deprecated: make(map[string]int64),
-		rdb:        rdb,
+		unknown:    make(map[string]int64),
 	}
 }
 
@@ -41,24 +60,59 @@ func composeKey(provider, model string) string {
 	return provider + ":" + model
 }
 
-func redisKey(kind, provider, model string) string {
-	day := time.Now().UTC().Format("2006-01-02")
-	return fmt.Sprintf("llm:model:%s:day:%s:%s:%s", kind, day, provider, model)
+func topN(m map[string]int64, n int) []kv {
+	out := make([]kv, 0, len(m))
+	for name, count := range m {
+		out = append(out, kv{Name: name, Count: count})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Name < out[j].Name
+	})
+	if n > 0 && len(out) > n {
+		out = out[:n]
+	}
+	return out
 }
 
-func (r *Recorder) incrRedis(kind, provider, model string) {
-	if r == nil || r.rdb == nil {
+func intMapDelta(cur, prev map[string]int64) map[string]float64 {
+	out := make(map[string]float64)
+	for k, v := range cur {
+		if dv := float64(v - prev[k]); dv != 0 {
+			out[k] = dv
+		}
+	}
+	return out
+}
+
+func copyIntMap(m map[string]int64) map[string]int64 {
+	out := make(map[string]int64, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func (r *Recorder) maybeRollDay(now time.Time) {
+	day := now.UTC().Format("2006-01-02")
+	if r.dayKey == day {
 		return
 	}
+	oldDay := r.dayKey
+	r.dayKey = day
+	r.FlushRollup()
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
-		defer cancel()
-		key := redisKey(kind, provider, model)
-		pipe := r.rdb.Pipeline()
-		pipe.Incr(ctx, key)
-		pipe.Expire(ctx, key, redisKeyTTL)
-		_, _ = pipe.Exec(ctx)
+		r.ArchiveDayFromAggregatesElected(adminrollup.MetricModelStatus, oldDay, modelStatusRollupCaps)
 	}()
+	r.flushed = statusFlushed{}
+	r.retiredTotal = 0
+	r.deprecatedTotal = 0
+	r.unknownTotal = 0
+	r.retired = make(map[string]int64)
+	r.deprecated = make(map[string]int64)
+	r.unknown = make(map[string]int64)
 }
 
 func (r *Recorder) bumpLocked(counter map[string]int64, provider, model string) {
@@ -68,48 +122,94 @@ func (r *Recorder) bumpLocked(counter map[string]int64, provider, model string) 
 	counter[composeKey(provider, model)]++
 }
 
-// RecordRetired increments the retired-model counter.
-func (r *Recorder) RecordRetired(provider, model string) {
+func (r *Recorder) statusDeltaLocked() adminrollup.Delta {
+	return adminrollup.Delta{
+		Totals: map[string]float64{
+			"retired_total":    float64(r.retiredTotal - r.flushed.retiredTotal),
+			"deprecated_total": float64(r.deprecatedTotal - r.flushed.deprecatedTotal),
+			"unknown_total":    float64(r.unknownTotal - r.flushed.unknownTotal),
+		},
+		Dimensions: map[string]map[string]float64{
+			"by_retired":    intMapDelta(r.retired, r.flushed.retired),
+			"by_deprecated": intMapDelta(r.deprecated, r.flushed.deprecated),
+			"by_unknown":    intMapDelta(r.unknown, r.flushed.unknown),
+		},
+	}
+}
+
+func (r *Recorder) advanceFlushedLocked() {
+	r.flushed.retiredTotal = r.retiredTotal
+	r.flushed.deprecatedTotal = r.deprecatedTotal
+	r.flushed.unknownTotal = r.unknownTotal
+	r.flushed.retired = copyIntMap(r.retired)
+	r.flushed.deprecated = copyIntMap(r.deprecated)
+	r.flushed.unknown = copyIntMap(r.unknown)
+}
+
+func (r *Recorder) publishLocked() {
+	dayKey := r.dayKey
+	delta := r.statusDeltaLocked()
+	r.advanceFlushedLocked()
+	r.mu.Unlock()
+	r.QueueDelta(dayKey, delta)
+	r.mu.Lock()
+}
+
+func (r *Recorder) record(total *int64, counter map[string]int64, provider, model string) {
 	if r == nil {
 		return
 	}
+	now := time.Now().UTC()
 	r.mu.Lock()
-	r.bumpLocked(r.retired, provider, model)
+	r.maybeRollDay(now)
+	*total++
+	r.bumpLocked(counter, provider, model)
+	r.publishLocked()
 	r.mu.Unlock()
-	r.incrRedis("retired", provider, model)
+}
+
+// RecordRetired increments the retired-model counter.
+func (r *Recorder) RecordRetired(provider, model string) {
+	r.record(&r.retiredTotal, r.retired, provider, model)
 }
 
 // RecordDeprecated increments the deprecated-model counter.
 func (r *Recorder) RecordDeprecated(provider, model string) {
-	if r == nil {
-		return
-	}
-	r.mu.Lock()
-	r.bumpLocked(r.deprecated, provider, model)
-	r.mu.Unlock()
-	r.incrRedis("deprecated", provider, model)
+	r.record(&r.deprecatedTotal, r.deprecated, provider, model)
 }
 
-// Snapshot returns a copy of current in-process counters.
-func (r *Recorder) Snapshot() Snapshot {
+// RecordUnknown increments the unrecognized-model counter.
+func (r *Recorder) RecordUnknown(provider, model string) {
+	r.record(&r.unknownTotal, r.unknown, provider, model)
+}
+
+// Snapshot returns a JSON-serialisable view for the admin API.
+func (r *Recorder) Snapshot() map[string]interface{} {
 	if r == nil {
-		return Snapshot{
-			Retired:    map[string]int64{},
-			Deprecated: map[string]int64{},
-		}
+		return map[string]interface{}{"available": false}
 	}
+
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	retired := make(map[string]int64, len(r.retired))
-	for k, v := range r.retired {
-		retired[k] = v
+	dayKey := r.dayKey
+	backend := "memory"
+	if r.RollupBound() {
+		backend = "redis"
 	}
-	deprecated := make(map[string]int64, len(r.deprecated))
-	for k, v := range r.deprecated {
-		deprecated[k] = v
+	snap := map[string]interface{}{
+		"available":        true,
+		"backend":          backend,
+		"day":              dayKey,
+		"started_at":       r.startedAt.Unix(),
+		"retired_total":    r.retiredTotal,
+		"deprecated_total": r.deprecatedTotal,
+		"unknown_total":    r.unknownTotal,
+		"by_retired":       topN(r.retired, 0),
+		"by_deprecated":    topN(r.deprecated, 0),
+		"by_unknown":       topN(r.unknown, 0),
 	}
-	return Snapshot{
-		Retired:    retired,
-		Deprecated: deprecated,
-	}
+	r.mu.RUnlock()
+
+	r.MergeToday(adminrollup.MetricModelStatus, dayKey, snap, modelStatusRollupCaps)
+	r.MergeHistory(adminrollup.MetricModelStatus, snap)
+	return snap
 }

--- a/internal/modelstatusstats/stats.go
+++ b/internal/modelstatusstats/stats.go
@@ -1,0 +1,115 @@
+package modelstatusstats
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+const redisOpTimeout = 500 * time.Millisecond
+const redisKeyTTL = 48 * time.Hour
+
+// Snapshot holds in-process counters for retired and deprecated model calls.
+type Snapshot struct {
+	Retired    map[string]int64 `json:"retired"`
+	Deprecated map[string]int64 `json:"deprecated"`
+}
+
+// Recorder accumulates retired and deprecated model call counts in-process,
+// with optional Redis mirroring for fleet-wide visibility.
+type Recorder struct {
+	mu         sync.RWMutex
+	retired    map[string]int64
+	deprecated map[string]int64
+	rdb        *redis.Client
+}
+
+// NewRecorder returns a recorder. The Redis client is optional; when nil only
+// in-process counters are updated.
+func NewRecorder(rdb *redis.Client) *Recorder {
+	return &Recorder{
+		retired:    make(map[string]int64),
+		deprecated: make(map[string]int64),
+		rdb:        rdb,
+	}
+}
+
+func composeKey(provider, model string) string {
+	return provider + ":" + model
+}
+
+func redisKey(kind, provider, model string) string {
+	day := time.Now().UTC().Format("2006-01-02")
+	return fmt.Sprintf("llm:model:%s:day:%s:%s:%s", kind, day, provider, model)
+}
+
+func (r *Recorder) incrRedis(kind, provider, model string) {
+	if r == nil || r.rdb == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+		defer cancel()
+		key := redisKey(kind, provider, model)
+		pipe := r.rdb.Pipeline()
+		pipe.Incr(ctx, key)
+		pipe.Expire(ctx, key, redisKeyTTL)
+		_, _ = pipe.Exec(ctx)
+	}()
+}
+
+func (r *Recorder) bumpLocked(counter map[string]int64, provider, model string) {
+	if provider == "" || model == "" {
+		return
+	}
+	counter[composeKey(provider, model)]++
+}
+
+// RecordRetired increments the retired-model counter.
+func (r *Recorder) RecordRetired(provider, model string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.bumpLocked(r.retired, provider, model)
+	r.mu.Unlock()
+	r.incrRedis("retired", provider, model)
+}
+
+// RecordDeprecated increments the deprecated-model counter.
+func (r *Recorder) RecordDeprecated(provider, model string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.bumpLocked(r.deprecated, provider, model)
+	r.mu.Unlock()
+	r.incrRedis("deprecated", provider, model)
+}
+
+// Snapshot returns a copy of current in-process counters.
+func (r *Recorder) Snapshot() Snapshot {
+	if r == nil {
+		return Snapshot{
+			Retired:    map[string]int64{},
+			Deprecated: map[string]int64{},
+		}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	retired := make(map[string]int64, len(r.retired))
+	for k, v := range r.retired {
+		retired[k] = v
+	}
+	deprecated := make(map[string]int64, len(r.deprecated))
+	for k, v := range r.deprecated {
+		deprecated[k] = v
+	}
+	return Snapshot{
+		Retired:    retired,
+		Deprecated: deprecated,
+	}
+}

--- a/internal/modelstatusstats/stats_test.go
+++ b/internal/modelstatusstats/stats_test.go
@@ -1,0 +1,34 @@
+package modelstatusstats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecorder_SnapshotCounts(t *testing.T) {
+	rec := NewRecorder()
+	rec.RecordRetired("openai", "o1-mini")
+	rec.RecordRetired("openai", "o1-mini")
+	rec.RecordDeprecated("anthropic", "claude-2")
+	rec.RecordUnknown("gemini", "typo-model")
+
+	snap := rec.Snapshot()
+	require.Equal(t, true, snap["available"])
+	assert.Equal(t, int64(2), snap["retired_total"])
+	assert.Equal(t, int64(1), snap["deprecated_total"])
+	assert.Equal(t, int64(1), snap["unknown_total"])
+
+	byRetired, ok := snap["by_retired"].([]kv)
+	require.True(t, ok)
+	require.Len(t, byRetired, 1)
+	assert.Equal(t, "openai:o1-mini", byRetired[0].Name)
+	assert.Equal(t, int64(2), byRetired[0].Count)
+}
+
+func TestRecorder_NilSnapshot(t *testing.T) {
+	var rec *Recorder
+	snap := rec.Snapshot()
+	assert.Equal(t, false, snap["available"])
+}

--- a/internal/providers/retired.go
+++ b/internal/providers/retired.go
@@ -1,0 +1,118 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+// HeaderModelRetired marks proxy-origin retired-model responses. The JSON body
+// matches each vendor's model-not-found envelope so downstream SDKs parse it
+// normally; this header identifies that the proxy short-circuited upstream.
+const HeaderModelRetired = "X-LLM-Proxy-Error-Class"
+
+const modelRetiredErrorClass = "model_retired"
+
+// RetiredModelResponder is an optional provider capability. Providers that
+// implement it return vendor-native model-not-found JSON; others fall back to
+// DefaultRetiredModelError (OpenAI-compatible).
+type RetiredModelResponder interface {
+	FormatRetiredModelError(model string, entry config.RetiredModelEntry) (status int, body []byte, err error)
+}
+
+// FormatRetiredModelErrorForProvider dispatches to the provider's custom
+// formatter when implemented, otherwise DefaultRetiredModelError.
+func FormatRetiredModelErrorForProvider(provider Provider, model string, entry config.RetiredModelEntry) (int, []byte, error) {
+	if r, ok := provider.(RetiredModelResponder); ok {
+		return r.FormatRetiredModelError(model, entry)
+	}
+	return DefaultRetiredModelError(model, entry)
+}
+
+// WriteRetiredModelResponse writes a vendor-shaped model-not-found response.
+func WriteRetiredModelResponse(w http.ResponseWriter, provider Provider, model string, entry config.RetiredModelEntry) error {
+	status, body, err := FormatRetiredModelErrorForProvider(provider, model, entry)
+	if err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(HeaderModelRetired, modelRetiredErrorClass)
+	w.WriteHeader(status)
+	_, err = w.Write(body)
+	return err
+}
+
+// DefaultRetiredModelError is the OpenAI-compatible fallback for providers
+// without a custom RetiredModelResponder implementation.
+func DefaultRetiredModelError(model string, entry config.RetiredModelEntry) (int, []byte, error) {
+	body, err := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": openAIRetiredMessage(model, entry),
+			"type":    "invalid_request_error",
+			"param":   nil,
+			"code":    "model_not_found",
+		},
+	})
+	return http.StatusNotFound, body, err
+}
+
+func openAIRetiredMessage(model string, entry config.RetiredModelEntry) string {
+	msg := fmt.Sprintf("The model `%s` has been retired", model)
+	if entry.RetiredDate != "" {
+		msg += fmt.Sprintf(" as of %s", entry.RetiredDate)
+	}
+	if entry.Replacement != "" {
+		msg += fmt.Sprintf(". Migrate to `%s`", entry.Replacement)
+	}
+	msg += "."
+	return msg
+}
+
+func anthropicRetiredMessage(model string, entry config.RetiredModelEntry) string {
+	msg := fmt.Sprintf("model: %s has been retired", model)
+	if entry.RetiredDate != "" {
+		msg += fmt.Sprintf(" as of %s", entry.RetiredDate)
+	}
+	if entry.Replacement != "" {
+		msg += fmt.Sprintf(". Migrate to %s", entry.Replacement)
+	}
+	return msg
+}
+
+func geminiRetiredMessage(model string, entry config.RetiredModelEntry) string {
+	geminiModel := model
+	if !strings.HasPrefix(geminiModel, "models/") {
+		geminiModel = "models/" + geminiModel
+	}
+	msg := fmt.Sprintf("%s is not found for API version v1beta, or is not supported for generateContent", geminiModel)
+	if entry.RetiredDate != "" || entry.Replacement != "" {
+		msg += "."
+		if entry.RetiredDate != "" {
+			msg += fmt.Sprintf(" Retired as of %s.", entry.RetiredDate)
+		}
+		if entry.Replacement != "" {
+			msg += fmt.Sprintf(" Migrate to %s.", entry.Replacement)
+		}
+	} else {
+		msg += ". Call ListModels to see the list of available models and their supported methods."
+	}
+	return msg
+}
+
+func bedrockRetiredMessage(model string, entry config.RetiredModelEntry) string {
+	msg := "Could not resolve the foundation model from the provided model identifier."
+	if entry.RetiredDate != "" || entry.Replacement != "" {
+		msg += fmt.Sprintf(" Model %q has been retired", model)
+		if entry.RetiredDate != "" {
+			msg += fmt.Sprintf(" as of %s", entry.RetiredDate)
+		}
+		if entry.Replacement != "" {
+			msg += fmt.Sprintf("; migrate to %q", entry.Replacement)
+		}
+		msg += "."
+	}
+	return msg
+}

--- a/internal/providers/retired_anthropic.go
+++ b/internal/providers/retired_anthropic.go
@@ -1,0 +1,19 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func (p *AnthropicProxy) FormatRetiredModelError(model string, entry config.RetiredModelEntry) (int, []byte, error) {
+	body, err := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]string{
+			"type":    "not_found_error",
+			"message": anthropicRetiredMessage(model, entry),
+		},
+	})
+	return http.StatusNotFound, body, err
+}

--- a/internal/providers/retired_bedrock.go
+++ b/internal/providers/retired_bedrock.go
@@ -1,0 +1,16 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func (p *BedrockProxy) FormatRetiredModelError(model string, entry config.RetiredModelEntry) (int, []byte, error) {
+	body, err := json.Marshal(map[string]string{
+		"__type":  "ResourceNotFoundException",
+		"message": bedrockRetiredMessage(model, entry),
+	})
+	return http.StatusNotFound, body, err
+}

--- a/internal/providers/retired_gemini.go
+++ b/internal/providers/retired_gemini.go
@@ -1,0 +1,19 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func (p *GeminiProxy) FormatRetiredModelError(model string, entry config.RetiredModelEntry) (int, []byte, error) {
+	body, err := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"code":    404,
+			"message": geminiRetiredMessage(model, entry),
+			"status":  "NOT_FOUND",
+		},
+	})
+	return http.StatusNotFound, body, err
+}

--- a/internal/providers/retired_openai.go
+++ b/internal/providers/retired_openai.go
@@ -1,0 +1,20 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func (p *OpenAIProxy) FormatRetiredModelError(model string, entry config.RetiredModelEntry) (int, []byte, error) {
+	body, err := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": openAIRetiredMessage(model, entry),
+			"type":    "invalid_request_error",
+			"param":   nil,
+			"code":    "model_not_found",
+		},
+	})
+	return http.StatusNotFound, body, err
+}

--- a/internal/providers/retired_test.go
+++ b/internal/providers/retired_test.go
@@ -1,0 +1,169 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func TestRetiredModelError_VendorShapes(t *testing.T) {
+	entry := config.RetiredModelEntry{
+		RetiredDate: "2025-10-27",
+		Replacement: "o4-mini",
+	}
+	model := "o1-mini"
+
+	tests := []struct {
+		name     string
+		provider Provider
+		wantCode int
+		assert   func(t *testing.T, body map[string]any)
+	}{
+		{
+			name:     "openai",
+			provider: &OpenAIProxy{},
+			wantCode: http.StatusNotFound,
+			assert: func(t *testing.T, body map[string]any) {
+				errObj, ok := body["error"].(map[string]any)
+				if !ok {
+					t.Fatalf("error object missing: %#v", body)
+				}
+				if errObj["type"] != "invalid_request_error" {
+					t.Fatalf("type=%v", errObj["type"])
+				}
+				if errObj["code"] != "model_not_found" {
+					t.Fatalf("code=%v", errObj["code"])
+				}
+				msg, _ := errObj["message"].(string)
+				if msg == "" || msg[0:1] != "T" {
+					t.Fatalf("message=%q", msg)
+				}
+			},
+		},
+		{
+			name:     "anthropic",
+			provider: &AnthropicProxy{},
+			wantCode: http.StatusNotFound,
+			assert: func(t *testing.T, body map[string]any) {
+				if body["type"] != "error" {
+					t.Fatalf("type=%v", body["type"])
+				}
+				errObj, ok := body["error"].(map[string]any)
+				if !ok {
+					t.Fatalf("error object missing: %#v", body)
+				}
+				if errObj["type"] != "not_found_error" {
+					t.Fatalf("error.type=%v", errObj["type"])
+				}
+				msg, _ := errObj["message"].(string)
+				if msg == "" || msg[:6] != "model:" {
+					t.Fatalf("message=%q", msg)
+				}
+			},
+		},
+		{
+			name:     "gemini",
+			provider: &GeminiProxy{},
+			wantCode: http.StatusNotFound,
+			assert: func(t *testing.T, body map[string]any) {
+				errObj, ok := body["error"].(map[string]any)
+				if !ok {
+					t.Fatalf("error object missing: %#v", body)
+				}
+				if errObj["status"] != "NOT_FOUND" {
+					t.Fatalf("status=%v", errObj["status"])
+				}
+				code, ok := errObj["code"].(float64)
+				if !ok || int(code) != 404 {
+					t.Fatalf("code=%v", errObj["code"])
+				}
+				msg, _ := errObj["message"].(string)
+				if msg == "" || msg[:7] != "models/" {
+					t.Fatalf("message=%q", msg)
+				}
+			},
+		},
+		{
+			name:     "bedrock",
+			provider: &BedrockProxy{},
+			wantCode: http.StatusNotFound,
+			assert: func(t *testing.T, body map[string]any) {
+				if body["__type"] != "ResourceNotFoundException" {
+					t.Fatalf("__type=%v", body["__type"])
+				}
+				msg, _ := body["message"].(string)
+				if msg == "" {
+					t.Fatalf("message empty")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, raw, err := FormatRetiredModelErrorForProvider(tc.provider, model, entry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status != tc.wantCode {
+				t.Fatalf("status=%d want %d", status, tc.wantCode)
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				t.Fatalf("unmarshal: %v body=%s", err, raw)
+			}
+			tc.assert(t, parsed)
+		})
+	}
+}
+
+func TestDefaultRetiredModelError_UnknownProvider(t *testing.T) {
+	type unknownProvider struct{}
+
+	prov := unknownProvider{}
+	if _, ok := any(prov).(Provider); ok {
+		t.Fatal("unexpected Provider satisfaction")
+	}
+
+	status, raw, err := DefaultRetiredModelError("foo", config.RetiredModelEntry{Replacement: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusNotFound {
+		t.Fatalf("status=%d", status)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatal(err)
+	}
+	errObj := body["error"].(map[string]any)
+	if errObj["code"] != "model_not_found" {
+		t.Fatalf("code=%v", errObj["code"])
+	}
+}
+
+func TestWriteRetiredModelResponse_SetsProxyHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if err := WriteRetiredModelResponse(rec, &OpenAIProxy{}, "o1-mini", config.RetiredModelEntry{
+		RetiredDate: "2025-10-27",
+		Replacement: "o4-mini",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if got := rec.Header().Get(HeaderModelRetired); got != "model_retired" {
+		t.Fatalf("header=%q", got)
+	}
+}
+
+var (
+	_ RetiredModelResponder = (*OpenAIProxy)(nil)
+	_ RetiredModelResponder = (*AnthropicProxy)(nil)
+	_ RetiredModelResponder = (*GeminiProxy)(nil)
+	_ RetiredModelResponder = (*BedrockProxy)(nil)
+)

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -10,8 +10,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <script type="module" crossorigin src="/admin/assets/index-CKhswwcd.js"></script>
-  <link rel="stylesheet" crossorigin href="/admin/assets/index-DYeI1Ooy.css">
+  <script type="module" crossorigin src="/admin/assets/index-ByBQw_UW.js"></script>
+  <link rel="stylesheet" crossorigin href="/admin/assets/index-B7Ks9axI.css">
 </head>
 
 <body>

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -119,6 +119,17 @@ function ShieldIcon() {
   );
 }
 
+function ModelStatusIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-5 w-5">
+      <path d="m12 2 8 4.5v7L12 18l-8-4.5v-7L12 2Z" />
+      <path d="m12 18 8-4.5" />
+      <path d="M12 18V9" />
+      <path d="m4 7.5 8 4.5" />
+    </svg>
+  );
+}
+
 function ConfigIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-5 w-5">
@@ -204,6 +215,7 @@ export default function AppShell({ children }: { children: ReactNode }) {
     "/rate-limits": <GaugeIcon />,
     "/cost": <CostIcon />,
     "/pii": <ShieldIcon />,
+    "/model-status": <ModelStatusIcon />,
     "/keys": <KeyIcon />,
     "/config": <ConfigIcon />,
     "/users": <UsersIcon />,

--- a/web/src/hooks/queries.ts
+++ b/web/src/hooks/queries.ts
@@ -13,6 +13,7 @@ import type {
   HealthResponse,
   KeyStatsResponse,
   CircuitActivityResponse,
+  ModelStatusResponse,
   PIIResponse,
   ProvisioningStatus,
   Provider,
@@ -37,6 +38,7 @@ export const queryKeys = {
   cost: ["admin", "cost"] as const,
   usage: ["admin", "usage"] as const,
   pii: ["admin", "pii"] as const,
+  modelStatus: ["admin", "model-status"] as const,
   provisioning: ["admin", "provisioning"] as const,
   users: ["admin", "users"] as const,
 };
@@ -176,6 +178,19 @@ export function usePII() {
   return useQuery({
     queryKey: queryKeys.pii,
     queryFn: () => apiFetch<PIIResponse>("/admin/api/pii"),
+    enabled: roleAtLeast(role, "editor"),
+    refetchInterval,
+    refetchIntervalInBackground: true,
+  });
+}
+
+export function useModelStatus() {
+  const { data: me } = useMe();
+  const role = me?.role ?? "viewer";
+  const refetchInterval = usePollInterval();
+  return useQuery({
+    queryKey: queryKeys.modelStatus,
+    queryFn: () => apiFetch<ModelStatusResponse>("/admin/api/model-status"),
     enabled: roleAtLeast(role, "editor"),
     refetchInterval,
     refetchIntervalInBackground: true,

--- a/web/src/lib/nav.ts
+++ b/web/src/lib/nav.ts
@@ -15,6 +15,7 @@ export const MONITORING_NAV: NavItem[] = [
   { to: "/rate-limits", label: "Rate Limits", minRole: "editor" },
   { to: "/cost", label: "Cost Tracking", minRole: "editor" },
   { to: "/pii", label: "PII Redaction", minRole: "editor" },
+  { to: "/model-status", label: "Model Status", minRole: "editor" },
 ];
 
 export const MANAGE_NAV: NavItem[] = [

--- a/web/src/pages/model-status.tsx
+++ b/web/src/pages/model-status.tsx
@@ -1,0 +1,341 @@
+import { useMemo, useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { BarChart, ChartCard, TrendChart } from "../components/charts";
+import { chartPalette } from "../components/charts/chart-setup";
+import DataTable from "../components/ui/data-table";
+import {
+  type DataSource,
+  LiveStat,
+  RangeToggle,
+  SectionPanel,
+  trendChartSource,
+} from "../components/ui/data-source";
+import PageHeader, { ErrorAlert, LiveIndicator, LoadingBlock } from "../components/ui/page-header";
+import { useModelStatus } from "../hooks/queries";
+import { LIVE_TREND_CHART_SUBTITLE, useHistory } from "../hooks/use-history";
+import {
+  DAILY_HISTORY_SUBTITLE,
+  type NameCount,
+  type RangeKey,
+  RANGE_OPTIONS,
+  aggNameCount,
+  pickToday,
+  scalarSeries,
+  sumScalarField,
+} from "../lib/daily-history";
+import type { ModelStatusNameCount, ModelStatusRegistryEntry } from "../types";
+
+function rangeLabel(range: RangeKey): string {
+  return range === "today" ? "today" : `last ${range === "7d" ? "7" : "30"} days`;
+}
+
+function splitScope(scope: string): { provider: string; model: string } {
+  const idx = scope.indexOf(":");
+  if (idx === -1) return { provider: "", model: scope };
+  return { provider: scope.slice(0, idx), model: scope.slice(idx + 1) };
+}
+
+function toNameCount(rows: ModelStatusNameCount[] | undefined): NameCount[] {
+  return (rows ?? []).map((r) => ({ name: r.name, count: r.count }));
+}
+
+function lookupRetired(
+  registry: ModelStatusRegistryEntry[] | undefined,
+  scope: string,
+): ModelStatusRegistryEntry | undefined {
+  const { provider, model } = splitScope(scope);
+  for (const row of registry ?? []) {
+    if (row.provider !== provider) continue;
+    if (row.model === model) return row;
+    if (row.aliases?.includes(model)) return row;
+  }
+  return undefined;
+}
+
+function lookupDeprecated(
+  registry: ModelStatusRegistryEntry[] | undefined,
+  scope: string,
+): ModelStatusRegistryEntry | undefined {
+  const { provider, model } = splitScope(scope);
+  for (const row of registry ?? []) {
+    if (row.provider !== provider) continue;
+    if (row.model === model) return row;
+    if (row.aliases?.includes(model)) return row;
+  }
+  return undefined;
+}
+
+interface TrafficRow {
+  id: string;
+  provider: string;
+  model: string;
+  calls: number;
+  replacement?: string;
+  retiredDate?: string;
+}
+
+function trafficRows(
+  counts: NameCount[],
+  kind: "retired" | "deprecated" | "unknown",
+  registry: ModelStatusRegistryEntry[] | undefined,
+): TrafficRow[] {
+  return counts.map((row) => {
+    const { provider, model } = splitScope(row.name);
+    const meta =
+      kind === "retired"
+        ? lookupRetired(registry, row.name)
+        : kind === "deprecated"
+          ? lookupDeprecated(registry, row.name)
+          : undefined;
+    return {
+      id: row.name,
+      provider,
+      model,
+      calls: row.count,
+      replacement: meta?.replacement,
+      retiredDate: meta?.retired_date,
+    };
+  });
+}
+
+function trafficColumns(showReplacement: boolean, showRetiredDate: boolean): ColumnDef<TrafficRow, unknown>[] {
+  const cols: ColumnDef<TrafficRow, unknown>[] = [
+    {
+      id: "provider",
+      accessorKey: "provider",
+      header: "Provider",
+      cell: ({ getValue }) => <span className="font-medium capitalize">{getValue<string>()}</span>,
+    },
+    {
+      id: "model",
+      accessorKey: "model",
+      header: "Model",
+      cell: ({ getValue }) => <code className="text-sm">{getValue<string>()}</code>,
+    },
+    {
+      id: "calls",
+      accessorKey: "calls",
+      header: "Calls",
+      cell: ({ getValue }) => getValue<number>().toLocaleString(),
+    },
+  ];
+  if (showReplacement) {
+    cols.push({
+      id: "replacement",
+      accessorKey: "replacement",
+      header: "Replacement",
+      cell: ({ getValue }) => {
+        const value = getValue<string | undefined>();
+        return value ? <code className="text-sm">{value}</code> : "—";
+      },
+    });
+  }
+  if (showRetiredDate) {
+    cols.push({
+      id: "retiredDate",
+      accessorKey: "retiredDate",
+      header: "Retired",
+      cell: ({ getValue }) => getValue<string | undefined>() ?? "—",
+    });
+  }
+  return cols;
+}
+
+export default function ModelStatusPage() {
+  const { data, isLoading, error, dataUpdatedAt, isFetching, refetch } = useModelStatus();
+  const [range, setRange] = useState<RangeKey>("today");
+
+  const stats = data?.stats;
+  const registry = data?.registry;
+  const history = stats?.daily_history;
+  const hasRedis = Boolean(stats?.daily_history_available);
+
+  const retiredPick = pickToday(
+    stats?.available ? stats?.retired_total : undefined,
+    history,
+    "retired_total",
+    hasRedis,
+  );
+  const deprecatedPick = pickToday(
+    stats?.available ? stats?.deprecated_total : undefined,
+    history,
+    "deprecated_total",
+    hasRedis,
+  );
+  const unknownPick = pickToday(
+    stats?.available ? stats?.unknown_total : undefined,
+    history,
+    "unknown_total",
+    hasRedis,
+  );
+
+  const retiredValue =
+    range === "today" ? retiredPick.value : sumScalarField(history, range, "retired_total");
+  const deprecatedValue =
+    range === "today" ? deprecatedPick.value : sumScalarField(history, range, "deprecated_total");
+  const unknownValue =
+    range === "today" ? unknownPick.value : sumScalarField(history, range, "unknown_total");
+  const summarySource: DataSource =
+    range === "today" ? retiredPick.source : hasRedis ? "redis" : "memory";
+
+  const retiredHistory = useHistory(stats?.available ? retiredPick.value : undefined);
+  const dailyRetired = useMemo(
+    () => scalarSeries(history, "retired_total", range),
+    [history, range],
+  );
+  const useDailyChart = Boolean(hasRedis && range !== "today" && dailyRetired.available);
+
+  const breakdownSource: DataSource = hasRedis || range !== "today" ? "redis" : "memory";
+  const byRetired = hasRedis || range !== "today"
+    ? aggNameCount(history, range, "by_retired")
+    : toNameCount(stats?.by_retired);
+  const byDeprecated = hasRedis || range !== "today"
+    ? aggNameCount(history, range, "by_deprecated")
+    : toNameCount(stats?.by_deprecated);
+  const byUnknown = hasRedis || range !== "today"
+    ? aggNameCount(history, range, "by_unknown")
+    : toNameCount(stats?.by_unknown);
+
+  const retiredRows = useMemo(
+    () => trafficRows(byRetired, "retired", registry?.retired),
+    [byRetired, registry?.retired],
+  );
+  const deprecatedRows = useMemo(
+    () => trafficRows(byDeprecated, "deprecated", registry?.deprecated),
+    [byDeprecated, registry?.deprecated],
+  );
+  const unknownRows = useMemo(
+    () => trafficRows(byUnknown, "unknown", undefined),
+    [byUnknown],
+  );
+
+  const retiredColumns = useMemo(() => trafficColumns(true, true), []);
+  const deprecatedColumns = useMemo(() => trafficColumns(true, false), []);
+  const unknownColumns = useMemo(() => trafficColumns(false, false), []);
+
+  if (isLoading) return <LoadingBlock />;
+  if (error) {
+    return (
+      <ErrorAlert message={error instanceof Error ? error.message : "Failed to load model status"} />
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Model Status"
+        description="Retired, deprecated, and unrecognized model traffic."
+        actions={
+          <div className="flex items-center gap-3">
+            <RangeToggle value={range} options={RANGE_OPTIONS} onChange={setRange} />
+            <LiveIndicator updatedAt={dataUpdatedAt} fetching={isFetching} onRefresh={() => refetch()} />
+          </div>
+        }
+      />
+
+      {!stats?.available ? (
+        <div className="alert alert-info">
+          <span>Model status stats are unavailable on this instance.</span>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <LiveStat
+          title="Retired calls"
+          value={retiredValue.toLocaleString()}
+          hint={`blocked requests · ${rangeLabel(range)}`}
+          source={summarySource}
+        />
+        <LiveStat
+          title="Deprecated calls"
+          value={deprecatedValue.toLocaleString()}
+          hint={`still forwarded · ${rangeLabel(range)}`}
+          source={summarySource}
+        />
+        <LiveStat
+          title="Unknown models"
+          value={unknownValue.toLocaleString()}
+          hint={`unregistered slugs · ${rangeLabel(range)}`}
+          source={summarySource}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <ChartCard
+            title="Retired calls over time"
+            subtitle={useDailyChart ? DAILY_HISTORY_SUBTITLE : LIVE_TREND_CHART_SUBTITLE}
+            source={trendChartSource(useDailyChart)}
+          >
+            {useDailyChart ? (
+              <BarChart
+                labels={dailyRetired.labels}
+                values={dailyRetired.values}
+                label="Retired calls"
+                colors={dailyRetired.labels.map(() => chartPalette.error())}
+              />
+            ) : (
+              <TrendChart points={retiredHistory} label="Retired calls" color={chartPalette.error()} />
+            )}
+          </ChartCard>
+        </div>
+        <ChartCard
+          title="Issue mix"
+          subtitle={`Retired vs deprecated vs unknown · ${rangeLabel(range)}`}
+          source={breakdownSource}
+        >
+          <BarChart
+            labels={["Retired", "Deprecated", "Unknown"]}
+            values={[retiredValue, deprecatedValue, unknownValue]}
+            label="Calls"
+            colors={[chartPalette.error(), chartPalette.warning(), chartPalette.info()]}
+          />
+        </ChartCard>
+      </div>
+
+      <SectionPanel
+        title="Retired model calls"
+        subtitle={`Blocked at the proxy · ${rangeLabel(range)}`}
+        source={breakdownSource}
+      >
+        <DataTable
+          data={retiredRows}
+          columns={retiredColumns}
+          searchPlaceholder="Filter models…"
+          emptyMessage="No retired model calls in this window"
+          getRowId={(row) => row.id}
+        />
+      </SectionPanel>
+
+      <SectionPanel
+        title="Deprecated model calls"
+        subtitle={`Still forwarded upstream · ${rangeLabel(range)}`}
+        source={breakdownSource}
+      >
+        <DataTable
+          data={deprecatedRows}
+          columns={deprecatedColumns}
+          searchPlaceholder="Filter models…"
+          emptyMessage="No deprecated model calls in this window"
+          getRowId={(row) => row.id}
+        />
+      </SectionPanel>
+
+      <SectionPanel
+        title="Unknown model calls"
+        subtitle={`Slugs not in proxy config · ${rangeLabel(range)}`}
+        source={breakdownSource}
+      >
+        <DataTable
+          data={unknownRows}
+          columns={unknownColumns}
+          searchPlaceholder="Filter models…"
+          emptyMessage="No unknown model calls in this window"
+          getRowId={(row) => row.id}
+        />
+      </SectionPanel>
+    </div>
+  );
+}

--- a/web/src/pages/overview.tsx
+++ b/web/src/pages/overview.tsx
@@ -11,7 +11,7 @@ import PageHeader, {
   LoadingBlock,
   StatusBadge,
 } from "../components/ui/page-header";
-import { useConfig, useHealth, useKeys, useUsage } from "../hooks/queries";
+import { useConfig, useHealth, useKeys, useModelStatus, useUsage } from "../hooks/queries";
 import { LIVE_TREND_CHART_SUBTITLE, useHistory } from "../hooks/use-history";
 import { aggScopeMap, DAILY_HISTORY_SUBTITLE, dailyHistoryChart, pickToday } from "../lib/daily-history";
 import { featureEnabled } from "../lib/features";
@@ -22,6 +22,7 @@ export default function OverviewPage() {
   const config = useConfig();
   const usage = useUsage();
   const keys = useKeys();
+  const modelStatus = useModelStatus();
 
   const cb = health.data?.circuit_breaker;
   const providers = cb?.providers ?? {};
@@ -63,19 +64,35 @@ export default function OverviewPage() {
   const modelRows = (
     usageRedis
       ? aggScopeMap(usageHistory, "today", "by_model").map((s) => ({
-          label: scopeLabel(s.scope),
-          requests: s.requests,
-        }))
+        label: scopeLabel(s.scope),
+        requests: s.requests,
+      }))
       : Object.entries(usageCounters)
-          .filter(([scope]) => scopeKind(scope) === "model")
-          .map(([scope, c]) => ({ label: scopeLabel(scope), requests: c.requests ?? 0 }))
+        .filter(([scope]) => scopeKind(scope) === "model")
+        .map(([scope, c]) => ({ label: scopeLabel(scope), requests: c.requests ?? 0 }))
   )
     .sort((a, b) => b.requests - a.requests)
     .slice(0, 6);
   const modelSource = usageRedis ? "redis" : "memory";
 
-  const isLoading = health.isLoading || config.isLoading || usage.isLoading;
-  const error = health.error || config.error || usage.error;
+  const modelStatusStats = modelStatus.data?.stats;
+  const modelStatusHistory = modelStatusStats?.daily_history;
+  const modelStatusRedis = Boolean(modelStatusStats?.daily_history_available);
+  const retiredTodayPick = pickToday(
+    modelStatusStats?.available ? modelStatusStats?.retired_total : undefined,
+    modelStatusHistory,
+    "retired_total",
+    modelStatusRedis,
+  );
+  const unknownTodayPick = pickToday(
+    modelStatusStats?.available ? modelStatusStats?.unknown_total : undefined,
+    modelStatusHistory,
+    "unknown_total",
+    modelStatusRedis,
+  );
+
+  const isLoading = health.isLoading || config.isLoading || usage.isLoading || modelStatus.isLoading;
+  const error = health.error || config.error || usage.error || modelStatus.error;
 
   if (isLoading) return <LoadingBlock />;
   if (error) {
@@ -97,6 +114,7 @@ export default function OverviewPage() {
             onRefresh={() => {
               health.refetch();
               usage.refetch();
+              modelStatus.refetch();
             }}
           />
         }
@@ -133,6 +151,28 @@ export default function OverviewPage() {
           hint={`${providerNames.length} providers · ${enabledFeatures}/${totalFeatures} features on · ${keys.data?.length ?? "—"} keys`}
           source={circuitLive}
         />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <LiveStat
+          title="Retired calls today"
+          value={retiredTodayPick.value.toLocaleString()}
+          hint="blocked at proxy"
+          source={retiredTodayPick.source}
+        />
+        <LiveStat
+          title="Unknown models today"
+          value={unknownTodayPick.value.toLocaleString()}
+          hint="unregistered slugs"
+          source={unknownTodayPick.source}
+        />
+        <div className="card bg-base-100 shadow-sm">
+          <div className="card-body justify-center">
+            <Link to="/model-status" className="btn btn-outline btn-sm">
+              Model status details
+            </Link>
+          </div>
+        </div>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-3">

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -13,6 +13,7 @@ import CostPage from "./pages/cost";
 import KeyDetailPage from "./pages/keys/detail";
 import KeysPage from "./pages/keys";
 import LoginPage from "./pages/login";
+import ModelStatusPage from "./pages/model-status";
 import OverviewPage from "./pages/overview";
 import PIIPage from "./pages/pii";
 import RateLimitsPage from "./pages/rate-limits";
@@ -80,6 +81,14 @@ export default function Router() {
             element={shell(
               <RequireRole minRole="editor">
                 <PIIPage />
+              </RequireRole>,
+            )}
+          />
+          <Route
+            path="/model-status"
+            element={shell(
+              <RequireRole minRole="editor">
+                <ModelStatusPage />
               </RequireRole>,
             )}
           />

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -350,6 +350,42 @@ export interface PIIResponse {
   stats: PIIStats;
 }
 
+export interface ModelStatusNameCount {
+  name: string;
+  count: number;
+}
+
+export interface ModelStatusRegistryEntry {
+  provider: string;
+  model: string;
+  retired_date?: string;
+  replacement?: string;
+  aliases?: string[];
+}
+
+export interface ModelStatusRegistry {
+  retired: ModelStatusRegistryEntry[];
+  deprecated: ModelStatusRegistryEntry[];
+}
+
+export interface ModelStatusStats extends StatsWithDailyHistory {
+  available: boolean;
+  backend?: string;
+  day?: string;
+  started_at?: number;
+  retired_total?: number;
+  deprecated_total?: number;
+  unknown_total?: number;
+  by_retired?: ModelStatusNameCount[];
+  by_deprecated?: ModelStatusNameCount[];
+  by_unknown?: ModelStatusNameCount[];
+}
+
+export interface ModelStatusResponse {
+  stats: ModelStatusStats;
+  registry: ModelStatusRegistry;
+}
+
 export interface UsageScopeCounter {
   requests?: number;
   tokens?: number;


### PR DESCRIPTION
## Summary

- Add `retired_models` config block + `ModelStatusMiddleware` that returns **410 Gone** for truly retired model slugs, logs + emits `model.unknown_call` for model names absent from config entirely
- Update `configs/base.yml`: remove retired OpenAI/Anthropic/Gemini models, add `gpt-5.5`/`gpt-5.5-pro`/`gemini-3.5-flash`, mark `claude-opus-4-1` and `gemini-2.5-pro` deprecated
- Bedrock left unchanged — AWS has its own retirement lifecycle separate from the Anthropic native API

## Details

**New infrastructure (`internal/middleware/model_status.go`, `internal/modelstatusstats/`):**
- Retired models → 410 Gone with provider-appropriate error envelope (OpenAI, Anthropic, Gemini, Bedrock shapes)
- Deprecated models → pass-through + `model.deprecated_call` Datadog metric + Redis/in-memory counter
- Unknown models (not in config at all) → pass-through + `log.Printf` warning + `model.unknown_call` metric — enables discovery of new models clients use before we add them

**`configs/base.yml` changes:**
- OpenAI: retired `o1-mini` (Oct 2025), `o1-preview` (Jul 2025); split `o3-deep-research` / `o4-mini-deep-research` into standalone entries; add `gpt-5.5`, `gpt-5.5-pro`
- Anthropic: flat pricing for `claude-sonnet-4-6` ($3/$15); retire 6 Claude 3.x / Opus 4.0 slugs; mark `claude-opus-4-1` deprecated → `claude-opus-4-7`
- Gemini: remove `gemini-3-pro`, `gemini-2.0-flash`, `gemini-2.0-flash-lite`; add `gemini-3.5-flash`; mark `gemini-2.5-pro` deprecated → `gemini-3.1-pro`

## Test plan

- [x] `go run ./cmd/config-validator/` passes all env configs
- [x] `go test ./...` passes
- [ ] Deploy to staging and confirm retired-model requests return 410 with correct error shape
- [ ] Verify `model.deprecated_call` and `model.unknown_call` metrics appear in Datadog after first real traffic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added handling for retired and deprecated models: retired requests are short-circuited with JSON error responses, a dedicated proxy error header, and replacement guidance; deprecated usage is tracked.
  * Added model status statistics tracking (in-process with optional Redis mirroring).

* **Configuration**
  * Added `retired_models` configuration and per-model `deprecated`/`replacement` metadata.
  * Updated provider model catalogs and retirement/deprecation mappings (OpenAI, Anthropic, Gemini).

* **Bug Fixes**
  * Improved retired-model response generation with consistent, provider-specific “not found” error shapes.

* **Tests**
  * Added coverage for retired-model short-circuit behavior, retired-model alias lookup, duplicate configuration validation, and vendor-specific error formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->