### PR TITLE
feat(pii): enable production PII redaction on standalone llm-proxy

### DIFF
--- a/configs/production.yml
+++ b/configs/production.yml
@@ -105,7 +105,7 @@ features:
       requests_per_day: 0
       tokens_per_day: 0
   pii_redact:
-    enabled: false
+    enabled: true
     analyzer_url: "http://localhost:3000"
     fail_mode: "open"
     allow_per_key_override: false

--- a/configs/sidecar.yml
+++ b/configs/sidecar.yml
@@ -2,7 +2,8 @@
 # Set LLM_PROXY_CONFIG_PROFILE=sidecar alongside ENVIRONMENT=production (or
 # staging) so deploy identity and infra settings stay on the env file while
 # PII redaction and the admin dashboard HTTP server stay off here — observability
-# redaction and the dashboard UI run only on the standalone llm-proxy service.
+# redaction, POST /redact, and the dashboard UI run only on the central
+# standalone llm-proxy service (not co-located app sidecars).
 #
 # This file deep-merges over the environment file (e.g. production.yml), but the
 # merge replaces whole nested blocks it names. So sidecars STILL write usage/cost/
@@ -18,6 +19,8 @@ features:
   pii_redact:
     enabled: false
     allow_per_key_override: false
+  redact_api:
+    enabled: false
   admin_dashboard:
     # HTTP dashboard server off (UI served only by the standalone service)...
     enabled: false

--- a/docs/PII_REDACT.md
+++ b/docs/PII_REDACT.md
@@ -17,9 +17,31 @@ extend the wire payload past the in-code allowlist — see
 
 ## Status
 
-Off by default. The middleware is gated by
-`features.pii_redact.enabled` in YAML — until you flip it, no /analyze
-calls happen and no body capture overhead is incurred.
+| Deployment | `pii_redact` | `POST /redact` | Notes |
+| ---------- | ------------ | -------------- | ----- |
+| Standalone production (`llm.instawork.com`) | **on** | on | Presidio sidecar co-located in the ECS task (`localhost:3000`) |
+| App sidecars (`LLM_PROXY_CONFIG_PROFILE=sidecar`) | off | off | Traffic still rolls up to the admin dashboard via Redis |
+| Local dev (`configs/dev.yml`) | on | on | Requires `docker compose --profile pii_redact up -d presidio` |
+| Default (`configs/base.yml`) | off | off | Opt-in per environment |
+
+First production rollout uses `fail_mode: open` — a Presidio outage logs a
+warning and passes the request through rather than returning 503. Monitor
+`fail_open` on the admin PII dashboard before tightening to `closed`.
+
+## Vendor posture
+
+Contractual safeguards for raw LLM egress (Decision gate 0 in
+[`PII_REMEDIATION_PLAN.md`](PII_REMEDIATION_PLAN.md)). Update this table
+when legal confirms status; it sets whether unredacted upstream egress is
+P0 or informational.
+
+| Vendor | BAA / DPA | Notes |
+| ------ | --------- | ----- |
+| OpenAI | pending review | |
+| Anthropic | pending review | |
+| Google Gemini | pending review | |
+| AWS Bedrock | pending review | Account BAA posture TBD |
+| Datadog (cost metric tags) | pending review | See W3 in remediation plan |
 
 ## Enabling locally
 

--- a/internal/config/loading_test.go
+++ b/internal/config/loading_test.go
@@ -373,6 +373,31 @@ func TestDevConfig_PerUserOverridesNotMisnested(t *testing.T) {
 	}
 }
 
+func TestRealEnvConfigs_ProductionStandalonePIIEnabled(t *testing.T) {
+	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
+	require.NoError(t, err)
+	if _, err := os.Stat(configsDir); err != nil {
+		t.Skipf("configs dir not found (%s) — skipping", configsDir)
+	}
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	require.NoError(t, os.Chdir(repoRoot))
+
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("LLM_PROXY_CONFIG_PROFILE", "")
+	cfg, err := LoadEnvironmentConfig()
+	require.NoError(t, err)
+
+	assert.True(t, cfg.Features.PIIRedact.Enabled,
+		"standalone production llm-proxy must enable PII redaction")
+	assert.True(t, cfg.Features.RedactAPI.Enabled,
+		"standalone production must expose POST /redact")
+}
+
 func TestRealEnvConfigs_ProductionSidecarProfile(t *testing.T) {
 	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
 	require.NoError(t, err)
@@ -396,6 +421,8 @@ func TestRealEnvConfigs_ProductionSidecarProfile(t *testing.T) {
 		"production infra (circuit breaker) must survive the sidecar profile overlay")
 	assert.False(t, cfg.Features.PIIRedact.Enabled,
 		"sidecar profile must disable PII redaction")
+	assert.False(t, cfg.Features.RedactAPI.Enabled,
+		"sidecar profile must disable POST /redact")
 	assert.False(t, cfg.Features.AdminDashboard.Enabled,
 		"sidecar profile must disable the admin dashboard")
 	assert.Equal(t, "none", cfg.Features.History.Backend,


### PR DESCRIPTION
## Summary
- Enable `features.pii_redact` on standalone production llm-proxy (Presidio sidecar already co-located in ECS)
- Explicitly disable `POST /redact` on the sidecar profile so Finch co-located proxies do not expose the redact API
- Add config loading tests asserting standalone vs sidecar PII/redact_api flags
- Update `docs/PII_REDACT.md` with deployment status table and vendor posture placeholder

## Test plan
- [x] `go test ./internal/config/... -run TestRealEnvConfigs_Production`
- [x] `go run ./cmd/config-validator/`
- [ ] Merge and deploy via CircleCI; confirm admin PII dashboard shows `requests_scanned` increasing
- [ ] Run live PII wire-restore smoke test after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PII redaction is now enabled in production environments

* **Documentation**
  * Added deployment guidance clarifying PII redaction and redact API availability across different deployment profiles
  * Included vendor security posture table documenting contractual safeguards (BAA/DPA status)
  * Documented fail-mode strategy for production rollout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->