### PR TITLE
Add Bedrock Mantle provider

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -695,6 +695,7 @@ func circuitModelExtractor(
 	anthropicProvider *providers.AnthropicProxy,
 	geminiProvider *providers.GeminiProxy,
 	bedrockProvider *providers.BedrockProxy,
+	bedrockMantleProvider *providers.BedrockMantleProxy,
 ) circuit.ModelFromRequestFunc {
 	return func(req *http.Request) string {
 		if req == nil || req.URL == nil {
@@ -722,6 +723,12 @@ func circuitModelExtractor(
 				return ""
 			}
 			model, _ := bedrockProvider.ExtractRequestModelAndMessages(req)
+			return model
+		case strings.HasPrefix(path, "/bedrock-mantle/"):
+			if bedrockMantleProvider == nil {
+				return ""
+			}
+			model, _ := bedrockMantleProvider.ExtractRequestModelAndMessages(req)
 			return model
 		}
 		return ""
@@ -1245,6 +1252,7 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 	anthropic *providers.AnthropicProxy,
 	gemini *providers.GeminiProxy,
 	bedrock *providers.BedrockProxy,
+	bedrockMantle *providers.BedrockMantleProxy,
 ) {
 	proxyOpts := providers.ProxyOptions{DisableGzip: disableGzip}
 	if disableGzip {
@@ -1268,7 +1276,15 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 	} else {
 		logger.Info("☁️  Bedrock provider: DISABLED (set providers.bedrock.enabled: true to enable)")
 	}
-	return openAI, anthropic, gemini, bedrock
+	if mantleCfg, ok := yamlConfig.Providers["bedrock-mantle"]; ok && mantleCfg.Enabled {
+		bedrockMantle = providers.NewBedrockMantleProxy(proxyOpts)
+		globalProviderManager.RegisterProvider(bedrockMantle)
+		circuitBreakerProviders = append(circuitBreakerProviders, "bedrock-mantle")
+		logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", bedrockMantle.GetHealthStatus()["region"])
+	} else {
+		logger.Info("☁️  Bedrock Mantle provider: DISABLED (set providers.bedrock-mantle.enabled: true to enable)")
+	}
+	return openAI, anthropic, gemini, bedrock, bedrockMantle
 }
 
 func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
@@ -1345,7 +1361,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		}
 	}
 
-	openAIProvider, anthropicProvider, geminiProvider, bedrockProvider := registerProviders(yamlConfig, disableGzip)
+	openAIProvider, anthropicProvider, geminiProvider, bedrockProvider, bedrockMantleProvider := registerProviders(yamlConfig, disableGzip)
 
 	fakeAllowed := isFakeModeAllowed(yamlConfig)
 	fakeCfg := fakeConfigFromYAML(yamlConfig, fakeAllowed)
@@ -1374,6 +1390,9 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	if bedrockProvider != nil {
 		namedProviders = append(namedProviders, namedProvider{"bedrock", bedrockProvider})
 	}
+	if bedrockMantleProvider != nil {
+		namedProviders = append(namedProviders, namedProvider{"bedrock-mantle", bedrockMantleProvider})
+	}
 
 	if fakeAllowed {
 		for _, np := range namedProviders {
@@ -1391,7 +1410,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		// is missing, which keeps test fixtures and Datadog-less
 		// deployments working unchanged.
 		circuitMetrics := initializeCircuitMetrics(yamlConfig)
-		modelFn := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider)
+		modelFn := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider, bedrockMantleProvider)
 		opts := []circuit.Option{
 			circuit.WithModelExtractor(modelFn),
 			circuit.WithCallerExtractor(circuitCallerExtractor()),
@@ -1783,6 +1802,9 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	logger.Info("Gemini API endpoints available", "url", "http://0.0.0.0:"+port+"/gemini/")
 	if bedrockProvider != nil {
 		logger.Info("Bedrock API endpoints available", "url", "http://0.0.0.0:"+port+"/bedrock/", "region", bedrockProvider.Region())
+	}
+	if bedrockMantleProvider != nil {
+		logger.Info("Bedrock Mantle API endpoints available", "url", "http://0.0.0.0:"+port+"/bedrock-mantle/v1/", "region", bedrockMantleProvider.GetHealthStatus()["region"])
 	}
 	logger.Info("Meta routes with user ID available", "pattern", "http://0.0.0.0:"+port+"/meta/{userID}/{provider}/")
 

--- a/cmd/llm-proxy/main_observability_test.go
+++ b/cmd/llm-proxy/main_observability_test.go
@@ -28,8 +28,9 @@ func TestCircuitModelExtractor_DispatchesToRealProviders(t *testing.T) {
 	anthropicProvider := providers.NewAnthropicProxy()
 	geminiProvider := providers.NewGeminiProxy()
 	bedrockProvider := providers.NewBedrockProxy()
+	bedrockMantleProvider := providers.NewBedrockMantleProxy()
 
-	extract := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider)
+	extract := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider, bedrockMantleProvider)
 
 	cases := []struct {
 		name string
@@ -80,6 +81,12 @@ func TestCircuitModelExtractor_DispatchesToRealProviders(t *testing.T) {
 			want: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
 		},
 		{
+			name: "bedrock mantle responses",
+			path: "/bedrock-mantle/v1/responses",
+			body: `{"model":"claude-sonnet-4-5","input":"hello"}`,
+			want: "claude-sonnet-4-5",
+		},
+		{
 			name: "non-matching path returns empty",
 			path: "/healthz",
 			body: ``,
@@ -116,6 +123,7 @@ func TestCircuitModelExtractor_NilSafe(t *testing.T) {
 		providers.NewAnthropicProxy(),
 		providers.NewGeminiProxy(),
 		providers.NewBedrockProxy(),
+		providers.NewBedrockMantleProxy(),
 	)
 	if got := extract(nil); got != "" {
 		t.Fatalf("nil request: want \"\", got %q", got)
@@ -130,6 +138,7 @@ func TestCircuitModelExtractor_NilBedrockSafe(t *testing.T) {
 		providers.NewOpenAIProxy(),
 		providers.NewAnthropicProxy(),
 		providers.NewGeminiProxy(),
+		nil,
 		nil,
 	)
 	req := httptest.NewRequestWithContext(

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -876,6 +876,44 @@ providers:
           output: 75.00
 
   # ---------------------------------------------------------------------------
+  # AWS BEDROCK MANTLE PROVIDER (OpenAI-compatible API + task-role SigV4)
+  # ---------------------------------------------------------------------------
+  # The proxy authenticates incoming Bearer credentials as llm-proxy keys and
+  # discards them before signing each outbound request with its AWS task role.
+  # No provider bearer token is stored or forwarded.
+  bedrock-mantle:
+    enabled: false # enabled by configs/{dev,staging,production}.yml
+    models:
+      "openai.gpt-5.4":
+        enabled: true
+        aliases: ["gpt-5.4-bedrock"]
+        pricing:
+          input: 2.50
+          output: 15.00
+      "openai.gpt-5.5":
+        enabled: true
+        aliases: ["gpt-5.5-bedrock"]
+        pricing:
+          input: 5.00
+          output: 30.00
+      "us.anthropic.claude-sonnet-4-5-20250929-v1:0":
+        enabled: true
+        aliases: ["claude-sonnet-4-5"]
+        pricing:
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
+      "us.anthropic.claude-haiku-4-5-20251001-v1:0":
+        enabled: true
+        aliases: ["claude-haiku-4-5"]
+        pricing:
+          input: 1.00
+          output: 5.00
+
+  # ---------------------------------------------------------------------------
   # GOOGLE GEMINI PROVIDER
   # ---------------------------------------------------------------------------
   gemini:

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -167,3 +167,5 @@ features:
 providers:
   bedrock:
     enabled: true
+  bedrock-mantle:
+    enabled: true

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -203,10 +203,9 @@ features:
 # =============================================================================
 # PROVIDER OVERRIDES
 # =============================================================================
-# Base config disables AWS Bedrock by default (see configs/base.yml).  Flip the
-# override below — and confirm the calling service's IAM role has bedrock:Invoke* /
-# Converse* grants for $AWS_REGION — to enable the SigV4 passthrough after
-# staging validation.
-# providers:
-#   bedrock:
-#     enabled: true
+# Bedrock Mantle signs outbound OpenAI-compatible requests with the task role.
+providers:
+  bedrock:
+    enabled: true
+  bedrock-mantle:
+    enabled: true

--- a/configs/staging.yml
+++ b/configs/staging.yml
@@ -63,9 +63,9 @@ features:
 # =============================================================================
 # PROVIDER OVERRIDES
 # =============================================================================
-# Base config disables AWS Bedrock by default (see configs/base.yml).  Uncomment
-# the override below — and confirm the calling service's IAM role has bedrock:Invoke* /
-# Converse* grants for $AWS_REGION — to enable the SigV4 passthrough.
-# providers:
-#   bedrock:
-#     enabled: true
+# Bedrock Mantle uses the task role to SigV4-sign OpenAI-compatible requests.
+providers:
+  bedrock:
+    enabled: true
+  bedrock-mantle:
+    enabled: true

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -21,6 +21,7 @@ func isProviderRoute(path string) bool {
 		strings.HasPrefix(path, "/anthropic/") ||
 		strings.HasPrefix(path, "/gemini/") ||
 		strings.HasPrefix(path, "/bedrock/") ||
+		strings.HasPrefix(path, "/bedrock-mantle/") ||
 		strings.HasPrefix(path, "/model/") ||
 		strings.HasPrefix(path, "/v1/models/gemini") ||
 		strings.HasPrefix(path, "/v1beta/models/gemini")
@@ -37,6 +38,7 @@ func isAPIEndpoint(path string) bool {
 		strings.Contains(path, ":streamGenerateContent") ||
 		strings.Contains(path, "/converse") ||
 		strings.Contains(path, "/converse-stream") ||
+		strings.Contains(path, "/responses") ||
 		strings.Contains(path, "/invoke") ||
 		strings.Contains(path, "/invoke-with-response-stream")
 }
@@ -47,7 +49,7 @@ func isAPIEndpoint(path string) bool {
 func getProviderFromPath(path string) string {
 	name := circuit.ProviderFromPath(path)
 	switch name {
-	case "openai", "anthropic", "gemini", "bedrock":
+	case "openai", "anthropic", "gemini", "bedrock", "bedrock-mantle":
 		return name
 	default:
 		return ""

--- a/internal/middleware/token_parsing.go
+++ b/internal/middleware/token_parsing.go
@@ -33,6 +33,7 @@ type MetadataCallback func(r *http.Request, metadata *providers.LLMResponseMetad
 //   - /v1/models/gemini..., /v1beta/models/gemini...  Gemini compatibility
 //   - /bedrock/...                    Bedrock native (with /bedrock prefix)
 //   - /model/...                      Bedrock SigV4 passthrough
+//   - /bedrock-mantle/...             Bedrock Mantle OpenAI compatibility API
 func GetProviderFromRequest(providerManager *providers.ProviderManager, req *http.Request) providers.Provider {
 	path := req.URL.Path
 
@@ -41,7 +42,7 @@ func GetProviderFromRequest(providerManager *providers.ProviderManager, req *htt
 		if len(parts) >= 4 { // ["", "meta", "userID", "provider", ...]
 			providerName := parts[3]
 			switch providerName {
-			case "openai", "anthropic", "gemini", "bedrock":
+			case "openai", "anthropic", "gemini", "bedrock", "bedrock-mantle":
 				return providerManager.GetProvider(providerName)
 			}
 		}
@@ -58,6 +59,8 @@ func GetProviderFromRequest(providerManager *providers.ProviderManager, req *htt
 		return providerManager.GetProvider("gemini")
 	case strings.HasPrefix(path, "/bedrock/"), strings.HasPrefix(path, "/model/"):
 		return providerManager.GetProvider("bedrock")
+	case strings.HasPrefix(path, "/bedrock-mantle/"):
+		return providerManager.GetProvider("bedrock-mantle")
 	}
 
 	return nil
@@ -90,7 +93,8 @@ func TokenParsingMiddleware(providerManager *providers.ProviderManager, callback
 				strings.Contains(r.URL.Path, "/messages") ||
 				strings.Contains(r.URL.Path, ":generateContent") ||
 				strings.Contains(r.URL.Path, ":streamGenerateContent") ||
-				strings.Contains(r.URL.Path, "/converse")
+				strings.Contains(r.URL.Path, "/converse") ||
+				strings.Contains(r.URL.Path, "/responses")
 
 			if provider == nil || !isAPIEndpoint {
 				return

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -1,0 +1,356 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/gorilla/mux"
+)
+
+const (
+	bedrockMantleName    = "bedrock-mantle"
+	bedrockMantleService = "bedrock-mantle"
+)
+
+// BedrockMantleProxy forwards OpenAI-compatible requests to AWS Bedrock Mantle.
+// It authenticates callers with llm-proxy API keys, then signs the rewritten
+// upstream request with the task's AWS credential chain.
+type BedrockMantleProxy struct {
+	proxy   *httputil.ReverseProxy
+	region  string
+	baseURL string
+}
+
+// NewBedrockMantleProxy creates a Bedrock Mantle proxy using the default AWS
+// credential chain. Credentials are resolved by the signer at request time.
+func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
+	var opt ProxyOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = defaultBedrockRegion
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(region))
+	if err != nil {
+		panic(fmt.Sprintf("load AWS config for Bedrock Mantle: %v", err))
+	}
+	return newBedrockMantleProxy(region, cfg.Credentials, opt)
+}
+
+func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, opt ProxyOptions) *BedrockMantleProxy {
+	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai", region)
+	targetURL, err := url.Parse(baseURL)
+	if err != nil {
+		panic(fmt.Sprintf("invalid Bedrock Mantle upstream URL %q: %v", baseURL, err))
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	mantle := &BedrockMantleProxy{proxy: proxy, region: region, baseURL: baseURL}
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/"+bedrockMantleName)
+		if req.URL.RawPath != "" {
+			req.URL.RawPath = strings.TrimPrefix(req.URL.RawPath, "/"+bedrockMantleName)
+		}
+		originalDirector(req)
+		req.Host = targetURL.Host
+		req.Header.Del("Authorization")
+		req.Header.Del("X-Amz-Date")
+		req.Header.Del("X-Amz-Content-Sha256")
+		req.Header.Del("X-Amz-Security-Token")
+		if opt.DisableGzip {
+			req.Header.Del("Accept-Encoding")
+		}
+		log.Printf("Proxying Bedrock Mantle request: %s %s", req.Method, req.URL.Path)
+	}
+	proxy.Transport = &sigV4Transport{
+		credentials: credentials,
+		inner:       newProxyTransport(opt.DisableGzip),
+		region:      region,
+		service:     bedrockMantleService,
+	}
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+			resp.Header.Set("Cache-Control", "no-cache")
+			resp.Header.Set("Connection", "keep-alive")
+			resp.Header.Set("X-Accel-Buffering", "no")
+			resp.Header.Del("Content-Length")
+		}
+		return nil
+	}
+	return mantle
+}
+
+// sigV4Transport signs the final URL, headers, and body immediately before
+// handing the request to the underlying transport.
+type sigV4Transport struct {
+	credentials aws.CredentialsProvider
+	inner       http.RoundTripper
+	region      string
+	service     string
+}
+
+func (t *sigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	payload, err := readAndRestoreMantleBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("read Bedrock Mantle request body: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	payloadHash := hex.EncodeToString(sum[:])
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	credentials, err := t.credentials.Retrieve(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("retrieve AWS credentials for Bedrock Mantle: %w", err)
+	}
+	if err := v4.NewSigner().SignHTTP(req.Context(), credentials, req, payloadHash, t.service, t.region, time.Now()); err != nil {
+		return nil, fmt.Errorf("sign Bedrock Mantle request: %w", err)
+	}
+	return t.inner.RoundTrip(req)
+}
+
+func readAndRestoreMantleBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	return body, nil
+}
+
+func (b *BedrockMantleProxy) GetName() string { return bedrockMantleName }
+
+func (b *BedrockMantleProxy) IsStreamingRequest(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	if strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
+		return true
+	}
+	if req.Method != http.MethodPost || (!strings.Contains(req.URL.Path, "/responses") && !strings.Contains(req.URL.Path, "/completions")) {
+		return false
+	}
+	body, err := readAndRestoreMantleBody(req)
+	return err == nil && bytes.Contains(body, []byte(`"stream":true`))
+}
+
+func (b *BedrockMantleProxy) Proxy() http.Handler { return b.proxy }
+
+func (b *BedrockMantleProxy) WrapTransport(fn func(http.RoundTripper) http.RoundTripper) {
+	b.proxy.Transport = fn(b.proxy.Transport)
+}
+
+func (b *BedrockMantleProxy) GetHealthStatus() map[string]interface{} {
+	return map[string]interface{}{
+		"provider":          bedrockMantleName,
+		"status":            "healthy",
+		"baseURL":           b.baseURL,
+		"region":            b.region,
+		"streaming_support": true,
+		"auth":              "proxy_api_key_and_task_sigv4",
+	}
+}
+
+func (b *BedrockMantleProxy) UserIDFromRequest(_ *http.Request) string { return "" }
+
+// ValidateAPIKey accepts only normal llm-proxy keys registered for Mantle.
+// The resolved provider credential is deliberately discarded: Mantle is
+// authenticated solely by the local AWS SigV4 signature.
+func (b *BedrockMantleProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return fmt.Errorf("Bearer proxy API key is required")
+	}
+	key := strings.TrimPrefix(auth, "Bearer ")
+	if key == "" {
+		return fmt.Errorf("Bearer proxy API key is required")
+	}
+	_, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), key)
+	if err != nil {
+		return fmt.Errorf("API key validation failed: %w", err)
+	}
+	if provider != bedrockMantleName {
+		return fmt.Errorf("API key is for provider %s, not %s", provider, bedrockMantleName)
+	}
+	req.Header.Del("Authorization")
+	return nil
+}
+
+func (b *BedrockMantleProxy) RegisterExtraRoutes(_ *mux.Router) {}
+
+func (b *BedrockMantleProxy) ExtractRequestModelAndMessages(req *http.Request) (string, []string) {
+	if req == nil || req.Body == nil || req.Method != http.MethodPost {
+		return "", nil
+	}
+	body, err := readAndRestoreMantleBody(req)
+	if err != nil {
+		return "", nil
+	}
+	var data struct {
+		Model    string          `json:"model"`
+		Input    json.RawMessage `json:"input"`
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if json.Unmarshal(body, &data) != nil {
+		return "", nil
+	}
+	var messages []string
+	appendText := func(raw json.RawMessage) {
+		var text string
+		if json.Unmarshal(raw, &text) == nil && text != "" {
+			messages = append(messages, text)
+			return
+		}
+		var parts []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(raw, &parts) == nil {
+			for _, part := range parts {
+				if (part.Type == "text" || part.Type == "input_text") && part.Text != "" {
+					messages = append(messages, part.Text)
+				}
+			}
+		}
+	}
+	appendText(data.Input)
+	for _, message := range data.Messages {
+		appendText(message.Content)
+	}
+	return data.Model, messages
+}
+
+func (b *BedrockMantleProxy) ParseResponseMetadata(responseBody io.Reader, isStreaming bool) (*LLMResponseMetadata, error) {
+	if isStreaming {
+		return parseMantleStream(responseBody)
+	}
+	body, err := io.ReadAll(responseBody)
+	if err != nil {
+		return nil, err
+	}
+	return parseMantleMetadata(body, false)
+}
+
+func parseMantleStream(responseBody io.Reader) (*LLMResponseMetadata, error) {
+	scanner := bufio.NewScanner(responseBody)
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	var partial *LLMResponseMetadata
+	for scanner.Scan() {
+		line := strings.TrimPrefix(scanner.Text(), "data: ")
+		if line == scanner.Text() || line == "[DONE]" {
+			continue
+		}
+		metadata, err := parseMantleMetadata([]byte(line), true)
+		if err == nil {
+			if metadata.TotalTokens > 0 {
+				return metadata, nil
+			}
+			if metadata.Model != "" {
+				partial = metadata
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if partial != nil {
+		return partial, nil
+	}
+	return nil, fmt.Errorf("no usage information found in Bedrock Mantle stream")
+}
+
+func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, error) {
+	var envelope struct {
+		Model  string `json:"model"`
+		ID     string `json:"id"`
+		Status string `json:"status"`
+		Type   string `json:"type"`
+		Usage  *struct {
+			InputTokens      int `json:"input_tokens"`
+			OutputTokens     int `json:"output_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+		Response *struct {
+			Model  string `json:"model"`
+			ID     string `json:"id"`
+			Status string `json:"status"`
+			Usage  *struct {
+				InputTokens  int `json:"input_tokens"`
+				OutputTokens int `json:"output_tokens"`
+				TotalTokens  int `json:"total_tokens"`
+			} `json:"usage"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	usage := envelope.Usage
+	if envelope.Response != nil {
+		if envelope.Model == "" {
+			envelope.Model = envelope.Response.Model
+		}
+		if envelope.ID == "" {
+			envelope.ID = envelope.Response.ID
+		}
+		if envelope.Status == "" {
+			envelope.Status = envelope.Response.Status
+		}
+		if usage == nil && envelope.Response.Usage != nil {
+			usage = &struct {
+				InputTokens      int `json:"input_tokens"`
+				OutputTokens     int `json:"output_tokens"`
+				TotalTokens      int `json:"total_tokens"`
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+			}{
+				InputTokens:  envelope.Response.Usage.InputTokens,
+				OutputTokens: envelope.Response.Usage.OutputTokens,
+				TotalTokens:  envelope.Response.Usage.TotalTokens,
+			}
+		}
+	}
+	if usage == nil {
+		return &LLMResponseMetadata{Model: envelope.Model, RequestID: envelope.ID, Provider: bedrockMantleName, IsStreaming: streaming}, nil
+	}
+	input, output := usage.InputTokens, usage.OutputTokens
+	if input == 0 && output == 0 {
+		input, output = usage.PromptTokens, usage.CompletionTokens
+	}
+	total := usage.TotalTokens
+	if total == 0 {
+		total = input + output
+	}
+	return &LLMResponseMetadata{
+		Model: envelope.Model, RequestID: envelope.ID, Provider: bedrockMantleName,
+		InputTokens: input, OutputTokens: output, TotalTokens: total,
+		FinishReason: envelope.Status, IsStreaming: streaming,
+	}, nil
+}

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -1,0 +1,93 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+type mantleRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f mantleRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type mantleKeyStore struct{}
+
+func (mantleKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (string, string, error) {
+	if key != "sk-iw-mantle" {
+		return "", "", io.EOF
+	}
+	return "discarded-provider-token", bedrockMantleName, nil
+}
+
+func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-5","input":"hello"}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	var gotBody []byte
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		gotBody, _ = io.ReadAll(req.Body)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"claude-sonnet-4-5","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	if got.URL.String() != "https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses" {
+		t.Fatalf("upstream URL = %q", got.URL.String())
+	}
+	if got.Header.Get("Authorization") == "Bearer sk-iw-mantle" {
+		t.Fatal("inbound bearer token reached the upstream")
+	}
+	if !strings.Contains(got.Header.Get("Authorization"), "AWS4-HMAC-SHA256") ||
+		!strings.Contains(got.Header.Get("Authorization"), "/bedrock-mantle/aws4_request") {
+		t.Fatalf("request was not signed for Bedrock Mantle: %q", got.Header.Get("Authorization"))
+	}
+	if got.Header.Get("X-Amz-Security-Token") != "session" {
+		t.Fatalf("session token = %q, want signer credential token", got.Header.Get("X-Amz-Security-Token"))
+	}
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("body changed: got %q want %q", gotBody, body)
+	}
+}
+
+func TestBedrockMantle_ParseResponsesStreamingUsage(t *testing.T) {
+	stream := `data: {"type":"response.created","response":{"id":"resp_1","model":"claude-sonnet-4-5"}}
+
+data: {"type":"response.done","response":{"id":"resp_1","model":"claude-sonnet-4-5","status":"completed","usage":{"input_tokens":12,"output_tokens":4,"total_tokens":16}}}
+
+data: [DONE]
+`
+	metadata, err := NewBedrockMantleProxy().ParseResponseMetadata(strings.NewReader(stream), true)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata: %v", err)
+	}
+	if metadata.Provider != bedrockMantleName || metadata.Model != "claude-sonnet-4-5" || metadata.TotalTokens != 16 {
+		t.Fatalf("unexpected metadata: %+v", metadata)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an OpenAI-compatible Bedrock Mantle provider with task-role SigV4 signing.
- Enables Mantle and native Bedrock configuration, response parsing, observability, and pricing.

## Test plan
- [x] `go test ./internal/providers/... ./internal/middleware/...`
- [x] `go run ./cmd/config-validator/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional AWS Bedrock Mantle support for OpenAI- and Anthropic-compatible models.
  * Added request authentication, AWS signing, streaming responses, and token usage tracking.
  * Added Mantle routes, health reporting, model detection, and cost tracking.
* **Configuration**
  * Enabled Bedrock and Bedrock Mantle in development, staging, and production configurations.
  * Added supported model and pricing definitions.
* **Tests**
  * Added coverage for request signing, response parsing, streaming usage, and model extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->