### PR TITLE
fix: Adjust api keys for openai compatibility

### DIFF
--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -609,8 +609,21 @@ func (a *AnthropicProxy) ExtractRequestModelAndMessages(req *http.Request) (stri
 
 // ValidateAPIKey validates and potentially replaces the API key in the request
 func (a *AnthropicProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
-	// Get the API key from the x-api-key header (Anthropic uses this header)
+	// Get the API key from the x-api-key header (Anthropic uses this header).
 	apiKey := req.Header.Get("x-api-key")
+	if apiKey == "" {
+		// Some clients (e.g. OpenAI-compatible SDKs) send credentials as
+		// "Authorization: Bearer <key>" instead. Translate that onto
+		// x-api-key — the header Anthropic's API actually expects — so the
+		// rest of this function, and the upstream request, only ever deal
+		// with x-api-key.
+		const bearerPrefix = "Bearer "
+		if authHeader := req.Header.Get("Authorization"); strings.HasPrefix(authHeader, bearerPrefix) {
+			apiKey = strings.TrimPrefix(authHeader, bearerPrefix)
+			req.Header.Set("x-api-key", apiKey)
+			req.Header.Del("Authorization")
+		}
+	}
 	if apiKey == "" {
 		// No API key provided, let the provider handle the error
 		return nil

--- a/internal/providers/api_key_validation_test.go
+++ b/internal/providers/api_key_validation_test.go
@@ -73,6 +73,34 @@ func TestAnthropic_ValidateAPIKey_Translates(t *testing.T) {
 	assert.Error(t, ap.ValidateAPIKey(req, &stubKeyStore{actual: "x", provider: "openai"}))
 }
 
+func TestAnthropic_ValidateAPIKey_TranslatesBearerAuthorizationHeader(t *testing.T) {
+	ap := NewAnthropicProxy()
+	store := &stubKeyStore{actual: "real-anthropic", provider: "anthropic"}
+
+	req, _ := http.NewRequest("POST", "/anthropic/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer iw:fake")
+	require.NoError(t, ap.ValidateAPIKey(req, store))
+	assert.Equal(t, "real-anthropic", req.Header.Get("x-api-key"))
+	assert.Empty(t, req.Header.Get("Authorization"))
+	assert.Equal(t, "iw:fake", store.lastInput)
+
+	// x-api-key takes precedence over Authorization when both are present.
+	req, _ = http.NewRequest("POST", "/anthropic/v1/messages", nil)
+	req.Header.Set("x-api-key", "iw:direct")
+	req.Header.Set("Authorization", "Bearer iw:fake")
+	store2 := &stubKeyStore{actual: "real-anthropic", provider: "anthropic"}
+	require.NoError(t, ap.ValidateAPIKey(req, store2))
+	assert.Equal(t, "iw:direct", store2.lastInput)
+	assert.Equal(t, "Bearer iw:fake", req.Header.Get("Authorization"))
+
+	// Non-Bearer Authorization headers are left untouched and don't count as a key.
+	req, _ = http.NewRequest("POST", "/anthropic/v1/messages", nil)
+	req.Header.Set("Authorization", "Basic xyz")
+	require.NoError(t, ap.ValidateAPIKey(req, &stubKeyStore{}))
+	assert.Equal(t, "Basic xyz", req.Header.Get("Authorization"))
+	assert.Empty(t, req.Header.Get("x-api-key"))
+}
+
 func TestGemini_ValidateAPIKey_Translates(t *testing.T) {
 	gp := NewGeminiProxy()
 	store := &stubKeyStore{actual: "real-gemini", provider: "gemini"}
@@ -96,4 +124,39 @@ func TestGemini_ValidateAPIKey_Translates(t *testing.T) {
 	req, _ = http.NewRequest("POST", "/gemini/v1/models/gemini-pro:generateContent", nil)
 	req.Header.Set("x-goog-api-key", "iw:fake")
 	assert.Error(t, gp.ValidateAPIKey(req, &stubKeyStore{actual: "x", provider: "openai"}))
+}
+
+func TestGemini_ValidateAPIKey_PreservesBearerAuthorizationHeader(t *testing.T) {
+	gp := NewGeminiProxy()
+	store := &stubKeyStore{actual: "real-gemini", provider: "gemini"}
+
+	req, _ := http.NewRequest("POST", "/gemini/v1/models/gemini-pro:generateContent", nil)
+	req.Header.Set("Authorization", "Bearer iw:fake")
+	require.NoError(t, gp.ValidateAPIKey(req, store))
+	// Translated key stays in Authorization, unlike Anthropic which moves it.
+	assert.Equal(t, "Bearer real-gemini", req.Header.Get("Authorization"))
+	assert.Empty(t, req.Header.Get("x-goog-api-key"))
+	assert.Equal(t, "iw:fake", store.lastInput)
+
+	// query and x-goog-api-key both take precedence over Authorization.
+	req, _ = http.NewRequest("POST", "/gemini/v1/models/gemini-pro:generateContent?key=iw:query", nil)
+	req.Header.Set("Authorization", "Bearer iw:fake")
+	store2 := &stubKeyStore{actual: "real-gemini", provider: "gemini"}
+	require.NoError(t, gp.ValidateAPIKey(req, store2))
+	assert.Equal(t, "iw:query", store2.lastInput)
+	assert.Equal(t, "Bearer iw:fake", req.Header.Get("Authorization"))
+
+	req, _ = http.NewRequest("POST", "/gemini/v1/models/gemini-pro:generateContent", nil)
+	req.Header.Set("x-goog-api-key", "iw:header")
+	req.Header.Set("Authorization", "Bearer iw:fake")
+	store3 := &stubKeyStore{actual: "real-gemini", provider: "gemini"}
+	require.NoError(t, gp.ValidateAPIKey(req, store3))
+	assert.Equal(t, "iw:header", store3.lastInput)
+	assert.Equal(t, "Bearer iw:fake", req.Header.Get("Authorization"))
+
+	// Non-Bearer Authorization headers are left untouched and don't count as a key.
+	req, _ = http.NewRequest("POST", "/gemini/v1/models/gemini-pro:generateContent", nil)
+	req.Header.Set("Authorization", "Basic xyz")
+	require.NoError(t, gp.ValidateAPIKey(req, &stubKeyStore{}))
+	assert.Equal(t, "Basic xyz", req.Header.Get("Authorization"))
 }

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -401,9 +401,13 @@ func (g *GeminiProxy) RegisterExtraRoutes(router *mux.Router) {
 
 // ValidateAPIKey validates and potentially replaces the API key in the request
 func (g *GeminiProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
-	// Gemini uses API keys in two ways:
+	// Gemini uses API keys in three ways:
 	// 1. In the URL query parameter as "key"
 	// 2. In the x-goog-api-key header
+	// 3. As "Authorization: Bearer <key>" (some OpenAI-compatible clients).
+	//    Unlike Anthropic, we leave this key in the Authorization header
+	//    rather than moving it to x-goog-api-key, since Gemini's
+	//    OpenAI-compatible endpoint expects Bearer auth there.
 
 	// Check query parameter first
 	query := req.URL.Query()
@@ -412,10 +416,20 @@ func (g *GeminiProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) er
 	// Check header if no query parameter
 	apiKeyFromHeader := req.Header.Get("x-goog-api-key")
 
-	// Use whichever is present (query takes precedence)
+	const bearerPrefix = "Bearer "
+	apiKeyFromAuth := ""
+	if authHeader := req.Header.Get("Authorization"); strings.HasPrefix(authHeader, bearerPrefix) {
+		apiKeyFromAuth = strings.TrimPrefix(authHeader, bearerPrefix)
+	}
+
+	// Use whichever is present (query takes precedence, then x-goog-api-key,
+	// then Authorization).
 	apiKey := apiKeyFromQuery
 	if apiKey == "" {
 		apiKey = apiKeyFromHeader
+	}
+	if apiKey == "" {
+		apiKey = apiKeyFromAuth
 	}
 
 	if apiKey == "" {
@@ -445,6 +459,9 @@ func (g *GeminiProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) er
 		} else if apiKeyFromHeader != "" {
 			// Replace in header
 			req.Header.Set("x-goog-api-key", actualKey)
+		} else if apiKeyFromAuth != "" {
+			// Replace in place, keeping it in the Authorization header.
+			req.Header.Set("Authorization", bearerPrefix+actualKey)
 		}
 		log.Printf("🔑 Gemini: Translated API key from iw: format")
 	}


### PR DESCRIPTION
Makes two small changes for OpenAI-format APIs to work for both anthropic and gemini:
1. For Anthropic, accept the "Bearer: Authorization <token>" format and move that to what anthropic expects (making it truly OpenAI-compliant)
2. For Gemini, instead just accept the "Berare: Authorization <token>" format, since this is what gemini expects for the OpenAI-compliant endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for API keys provided through `Authorization: Bearer` headers for Anthropic and Gemini integrations.
  * Preserved existing key-source precedence and credential replacement behavior.

* **Bug Fixes**
  * Anthropic credentials are now translated correctly and conflicting headers are handled consistently.
  * Gemini Bearer credentials are preserved and restored correctly during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->