### PR TITLE
feat(bedrock): mantle proxy provider + per-provider region routing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,8 @@ workflows:
               only: /.*/
 
       - unit-tests:
+          context:
+            - AWS
           filters:
             branches:
               only: /.*/
@@ -313,6 +315,8 @@ workflows:
               only: /.*/
 
       - fuzz-tests:
+          context:
+            - AWS
           filters:
             branches:
               only: /.*/

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -695,6 +695,7 @@ func circuitModelExtractor(
 	anthropicProvider *providers.AnthropicProxy,
 	geminiProvider *providers.GeminiProxy,
 	bedrockProvider *providers.BedrockProxy,
+	bedrockMantleProvider *providers.BedrockMantleProxy,
 ) circuit.ModelFromRequestFunc {
 	return func(req *http.Request) string {
 		if req == nil || req.URL == nil {
@@ -722,6 +723,12 @@ func circuitModelExtractor(
 				return ""
 			}
 			model, _ := bedrockProvider.ExtractRequestModelAndMessages(req)
+			return model
+		case strings.HasPrefix(path, "/bedrock-mantle/"):
+			if bedrockMantleProvider == nil {
+				return ""
+			}
+			model, _ := bedrockMantleProvider.ExtractRequestModelAndMessages(req)
 			return model
 		}
 		return ""
@@ -1245,6 +1252,7 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 	anthropic *providers.AnthropicProxy,
 	gemini *providers.GeminiProxy,
 	bedrock *providers.BedrockProxy,
+	bedrockMantle *providers.BedrockMantleProxy,
 ) {
 	proxyOpts := providers.ProxyOptions{DisableGzip: disableGzip}
 	if disableGzip {
@@ -1268,7 +1276,15 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 	} else {
 		logger.Info("☁️  Bedrock provider: DISABLED (set providers.bedrock.enabled: true to enable)")
 	}
-	return openAI, anthropic, gemini, bedrock
+	if mantleCfg, ok := yamlConfig.Providers["bedrock-mantle"]; ok && mantleCfg.Enabled {
+		bedrockMantle = providers.NewBedrockMantleProxy(proxyOpts)
+		globalProviderManager.RegisterProvider(bedrockMantle)
+		circuitBreakerProviders = append(circuitBreakerProviders, "bedrock-mantle")
+		logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", bedrockMantle.GetHealthStatus()["region"])
+	} else {
+		logger.Info("☁️  Bedrock Mantle provider: DISABLED (set providers.bedrock-mantle.enabled: true to enable)")
+	}
+	return openAI, anthropic, gemini, bedrock, bedrockMantle
 }
 
 func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
@@ -1345,7 +1361,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		}
 	}
 
-	openAIProvider, anthropicProvider, geminiProvider, bedrockProvider := registerProviders(yamlConfig, disableGzip)
+	openAIProvider, anthropicProvider, geminiProvider, bedrockProvider, bedrockMantleProvider := registerProviders(yamlConfig, disableGzip)
 
 	fakeAllowed := isFakeModeAllowed(yamlConfig)
 	fakeCfg := fakeConfigFromYAML(yamlConfig, fakeAllowed)
@@ -1374,6 +1390,9 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	if bedrockProvider != nil {
 		namedProviders = append(namedProviders, namedProvider{"bedrock", bedrockProvider})
 	}
+	if bedrockMantleProvider != nil {
+		namedProviders = append(namedProviders, namedProvider{"bedrock-mantle", bedrockMantleProvider})
+	}
 
 	if fakeAllowed {
 		for _, np := range namedProviders {
@@ -1391,7 +1410,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		// is missing, which keeps test fixtures and Datadog-less
 		// deployments working unchanged.
 		circuitMetrics := initializeCircuitMetrics(yamlConfig)
-		modelFn := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider)
+		modelFn := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider, bedrockMantleProvider)
 		opts := []circuit.Option{
 			circuit.WithModelExtractor(modelFn),
 			circuit.WithCallerExtractor(circuitCallerExtractor()),
@@ -1783,6 +1802,9 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	logger.Info("Gemini API endpoints available", "url", "http://0.0.0.0:"+port+"/gemini/")
 	if bedrockProvider != nil {
 		logger.Info("Bedrock API endpoints available", "url", "http://0.0.0.0:"+port+"/bedrock/", "region", bedrockProvider.Region())
+	}
+	if bedrockMantleProvider != nil {
+		logger.Info("Bedrock Mantle API endpoints available", "url", "http://0.0.0.0:"+port+"/bedrock-mantle/v1/", "region", bedrockMantleProvider.GetHealthStatus()["region"])
 	}
 	logger.Info("Meta routes with user ID available", "pattern", "http://0.0.0.0:"+port+"/meta/{userID}/{provider}/")
 

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/pii"
 	"github.com/Instawork/llm-proxy/internal/providers"
 	"github.com/Instawork/llm-proxy/internal/provision"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/Instawork/llm-proxy/internal/ratelimitstats"
 	"github.com/Instawork/llm-proxy/internal/redact"
@@ -89,6 +90,14 @@ func (h *CustomPrettyHandler) WithGroup(name string) slog.Handler {
 }
 
 var logger *slog.Logger
+
+func logProxyError(msg string, args ...any) {
+	logger.Error(proxylog.ProxyMsg(msg), args...)
+}
+
+func logProxyWarn(msg string, args ...any) {
+	logger.Warn(proxylog.ProxyMsg(msg), args...)
+}
 
 const (
 	// Version of the LLM Proxy
@@ -232,7 +241,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 	// Get all transport configurations
 	transportConfigs := yamlConfig.GetAllTransports()
 	if len(transportConfigs) == 0 {
-		logger.Error("💰 Cost Tracker: No transport configurations found")
+		logProxyError("💰 Cost Tracker: No transport configurations found")
 		return nil
 	}
 
@@ -272,35 +281,35 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 			switch transportConfig.Type {
 			case "dynamodb":
 				if transportConfig.DynamoDB != nil {
-					logger.Error("💰 Cost Tracker: Failed to create DynamoDB transport",
+					logProxyError("💰 Cost Tracker: Failed to create DynamoDB transport",
 						"configured_type", transportConfig.Type,
 						"table_name", transportConfig.DynamoDB.TableName,
 						"region", transportConfig.DynamoDB.Region,
 						"error", err)
 				} else {
-					logger.Error("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
+					logProxyError("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
 				}
 			case "file":
 				if transportConfig.File != nil {
-					logger.Error("💰 Cost Tracker: Failed to create file transport",
+					logProxyError("💰 Cost Tracker: Failed to create file transport",
 						"configured_type", transportConfig.Type,
 						"path", transportConfig.File.Path,
 						"error", err)
 				} else {
-					logger.Error("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
+					logProxyError("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
 				}
 			case "datadog":
 				if transportConfig.Datadog != nil {
-					logger.Error("💰 Cost Tracker: Failed to create Datadog transport",
+					logProxyError("💰 Cost Tracker: Failed to create Datadog transport",
 						"configured_type", transportConfig.Type,
 						"host", transportConfig.Datadog.Host,
 						"port", transportConfig.Datadog.Port,
 						"error", err)
 				} else {
-					logger.Error("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
+					logProxyError("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
 				}
 			default:
-				logger.Error("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
+				logProxyError("💰 Cost Tracker: Failed to create transport", "configured_type", transportConfig.Type, "error", err)
 			}
 			failedTransports = append(failedTransports, transportConfig.Type)
 			continue
@@ -312,7 +321,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 
 	// Check if we have at least one working transport
 	if len(transports) == 0 {
-		logger.Error("💰 Cost Tracker: No transports could be created, falling back to file transport")
+		logProxyError("💰 Cost Tracker: No transports could be created, falling back to file transport")
 
 		// Fallback to file transport with env var or default
 		outputFile := os.Getenv("COST_TRACKING_FILE")
@@ -320,7 +329,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 			outputFile = "logs/cost-tracking.jsonl"
 		}
 
-		logger.Warn("💰 Cost Tracker: Falling back to file transport", "fallback_type", "file", "output_file", outputFile)
+		logProxyWarn("💰 Cost Tracker: Falling back to file transport", "fallback_type", "file", "output_file", outputFile)
 		transport := cost.NewFileTransport(outputFile)
 		transports = append(transports, transport)
 		logger.Info("💰 Cost Tracker: Initialized with fallback", "actual_transport_type", "file", "output_file", outputFile)
@@ -338,7 +347,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 	}
 
 	if len(failedTransports) > 0 {
-		logger.Warn("💰 Cost Tracker: Initialized with some transport failures",
+		logProxyWarn("💰 Cost Tracker: Initialized with some transport failures",
 			"successful_transports", transportTypes,
 			"failed_transports", failedTransports)
 	} else {
@@ -369,8 +378,8 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 
 		// Start the async workers
 		if err := costTracker.StartAsyncWorkers(); err != nil {
-			logger.Error("💰 Cost Tracker: Failed to start async workers", "error", err)
-			logger.Warn("💰 Cost Tracker: Falling back to synchronous mode")
+			logProxyError("💰 Cost Tracker: Failed to start async workers", "error", err)
+			logProxyWarn("💰 Cost Tracker: Falling back to synchronous mode")
 			costTracker.SetSyncMode()
 		} else {
 			logger.Info("💰 Cost Tracker: Async mode enabled", "workers", workers, "queue_size", queueSize, "flush_interval_seconds", flushInterval)
@@ -396,7 +405,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 				// Convert YAML pricing to cost tracker format
 				modelPricing, ok := modelConfig.Pricing.(*config.ModelPricing)
 				if !ok {
-					logger.Warn("Could not parse pricing", "provider", providerName, "model", modelName)
+					logProxyWarn("Could not parse pricing", "provider", providerName, "model", modelName)
 					continue
 				}
 
@@ -432,7 +441,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 					totalModelsConfigured++
 				}
 			} else {
-				logger.Warn("Model has no pricing configured", "provider", providerName, "model", modelName)
+				logProxyWarn("Model has no pricing configured", "provider", providerName, "model", modelName)
 			}
 		}
 	}
@@ -585,13 +594,13 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 
 	cfg := circuitConfigFromYAML(cb, isTestModeAllowed(yamlConfig))
 	if err := cfg.Validate(); err != nil {
-		logger.Error("⚡ Circuit Breaker: invalid configuration — falling back to memory store", "error", err)
+		logProxyError("⚡ Circuit Breaker: invalid configuration — falling back to memory store", "error", err)
 		cfg.Backend = "memory"
 	}
 
 	store, err := circuit.Factory(cfg)
 	if err != nil {
-		logger.Error(
+		logProxyError(
 			"⚡ Circuit Breaker: store construction failed — falling back to memory store",
 			"backend", cfg.Backend,
 			"error", err,
@@ -603,7 +612,7 @@ func initializeCircuitStore(yamlConfig *config.YAMLConfig) circuit.Store {
 	if rs, ok := store.(*circuit.RedisStore); ok {
 		pingCtx, cancel := context.WithTimeout(context.Background(), redisPingTimeout)
 		if pingErr := rs.Ping(pingCtx); pingErr != nil {
-			logger.Warn(
+			logProxyWarn(
 				"⚡ Circuit Breaker: Redis PING failed at startup — proxy will continue (store fails open on Redis errors)",
 				"error", pingErr,
 			)
@@ -764,7 +773,7 @@ func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore 
 	// Get API key management configuration
 	apiKeyConfig := yamlConfig.Features.APIKeyManagement
 	if apiKeyConfig.TableName == "" || apiKeyConfig.Region == "" {
-		logger.Error("🔑 API Key Store: Missing required configuration (table_name or region)")
+		logProxyError("🔑 API Key Store: Missing required configuration (table_name or region)")
 		return nil
 	}
 
@@ -803,7 +812,7 @@ func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore 
 	})
 	if err != nil {
 		globalAPIKeyStoreInitError = err
-		logger.Error("🔑 API Key Store: Failed to create API key store", "error", err)
+		logProxyError("🔑 API Key Store: Failed to create API key store", "error", err)
 		return nil
 	}
 
@@ -819,7 +828,7 @@ func initializeAdminUserStore(yamlConfig *config.YAMLConfig) *adminusers.Store {
 
 	userCfg := yamlConfig.Features.AdminDashboard.Users.DynamoDB
 	if userCfg.TableName == "" || userCfg.Region == "" {
-		logger.Error("👤 Admin User Store: missing table_name or region")
+		logProxyError("👤 Admin User Store: missing table_name or region")
 		globalAdminUserStoreError = fmt.Errorf("admin users dynamodb table_name and region are required")
 		return nil
 	}
@@ -838,7 +847,7 @@ func initializeAdminUserStore(yamlConfig *config.YAMLConfig) *adminusers.Store {
 	})
 	if err != nil {
 		globalAdminUserStoreError = err
-		logger.Error("👤 Admin User Store: failed to initialize", "error", err)
+		logProxyError("👤 Admin User Store: failed to initialize", "error", err)
 		return nil
 	}
 
@@ -958,7 +967,7 @@ func initHistory(yamlConfig *config.YAMLConfig) {
 	}
 	sink, err := history.New(history.ConfigFromYAML(hc, logger))
 	if err != nil {
-		logger.Warn("History sink: disabled", "error", err)
+		logProxyWarn("History sink: disabled", "error", err)
 		return
 	}
 	if sink == nil {
@@ -989,7 +998,7 @@ func initAdminRollups(yamlConfig *config.YAMLConfig) {
 	rollupCfg.Logger = logger
 	store, err := adminrollup.NewStore(rollupCfg)
 	if err != nil {
-		logger.Warn("Admin rollups: disabled", "error", err)
+		logProxyWarn("Admin rollups: disabled", "error", err)
 		return
 	}
 	if store == nil {
@@ -1068,7 +1077,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 				// that helps an attacker enumerate the deployment).
 				// Operators get the full detail via the structured
 				// logger below.
-				logger.Warn(
+				logProxyWarn(
 					"⚡ Circuit Breaker: GetStats error on /health",
 					"provider", name,
 					"error", err,
@@ -1242,6 +1251,32 @@ func handleVersionFlag(yamlConfig *config.YAMLConfig) {
 	os.Exit(0)
 }
 
+// buildMantleModelProjects flattens a Bedrock Mantle provider config into a
+// model-id/alias -> project-id map for OpenAI-Project header injection. Project
+// ids are expanded with os.ExpandEnv so account-specific values stay out of the
+// committed YAML (e.g. project_id: "${LLM_PROXY_..._PROJECT_ID}"). Models with
+// no configured (or env-empty) project id are skipped, leaving the account
+// default in force.
+func buildMantleModelProjects(cfg config.ProviderConfig) map[string]string {
+	projects := make(map[string]string)
+	for name, model := range cfg.Models {
+		project := os.ExpandEnv(model.ProjectID)
+		if project == "" {
+			continue
+		}
+		projects[name] = project
+		for _, alias := range model.Aliases {
+			if alias != "" {
+				projects[alias] = project
+			}
+		}
+	}
+	if len(projects) == 0 {
+		return nil
+	}
+	return projects
+}
+
 // runServer starts and runs the LLM proxy server
 // registerProviders constructs each provider proxy, registers it with the
 // global provider manager, and returns concrete handles needed by the
@@ -1256,7 +1291,7 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 ) {
 	proxyOpts := providers.ProxyOptions{DisableGzip: disableGzip}
 	if disableGzip {
-		logger.Warn("Gzip disabled: Accept-Encoding stripped and transport compression off (debug mode)")
+		logProxyWarn("Gzip disabled: Accept-Encoding stripped and transport compression off (debug mode)")
 	}
 
 	openAI = providers.NewOpenAIProxy(proxyOpts)
@@ -1277,10 +1312,16 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 		logger.Info("☁️  Bedrock provider: DISABLED (set providers.bedrock.enabled: true to enable)")
 	}
 	if mantleCfg, ok := yamlConfig.Providers["bedrock-mantle"]; ok && mantleCfg.Enabled {
-		bedrockMantle = providers.NewBedrockMantleProxy(proxyOpts)
+		mantleOpts := proxyOpts
+		mantleOpts.MantleModelProjects = buildMantleModelProjects(mantleCfg)
+		bedrockMantle = providers.NewBedrockMantleProxy(mantleOpts)
 		globalProviderManager.RegisterProvider(bedrockMantle)
 		circuitBreakerProviders = append(circuitBreakerProviders, "bedrock-mantle")
-		logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", bedrockMantle.GetHealthStatus()["region"])
+		if len(mantleOpts.MantleModelProjects) > 0 {
+			logger.Info("☁️  Bedrock Mantle project routing: ENABLED", "models", len(mantleOpts.MantleModelProjects))
+		}
+		mantleHealth := bedrockMantle.GetHealthStatus()
+		logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", mantleHealth["region"], "anthropic_region", mantleHealth["anthropic_region"])
 	} else {
 		logger.Info("☁️  Bedrock Mantle provider: DISABLED (set providers.bedrock-mantle.enabled: true to enable)")
 	}
@@ -1316,7 +1357,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	provRT := provision.RuntimeFromYAML(yamlConfig.Features.APIKeyManagement.Provisioning)
 	keyProvisioner, provErr := provision.NewManagerFromRuntime(provRT, logger)
 	if provErr != nil {
-		logger.Error("Key provisioning disabled: setup failed", "error", provErr)
+		logProxyError("Key provisioning disabled: setup failed", "error", provErr)
 	} else {
 		globalKeyProvisioner = keyProvisioner
 		if keyProvisioner.Enabled() {
@@ -1328,7 +1369,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	if yamlConfig.Features.RateLimiting.Enabled {
 		lim, err := ratelimit.Factory(yamlConfig)
 		if err != nil {
-			logger.Error("Failed to initialize rate limiter", "error", err)
+			logProxyError("Failed to initialize rate limiter", "error", err)
 		} else {
 			globalRateLimiter = lim
 			globalRateLimitStatsRecorder = ratelimitstats.NewRecorder()
@@ -1366,12 +1407,12 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	fakeAllowed := isFakeModeAllowed(yamlConfig)
 	fakeCfg := fakeConfigFromYAML(yamlConfig, fakeAllowed)
 	if fakeAllowed {
-		logger.Warn(
+		logProxyWarn(
 			"🎭 Fake upstream: ENABLED — synthetic LLM responses, no real provider calls",
 			"chaos_failure_rate", yamlConfig.Features.FakeUpstream.ChaosFailureRate,
 		)
 	} else if yamlConfig.Features.FakeUpstream.Enabled {
-		logger.Warn(
+		logProxyWarn(
 			"🎭 Fake upstream: requested in YAML but LLM_PROXY_ALLOW_FAKE_MODE is not set; fake transport NOT installed",
 		)
 	}
@@ -1504,7 +1545,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		fingerprint := redact.AnalyzeCacheFingerprint(redactCfg)
 		analyzeCache, closeCache, cacheErr := redact.NewAnalyzeCache(cacheCfg, fingerprint)
 		if cacheErr != nil {
-			logger.Error("Failed to construct PII analyze cache; continuing without cache",
+			logProxyError("Failed to construct PII analyze cache; continuing without cache",
 				"error", cacheErr)
 		} else if analyzeCache != nil {
 			redactCfg.AnalyzeCache = analyzeCache
@@ -1513,7 +1554,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		var err error
 		redactor, err = redact.New(redactCfg)
 		if err != nil {
-			logger.Error("Failed to construct PII redactor; redaction features disabled",
+			logProxyError("Failed to construct PII redactor; redaction features disabled",
 				"error", err)
 			redactor = nil
 		} else {
@@ -1531,7 +1572,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 
 	if idGateCfg.Enabled {
 		if redactor == nil {
-			logger.Error("id_gate enabled but Presidio redactor unavailable; ID gate disabled")
+			logProxyError("id_gate enabled but Presidio redactor unavailable; ID gate disabled")
 		} else {
 			globalIDGateRecorder = idgatestats.NewRecorder()
 			ocrURL := idGateCfg.OCRSidecarURL
@@ -1631,9 +1672,9 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	if testModeAllowed {
 		cbCfg := circuitConfigFromYAML(yamlConfig.Features.CircuitBreaker, testModeAllowed)
 		r.Use(middleware.NewTestModeMiddleware(cbCfg.DegradedSignal))
-		logger.Warn("⚡ Circuit Breaker: test-mode middleware ENABLED (not for production)")
+		logProxyWarn("⚡ Circuit Breaker: test-mode middleware ENABLED (not for production)")
 	} else if yamlConfig.Features.CircuitBreaker.TestModeEnabled {
-		logger.Warn(
+		logProxyWarn(
 			"⚡ Circuit Breaker: test-mode requested in YAML but one or more guards not satisfied; middleware NOT installed",
 			"circuit_breaker_enabled", yamlConfig.Features.CircuitBreaker.Enabled,
 			"allow_env_set", os.Getenv("LLM_PROXY_ALLOW_TEST_MODE") == "1",
@@ -1664,12 +1705,12 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 					keyID = middleware.MaskKeyID(keyRecord.PK)
 					if store, ok := globalAPIKeyStore.(*apikeys.Store); ok && store != nil {
 						if err := store.MarkFirstRequest(r.Context(), keyRecord.PK, time.Now()); err != nil {
-							logger.Warn("Failed to mark first request", "error", err, "key", keyID)
+							logProxyWarn("Failed to mark first request", "error", err, "key", keyID)
 						}
 					}
 				}
 				if err := globalCostTracker.TrackRequest(metadata, userID, ipAddress, r.URL.Path, keyID); err != nil {
-					logger.Warn("Failed to track request cost", "error", err)
+					logProxyWarn("Failed to track request cost", "error", err)
 				}
 			}
 		}
@@ -1689,7 +1730,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		if store, ok := globalAPIKeyStore.(*apikeys.Store); ok && store != nil {
 			keyLookup = store
 		} else if !allowUnauth {
-			logger.Error("redact_api enabled but API key store unavailable — POST /redact not registered")
+			logProxyError("redact_api enabled but API key store unavailable — POST /redact not registered")
 		}
 		if keyLookup != nil || allowUnauth {
 			maxBody := redactAPICfg.MaxBodyBytes
@@ -1706,7 +1747,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 				"dev_allow_unauthenticated", allowUnauth)
 		}
 	} else if redactAPICfg.Enabled {
-		logger.Error("redact_api enabled but redactor unavailable — POST /redact not registered")
+		logProxyError("redact_api enabled but redactor unavailable — POST /redact not registered")
 	}
 
 	// robots.txt: keep the admin dashboard and (capability-URL) share pages
@@ -1804,7 +1845,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		logger.Info("Bedrock API endpoints available", "url", "http://0.0.0.0:"+port+"/bedrock/", "region", bedrockProvider.Region())
 	}
 	if bedrockMantleProvider != nil {
-		logger.Info("Bedrock Mantle API endpoints available", "url", "http://0.0.0.0:"+port+"/bedrock-mantle/v1/", "region", bedrockMantleProvider.GetHealthStatus()["region"])
+		logger.Info("Bedrock Mantle API endpoints available", "url", "http://0.0.0.0:"+port+"/bedrock-mantle/", "region", bedrockMantleProvider.GetHealthStatus()["region"])
 	}
 	logger.Info("Meta routes with user ID available", "pattern", "http://0.0.0.0:"+port+"/meta/{userID}/{provider}/")
 
@@ -1825,7 +1866,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	go func() {
 		logger.Info("🚀 Starting server", "address", "0.0.0.0:"+port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Error("Server failed to start", "error", err)
+			logProxyError("Server failed to start", "error", err)
 		}
 	}()
 
@@ -1856,7 +1897,7 @@ func gracefulShutdown(server *http.Server) {
 
 	logger.Info("🔄 Shutting down HTTP server...")
 	if err := server.Shutdown(ctx); err != nil {
-		logger.Error("HTTP server shutdown failed", "error", err)
+		logProxyError("HTTP server shutdown failed", "error", err)
 	} else {
 		logger.Info("✅ HTTP server shut down successfully")
 	}
@@ -1891,7 +1932,7 @@ func gracefulShutdown(server *http.Server) {
 	if globalHistorySink != nil {
 		logger.Info("🔄 Flushing history sink...")
 		if err := closeGlobalHistorySink(); err != nil {
-			logger.Warn("History sink: close failed", "error", err)
+			logProxyWarn("History sink: close failed", "error", err)
 		} else {
 			logger.Info("✅ History sink flushed")
 		}
@@ -1901,18 +1942,18 @@ func gracefulShutdown(server *http.Server) {
 	}
 	if globalAdminRollupStore != nil {
 		if err := globalAdminRollupStore.Close(); err != nil {
-			logger.Warn("Admin rollups: Redis close failed", "error", err)
+			logProxyWarn("Admin rollups: Redis close failed", "error", err)
 		}
 	}
 	if globalAnalyzeCacheClose != nil {
 		if err := globalAnalyzeCacheClose(); err != nil {
-			logger.Warn("PII analyze cache: Redis close failed", "error", err)
+			logProxyWarn("PII analyze cache: Redis close failed", "error", err)
 		}
 	}
 
 	if rs, ok := globalCircuitStore.(*circuit.RedisStore); ok {
 		if err := rs.Close(); err != nil {
-			logger.Warn("Circuit Breaker: Redis close failed", "error", err)
+			logProxyWarn("Circuit Breaker: Redis close failed", "error", err)
 		} else {
 			logger.Info("✅ Circuit Breaker: Redis client closed")
 		}
@@ -1923,7 +1964,7 @@ func gracefulShutdown(server *http.Server) {
 	if globalRateLimiter != nil {
 		if closer, ok := globalRateLimiter.(interface{ Close() error }); ok {
 			if err := closer.Close(); err != nil {
-				logger.Warn("Rate limiter: Redis close failed", "error", err)
+				logProxyWarn("Rate limiter: Redis close failed", "error", err)
 			} else {
 				logger.Info("✅ Rate limiter: Redis client closed")
 			}
@@ -1959,12 +2000,12 @@ func main() {
 		env := os.Getenv("ENVIRONMENT")
 		allowDefault := os.Getenv("LLM_PROXY_ALLOW_DEFAULT_CONFIG") == "1" || env == "" || env == "dev" || env == "local"
 		if !allowDefault {
-			logger.Error("Failed to load environment config; refusing to start with in-binary defaults",
+			logProxyError("Failed to load environment config; refusing to start with in-binary defaults",
 				"error", err, "environment", env,
 				"hint", "set LLM_PROXY_ALLOW_DEFAULT_CONFIG=1 to opt in to default config")
 			os.Exit(1)
 		}
-		logger.Warn("Failed to load environment config, using defaults (dev only)", "error", err)
+		logProxyWarn("Failed to load environment config, using defaults (dev only)", "error", err)
 		yamlConfig = config.GetDefaultYAMLConfig()
 	}
 

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1314,14 +1314,20 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 	if mantleCfg, ok := yamlConfig.Providers["bedrock-mantle"]; ok && mantleCfg.Enabled {
 		mantleOpts := proxyOpts
 		mantleOpts.MantleModelProjects = buildMantleModelProjects(mantleCfg)
-		bedrockMantle = providers.NewBedrockMantleProxy(mantleOpts)
-		globalProviderManager.RegisterProvider(bedrockMantle)
-		circuitBreakerProviders = append(circuitBreakerProviders, "bedrock-mantle")
-		if len(mantleOpts.MantleModelProjects) > 0 {
-			logger.Info("☁️  Bedrock Mantle project routing: ENABLED", "models", len(mantleOpts.MantleModelProjects))
+		var mantleErr error
+		bedrockMantle, mantleErr = providers.NewBedrockMantleProxy(mantleOpts)
+		if mantleErr != nil {
+			logger.Warn("☁️  Bedrock Mantle provider: UNAVAILABLE (AWS config failed; other providers still registered)", "error", mantleErr)
+			bedrockMantle = nil
+		} else {
+			globalProviderManager.RegisterProvider(bedrockMantle)
+			circuitBreakerProviders = append(circuitBreakerProviders, "bedrock-mantle")
+			if len(mantleOpts.MantleModelProjects) > 0 {
+				logger.Info("☁️  Bedrock Mantle project routing: ENABLED", "models", len(mantleOpts.MantleModelProjects))
+			}
+			mantleHealth := bedrockMantle.GetHealthStatus()
+			logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", mantleHealth["region"], "anthropic_region", mantleHealth["anthropic_region"])
 		}
-		mantleHealth := bedrockMantle.GetHealthStatus()
-		logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", mantleHealth["region"], "anthropic_region", mantleHealth["anthropic_region"])
 	} else {
 		logger.Info("☁️  Bedrock Mantle provider: DISABLED (set providers.bedrock-mantle.enabled: true to enable)")
 	}

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -718,7 +718,7 @@ func circuitModelExtractor(
 			strings.HasPrefix(path, "/v1/models/"):
 			model, _ := geminiProvider.ExtractRequestModelAndMessages(req)
 			return model
-		case strings.HasPrefix(path, "/bedrock/"):
+		case strings.HasPrefix(path, "/bedrock/"), strings.HasPrefix(path, "/model/"):
 			if bedrockProvider == nil {
 				return ""
 			}

--- a/cmd/llm-proxy/main_observability_test.go
+++ b/cmd/llm-proxy/main_observability_test.go
@@ -82,7 +82,7 @@ func TestCircuitModelExtractor_DispatchesToRealProviders(t *testing.T) {
 		},
 		{
 			name: "bedrock mantle responses",
-			path: "/bedrock-mantle/v1/responses",
+			path: "/bedrock-mantle/openai/v1/responses",
 			body: `{"model":"claude-sonnet-4-5","input":"hello"}`,
 			want: "claude-sonnet-4-5",
 		},

--- a/cmd/llm-proxy/main_observability_test.go
+++ b/cmd/llm-proxy/main_observability_test.go
@@ -28,8 +28,9 @@ func TestCircuitModelExtractor_DispatchesToRealProviders(t *testing.T) {
 	anthropicProvider := providers.NewAnthropicProxy()
 	geminiProvider := providers.NewGeminiProxy()
 	bedrockProvider := providers.NewBedrockProxy()
+	bedrockMantleProvider := providers.NewBedrockMantleProxy()
 
-	extract := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider)
+	extract := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider, bedrockMantleProvider)
 
 	cases := []struct {
 		name string
@@ -80,6 +81,12 @@ func TestCircuitModelExtractor_DispatchesToRealProviders(t *testing.T) {
 			want: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
 		},
 		{
+			name: "bedrock mantle responses",
+			path: "/bedrock-mantle/v1/responses",
+			body: `{"model":"claude-sonnet-4-5","input":"hello"}`,
+			want: "claude-sonnet-4-5",
+		},
+		{
 			name: "non-matching path returns empty",
 			path: "/healthz",
 			body: ``,
@@ -116,6 +123,7 @@ func TestCircuitModelExtractor_NilSafe(t *testing.T) {
 		providers.NewAnthropicProxy(),
 		providers.NewGeminiProxy(),
 		providers.NewBedrockProxy(),
+		providers.NewBedrockMantleProxy(),
 	)
 	if got := extract(nil); got != "" {
 		t.Fatalf("nil request: want \"\", got %q", got)
@@ -130,6 +138,7 @@ func TestCircuitModelExtractor_NilBedrockSafe(t *testing.T) {
 		providers.NewOpenAIProxy(),
 		providers.NewAnthropicProxy(),
 		providers.NewGeminiProxy(),
+		nil,
 		nil,
 	)
 	req := httptest.NewRequestWithContext(

--- a/cmd/llm-proxy/main_observability_test.go
+++ b/cmd/llm-proxy/main_observability_test.go
@@ -28,7 +28,10 @@ func TestCircuitModelExtractor_DispatchesToRealProviders(t *testing.T) {
 	anthropicProvider := providers.NewAnthropicProxy()
 	geminiProvider := providers.NewGeminiProxy()
 	bedrockProvider := providers.NewBedrockProxy()
-	bedrockMantleProvider := providers.NewBedrockMantleProxy()
+	bedrockMantleProvider, err := providers.NewBedrockMantleProxy()
+	if err != nil {
+		t.Fatalf("NewBedrockMantleProxy: %v", err)
+	}
 
 	extract := circuitModelExtractor(openAIProvider, anthropicProvider, geminiProvider, bedrockProvider, bedrockMantleProvider)
 
@@ -118,12 +121,16 @@ func TestCircuitModelExtractor_DispatchesToRealProviders(t *testing.T) {
 // reaches the circuit transport with a nil URL must produce "" and
 // not crash, since model attribution is best-effort.
 func TestCircuitModelExtractor_NilSafe(t *testing.T) {
+	bedrockMantleProvider, err := providers.NewBedrockMantleProxy()
+	if err != nil {
+		t.Fatalf("NewBedrockMantleProxy: %v", err)
+	}
 	extract := circuitModelExtractor(
 		providers.NewOpenAIProxy(),
 		providers.NewAnthropicProxy(),
 		providers.NewGeminiProxy(),
 		providers.NewBedrockProxy(),
-		providers.NewBedrockMantleProxy(),
+		bedrockMantleProvider,
 	)
 	if got := extract(nil); got != "" {
 		t.Fatalf("nil request: want \"\", got %q", got)

--- a/cmd/llm-proxy/mantle_projects_test.go
+++ b/cmd/llm-proxy/mantle_projects_test.go
@@ -36,6 +36,7 @@ func TestBuildMantleModelProjects_ExpandsEnvAndAliases(t *testing.T) {
 }
 
 func TestBuildMantleModelProjects_NilWhenNoneConfigured(t *testing.T) {
+	t.Setenv("LLM_PROXY_UNSET_PROJECT_ID", "")
 	cfg := config.ProviderConfig{
 		Models: map[string]config.ModelConfig{
 			"openai.gpt-5.5": {ProjectID: "${LLM_PROXY_UNSET_PROJECT_ID}"}, // expands to ""

--- a/cmd/llm-proxy/mantle_projects_test.go
+++ b/cmd/llm-proxy/mantle_projects_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+)
+
+func TestBuildMantleModelProjects_ExpandsEnvAndAliases(t *testing.T) {
+	t.Setenv("LLM_PROXY_BEDROCK_MANTLE_OPENAI_PROJECT_ID", "proj_env123")
+
+	cfg := config.ProviderConfig{
+		Models: map[string]config.ModelConfig{
+			"openai.gpt-5.5": {
+				Aliases:   []string{"gpt-5.5-bedrock", ""},
+				ProjectID: "${LLM_PROXY_BEDROCK_MANTLE_OPENAI_PROJECT_ID}",
+			},
+			"anthropic.claude-sonnet-5": {}, // no project id -> skipped
+		},
+	}
+
+	projects := buildMantleModelProjects(cfg)
+
+	if got := projects["openai.gpt-5.5"]; got != "proj_env123" {
+		t.Fatalf("canonical model project = %q, want proj_env123", got)
+	}
+	if got := projects["gpt-5.5-bedrock"]; got != "proj_env123" {
+		t.Fatalf("alias project = %q, want proj_env123", got)
+	}
+	if _, ok := projects[""]; ok {
+		t.Fatal("empty alias must not be mapped")
+	}
+	if _, ok := projects["anthropic.claude-sonnet-5"]; ok {
+		t.Fatal("model without project id must be skipped")
+	}
+}
+
+func TestBuildMantleModelProjects_NilWhenNoneConfigured(t *testing.T) {
+	cfg := config.ProviderConfig{
+		Models: map[string]config.ModelConfig{
+			"openai.gpt-5.5": {ProjectID: "${LLM_PROXY_UNSET_PROJECT_ID}"}, // expands to ""
+			"openai.gpt-5.4": {},
+		},
+	}
+	if got := buildMantleModelProjects(cfg); got != nil {
+		t.Fatalf("expected nil map when no project ids resolve, got %v", got)
+	}
+}

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -876,6 +876,44 @@ providers:
           output: 75.00
 
   # ---------------------------------------------------------------------------
+  # AWS BEDROCK MANTLE PROVIDER (OpenAI-compatible API + task-role SigV4)
+  # ---------------------------------------------------------------------------
+  # The proxy authenticates incoming Bearer credentials as llm-proxy keys and
+  # discards them before signing each outbound request with its AWS task role.
+  # No provider bearer token is stored or forwarded.
+  bedrock-mantle:
+    enabled: false # enabled by configs/{dev,staging,production}.yml
+    models:
+      "openai.gpt-5.4":
+        enabled: true
+        aliases: ["gpt-5.4-bedrock"]
+        pricing:
+          input: 2.50
+          output: 15.00
+      "openai.gpt-5.5":
+        enabled: true
+        aliases: ["gpt-5.5-bedrock"]
+        pricing:
+          input: 5.00
+          output: 30.00
+      "us.anthropic.claude-sonnet-4-5-20250929-v1:0":
+        enabled: true
+        aliases: ["claude-sonnet-4-5"]
+        pricing:
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
+      "us.anthropic.claude-haiku-4-5-20251001-v1:0":
+        enabled: true
+        aliases: ["claude-haiku-4-5"]
+        pricing:
+          input: 1.00
+          output: 5.00
+
+  # ---------------------------------------------------------------------------
   # GOOGLE GEMINI PROVIDER
   # ---------------------------------------------------------------------------
   gemini:

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -823,6 +823,8 @@ providers:
             "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "claude-sonnet-4-5-bedrock",
             "claude-sonnet-4.5-bedrock",
+            "claude-sonnet-bedrock",
+            "claude-sonnet-bedrock-thinking",
           ]
         limits:
           tokens_per_minute: 80_000
@@ -845,6 +847,8 @@ providers:
             "anthropic.claude-haiku-4-5-20251001-v1:0",
             "claude-haiku-4-5-bedrock",
             "claude-haiku-4.5-bedrock",
+            "claude-haiku-bedrock",
+            "claude-haiku-bedrock-thinking",
           ]
         limits:
           tokens_per_minute: 100_000
@@ -863,6 +867,8 @@ providers:
             "anthropic.claude-opus-4-1-20250805-v1:0",
             "claude-opus-4-1-bedrock",
             "claude-opus-4.1-bedrock",
+            "claude-opus-bedrock",
+            "claude-opus-bedrock-thinking",
           ]
         limits:
           tokens_per_minute: 40_000
@@ -874,6 +880,73 @@ providers:
         pricing:
           input: 15.00
           output: 75.00
+      "us.anthropic.claude-sonnet-5":
+        enabled: true
+        aliases:
+          [
+            "anthropic.claude-sonnet-5",
+            "claude-sonnet-5-bedrock",
+            "claude-sonnet-5-bedrock-thinking",
+          ]
+        limits:
+          tokens_per_minute: 80_000
+          requests_per_minute: 1_000
+          tokens_per_day: 1_920_000
+          requests_per_day: 1_440_000
+          burst_tokens: 8_000
+          burst_requests: 100
+        # Standard on-demand pricing ($3/$15, tiered above 200K). The launch
+        # intro rate ($2/$10 through 2026-08-31) is intentionally omitted so
+        # cost tracking never under-bills after the promo ends.
+        pricing:
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
+      "us.anthropic.claude-sonnet-4-6":
+        enabled: true
+        aliases:
+          [
+            "anthropic.claude-sonnet-4-6",
+            "claude-sonnet-4-6-bedrock",
+            "claude-sonnet-4.6-bedrock",
+            "claude-sonnet-4-6-bedrock-thinking",
+          ]
+        limits:
+          tokens_per_minute: 80_000
+          requests_per_minute: 1_000
+          tokens_per_day: 1_920_000
+          requests_per_day: 1_440_000
+          burst_tokens: 8_000
+          burst_requests: 100
+        pricing:
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
+      "us.anthropic.claude-opus-4-8":
+        enabled: true
+        aliases:
+          [
+            "anthropic.claude-opus-4-8",
+            "claude-opus-4-8-bedrock",
+            "claude-opus-4.8-bedrock",
+            "claude-opus-4-8-bedrock-thinking",
+          ]
+        limits:
+          tokens_per_minute: 40_000
+          requests_per_minute: 1_000
+          tokens_per_day: 960_000
+          requests_per_day: 1_440_000
+          burst_tokens: 4_000
+          burst_requests: 100
+        pricing:
+          input: 6.00
+          output: 30.00
 
   # ---------------------------------------------------------------------------
   # AWS BEDROCK MANTLE PROVIDER (OpenAI-compatible API + task-role SigV4)
@@ -884,21 +957,28 @@ providers:
   bedrock-mantle:
     enabled: false # enabled by configs/{dev,staging,production}.yml
     models:
+      # openai.gpt-5.4/5.5 do not support zero-data-retention (their allowed_modes
+      # omit "none"). With the account pinned to none they'd be blocked, so route
+      # them through a project pinned to "default" retention (data stays inside
+      # AWS, not shared with OpenAI). project_id is env-driven per account; unset
+      # -> no OpenAI-Project header -> account default applies.
       "openai.gpt-5.4":
         enabled: true
         aliases: ["gpt-5.4-bedrock"]
+        project_id: "${LLM_PROXY_BEDROCK_MANTLE_OPENAI_PROJECT_ID}"
         pricing:
           input: 2.50
           output: 15.00
       "openai.gpt-5.5":
         enabled: true
         aliases: ["gpt-5.5-bedrock"]
+        project_id: "${LLM_PROXY_BEDROCK_MANTLE_OPENAI_PROJECT_ID}"
         pricing:
           input: 5.00
           output: 30.00
       "us.anthropic.claude-sonnet-4-5-20250929-v1:0":
         enabled: true
-        aliases: ["claude-sonnet-4-5"]
+        aliases: ["claude-sonnet-4-5", "anthropic.claude-sonnet-4-5"]
         pricing:
           - threshold: 200_000
             input: 3.00
@@ -908,7 +988,7 @@ providers:
             output: 22.50
       "us.anthropic.claude-haiku-4-5-20251001-v1:0":
         enabled: true
-        aliases: ["claude-haiku-4-5"]
+        aliases: ["claude-haiku-4-5", "anthropic.claude-haiku-4-5"]
         pricing:
           input: 1.00
           output: 5.00

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -167,3 +167,5 @@ features:
 providers:
   bedrock:
     enabled: true
+  bedrock-mantle:
+    enabled: true

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -19,13 +19,9 @@ features:
       - type: "file"
         file:
           path: "./logs/cost-tracking.jsonl"
-      - type: "datadog"
-        datadog:
-          host: "datadog-agent"
-          port: "8125"
-          namespace: "llm"
-          tags: ["env:dev", "service:llm-proxy"]
-          sample_rate: 1.0
+      # Datadog metrics require the profile-gated datadog-agent service:
+      #   docker compose --profile datadog up
+      # Default local compose uses file transport only so the proxy can bind :9002.
   api_key_management:
     enabled: true
     table_name: "llm-proxy-api-keys-dev"

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -203,10 +203,9 @@ features:
 # =============================================================================
 # PROVIDER OVERRIDES
 # =============================================================================
-# Base config disables AWS Bedrock by default (see configs/base.yml).  Flip the
-# override below — and confirm the calling service's IAM role has bedrock:Invoke* /
-# Converse* grants for $AWS_REGION — to enable the SigV4 passthrough after
-# staging validation.
-# providers:
-#   bedrock:
-#     enabled: true
+# Bedrock Mantle signs outbound OpenAI-compatible requests with the task role.
+providers:
+  bedrock:
+    enabled: true
+  bedrock-mantle:
+    enabled: true

--- a/configs/staging.yml
+++ b/configs/staging.yml
@@ -63,9 +63,9 @@ features:
 # =============================================================================
 # PROVIDER OVERRIDES
 # =============================================================================
-# Base config disables AWS Bedrock by default (see configs/base.yml).  Uncomment
-# the override below — and confirm the calling service's IAM role has bedrock:Invoke* /
-# Converse* grants for $AWS_REGION — to enable the SigV4 passthrough.
-# providers:
-#   bedrock:
-#     enabled: true
+# Bedrock Mantle uses the task role to SigV4-sign OpenAI-compatible requests.
+providers:
+  bedrock:
+    enabled: true
+  bedrock-mantle:
+    enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - /app/bin # Exclude bin directory to avoid conflicts
       - /app/tmp # air build output (linux binary) — keep out of host mount
       - ./logs:/app/logs # Ensure logs directory is writable
+      # Bedrock Mantle SigV4 + optional SSO (run `aws sso login` on the host first).
+      - ~/.aws:/root/.aws:ro
     working_dir: /app
     # air watches Go sources + YAML and rebuilds/restarts on change.
     # See .air.toml. Falls back to `go run` only if air is unavailable.
@@ -39,7 +41,10 @@ services:
       # Local DynamoDB for API key management in docker-compose dev.
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-local}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-local}
+      - AWS_REGION=${AWS_REGION:-us-west-2}
       - AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL:-http://dynamodb:8000}
+      # Bedrock Mantle SigV4 uses ~/.aws profile creds, not the DynamoDB Local keys above.
+      - BEDROCK_AWS_PROFILE=${BEDROCK_AWS_PROFILE:-default}
       # Override the YAML default analyzer_url for the docker-compose
       # network. The sidecar service hostname `presidio` resolves only
       # over this network; production ECS task definitions point at
@@ -224,7 +229,8 @@ services:
     environment:
       - VITE_API_PROXY_TARGET=http://llm-proxy:9002
     depends_on:
-      - llm-proxy
+      llm-proxy:
+        condition: service_healthy
     command: [ "sh", "-c", "npm install && npm run dev -- --host 0.0.0.0" ]
     networks:
       - llm-proxy-network

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -196,8 +196,11 @@ func (h *handler) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 				UpstreamKind:  res.UpstreamKind,
 			}
 		} else if actualKey == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "actual_key is required unless auto_provision is true"})
-			return
+			actualKey = apikeys.ResolveActualKey(req.Provider, actualKey)
+			if actualKey == "" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "actual_key is required unless auto_provision is true"})
+				return
+			}
 		}
 		key, err := h.deps.APIKeyStore.CreatePersonalKey(
 			r.Context(),

--- a/internal/admin/key_requests_handlers.go
+++ b/internal/admin/key_requests_handlers.go
@@ -304,7 +304,10 @@ func (h *handler) createOrgKey(r *http.Request, role adminusers.Role, req Create
 			req.Tags["tier"] = res.UpstreamID
 		}
 	} else if actualKey == "" {
-		return nil, &orgKeyError{status: http.StatusBadRequest, message: "actual_key is required unless auto_provision is true"}
+		actualKey = apikeys.ResolveActualKey(req.Provider, actualKey)
+		if actualKey == "" {
+			return nil, &orgKeyError{status: http.StatusBadRequest, message: "actual_key is required unless auto_provision is true"}
+		}
 	}
 
 	key, err := h.deps.APIKeyStore.CreateKeyWithMeta(

--- a/internal/admin/keys_handlers_test.go
+++ b/internal/admin/keys_handlers_test.go
@@ -82,6 +82,32 @@ func TestHandleCreateKey_PIIOffBedrockAllowed(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, rec.Code)
 }
 
+func TestHandleCreateKey_BedrockMantleWithoutActualKey(t *testing.T) {
+	h, _ := testAdminHandler(t)
+
+	body, _ := json.Marshal(CreateKeyRequest{
+		Provider:    "bedrock-mantle",
+		Description: "local mantle",
+	})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateKey(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestHandleCreateKey_BedrockWithoutActualKey(t *testing.T) {
+	h, _ := testAdminHandler(t)
+
+	body, _ := json.Marshal(CreateKeyRequest{
+		Provider:    "bedrock",
+		Description: "local bedrock",
+	})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateKey(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
 func TestHandleCreateKey_PIIOffBypassAdmin(t *testing.T) {
 	t.Setenv("LLM_PROXY_ADMIN_DEV_USER_EMAIL", "admin@example.com")
 	// The shipped allowlist is empty; opt this admin in for the test.

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/admin/permissions"
 	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/gorilla/mux"
 )
 
@@ -27,7 +28,7 @@ func RegisterRoutes(r *mux.Router, deps Deps) {
 	}
 	auth, err := newAuthenticator(logger, adminCfg, deps.UserStore)
 	if err != nil {
-		logger.Error("admin dashboard disabled: auth setup failed", "error", err)
+		logger.Error(proxylog.ProxyMsg("admin dashboard disabled: auth setup failed"), "error", err)
 		return
 	}
 

--- a/internal/apikeys/credential_id.go
+++ b/internal/apikeys/credential_id.go
@@ -22,7 +22,7 @@ var byoPrefixProviders = []struct {
 
 func isSupportedProxyProvider(provider string) bool {
 	switch normalizeProvider(provider) {
-	case "openai", "anthropic", "gemini", "bedrock":
+	case "openai", "anthropic", "gemini", "bedrock", "bedrock-mantle":
 		return true
 	default:
 		return false

--- a/internal/apikeys/provider_upstream.go
+++ b/internal/apikeys/provider_upstream.go
@@ -25,13 +25,11 @@ func ProviderUsesAWSAuth(provider string) bool {
 }
 
 // ResolveActualKey returns the upstream credential to store. AWS-auth providers
-// accept an empty request actual_key and receive a placeholder.
+// always receive a placeholder — outbound auth is SigV4, so never persist a
+// caller-supplied actual_key for them.
 func ResolveActualKey(provider, actualKey string) string {
-	if actualKey != "" {
-		return actualKey
-	}
 	if ProviderUsesAWSAuth(provider) {
 		return AWSAuthProviderPlaceholderKey
 	}
-	return ""
+	return actualKey
 }

--- a/internal/apikeys/provider_upstream.go
+++ b/internal/apikeys/provider_upstream.go
@@ -1,0 +1,37 @@
+package apikeys
+
+// AWSAuthProviderPlaceholderKey is stored for providers that authenticate
+// upstream via AWS SigV4 instead of a provider bearer token.
+const AWSAuthProviderPlaceholderKey = "unused"
+
+const bedrockMantleProvider = "bedrock-mantle"
+
+// IsBedrockFamilyProvider reports proxy-key providers that authenticate Bedrock
+// traffic (Converse identity keys and Mantle caller keys share the bedrock
+// provider; legacy bedrock-mantle keys remain valid).
+func IsBedrockFamilyProvider(provider string) bool {
+	switch normalizeProvider(provider) {
+	case BedrockProvider, bedrockMantleProvider:
+		return true
+	default:
+		return false
+	}
+}
+
+// ProviderUsesAWSAuth reports providers whose outbound calls use AWS SigV4
+// rather than the stored actual_key.
+func ProviderUsesAWSAuth(provider string) bool {
+	return IsBedrockFamilyProvider(provider)
+}
+
+// ResolveActualKey returns the upstream credential to store. AWS-auth providers
+// accept an empty request actual_key and receive a placeholder.
+func ResolveActualKey(provider, actualKey string) string {
+	if actualKey != "" {
+		return actualKey
+	}
+	if ProviderUsesAWSAuth(provider) {
+		return AWSAuthProviderPlaceholderKey
+	}
+	return ""
+}

--- a/internal/apikeys/provider_upstream_test.go
+++ b/internal/apikeys/provider_upstream_test.go
@@ -25,6 +25,9 @@ func TestResolveActualKey(t *testing.T) {
 	if got := ResolveActualKey("bedrock-mantle", ""); got != AWSAuthProviderPlaceholderKey {
 		t.Fatalf("ResolveActualKey(bedrock-mantle, empty) = %q", got)
 	}
+	if got := ResolveActualKey("bedrock", "sk-caller-supplied"); got != AWSAuthProviderPlaceholderKey {
+		t.Fatalf("ResolveActualKey(bedrock, caller key) = %q, want placeholder", got)
+	}
 	if got := ResolveActualKey("openai", ""); got != "" {
 		t.Fatalf("ResolveActualKey(openai, empty) = %q, want empty", got)
 	}

--- a/internal/apikeys/provider_upstream_test.go
+++ b/internal/apikeys/provider_upstream_test.go
@@ -1,0 +1,34 @@
+package apikeys
+
+import "testing"
+
+func TestProviderUsesAWSAuth(t *testing.T) {
+	for _, provider := range []string{"bedrock", "bedrock-mantle", "BEDROCK-MANTLE"} {
+		if !ProviderUsesAWSAuth(provider) {
+			t.Fatalf("ProviderUsesAWSAuth(%q) = false, want true", provider)
+		}
+		if !IsBedrockFamilyProvider(provider) {
+			t.Fatalf("IsBedrockFamilyProvider(%q) = false, want true", provider)
+		}
+	}
+	for _, provider := range []string{"openai", "anthropic", "gemini"} {
+		if ProviderUsesAWSAuth(provider) {
+			t.Fatalf("ProviderUsesAWSAuth(%q) = true, want false", provider)
+		}
+	}
+}
+
+func TestResolveActualKey(t *testing.T) {
+	if got := ResolveActualKey("bedrock", ""); got != AWSAuthProviderPlaceholderKey {
+		t.Fatalf("ResolveActualKey(bedrock, empty) = %q", got)
+	}
+	if got := ResolveActualKey("bedrock-mantle", ""); got != AWSAuthProviderPlaceholderKey {
+		t.Fatalf("ResolveActualKey(bedrock-mantle, empty) = %q", got)
+	}
+	if got := ResolveActualKey("openai", ""); got != "" {
+		t.Fatalf("ResolveActualKey(openai, empty) = %q, want empty", got)
+	}
+	if got := ResolveActualKey("openai", "sk-real"); got != "sk-real" {
+		t.Fatalf("ResolveActualKey(openai, sk-real) = %q", got)
+	}
+}

--- a/internal/circuit/redis.go
+++ b/internal/circuit/redis.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
+
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 const (
@@ -202,7 +204,7 @@ func (s *RedisStore) GetState(ctx context.Context, key string) (State, error) {
 		// On Redis errors, fail open (treat as closed) to avoid taking down the
 		// service because of a Redis blip.
 		s.log.Warn(
-			"circuit.RedisStore: GetState failed open",
+			proxylog.ProxyMsg("circuit.RedisStore: GetState failed open"),
 			"key", key,
 			"error", err,
 			"ctx_err", ctx.Err(),
@@ -307,7 +309,7 @@ func (s *RedisStore) RecordTerminalFailure(ctx context.Context, key string) (Sta
 	if err != nil {
 		// On Redis error fail safe: return closed so we don't block traffic.
 		s.log.Warn(
-			"circuit.RedisStore: luaRecordFailure failed open",
+			proxylog.ProxyMsg("circuit.RedisStore: luaRecordFailure failed open"),
 			"key", key,
 			"script", "luaRecordFailure",
 			"redis_client", fmt.Sprintf("%p", s.rdb),
@@ -318,7 +320,7 @@ func (s *RedisStore) RecordTerminalFailure(ctx context.Context, key string) (Sta
 	}
 	if len(res) < 2 {
 		s.log.Warn(
-			"circuit.RedisStore: luaRecordFailure unexpected reply shape",
+			proxylog.ProxyMsg("circuit.RedisStore: luaRecordFailure unexpected reply shape"),
 			"key", key,
 			"reply_len", len(res),
 		)
@@ -393,7 +395,7 @@ func (s *RedisStore) ForceOpen(ctx context.Context, key string, cooldownSeconds 
 	pipe.Expire(ctx, s.failuresKey(key), fttl)
 	if _, err := pipe.Exec(ctx); err != nil {
 		s.log.Warn(
-			"circuit.RedisStore: ForceOpen failed (provider will NOT fast-fail account-wide)",
+			proxylog.ProxyMsg("circuit.RedisStore: ForceOpen failed (provider will NOT fast-fail account-wide)"),
 			"key", key,
 			"error", err,
 		)
@@ -521,7 +523,7 @@ func (s *RedisStore) RecordKeyOpenedForRollup(ctx context.Context, provider stri
 	_, err := pipe.Exec(ctx)
 	if err != nil {
 		s.log.Warn(
-			"circuit.RedisStore: RecordKeyOpenedForRollup failed (rollup signal will lag)",
+			proxylog.ProxyMsg("circuit.RedisStore: RecordKeyOpenedForRollup failed (rollup signal will lag)"),
 			"provider", provider,
 			"key", openedKey,
 			"error", err,
@@ -550,7 +552,7 @@ func (s *RedisStore) RollupOpen(ctx context.Context, provider string, threshold,
 		fmt.Sprintf("%f", cutoff), "+inf").Result()
 	if err != nil {
 		s.log.Warn(
-			"circuit.RedisStore: RollupOpen failed open",
+			proxylog.ProxyMsg("circuit.RedisStore: RollupOpen failed open"),
 			"provider", provider,
 			"error", err,
 			"ctx_err", ctx.Err(),
@@ -569,7 +571,7 @@ func (s *RedisStore) ClearRollupKey(ctx context.Context, provider string, opened
 	}
 	if err := s.rdb.ZRem(ctx, s.rollupKey(provider), openedKey).Err(); err != nil {
 		s.log.Warn(
-			"circuit.RedisStore: ClearRollupKey failed (rollup may lag)",
+			proxylog.ProxyMsg("circuit.RedisStore: ClearRollupKey failed (rollup may lag)"),
 			"provider", provider,
 			"key", openedKey,
 			"error", err,
@@ -596,7 +598,7 @@ func (s *RedisStore) RolledUpKeys(ctx context.Context, provider string, windowSe
 	}).Result()
 	if err != nil {
 		s.log.Warn(
-			"circuit.RedisStore: RolledUpKeys failed (rollup view will lag)",
+			proxylog.ProxyMsg("circuit.RedisStore: RolledUpKeys failed (rollup view will lag)"),
 			"provider", provider,
 			"error", err,
 		)

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/observability"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // errRetryBodyTooLarge is an internal sentinel returned by cacheBody when
@@ -407,7 +408,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.testModeFromRequest(req) == TestModeForceDegraded {
 		t.log.Info("circuit: test-mode force_degraded",
 			t.newFailureContext(req, nil, nil).withKind(KindCircuitOpen).attrs()...)
-		return t.degradedResponse(req), nil
+		return t.degradedResponse(req, false), nil
 	}
 
 	// ── Bypass header / query param ───────────────────────────────────────
@@ -434,13 +435,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	switch state {
 	case StateOpen:
 		fc := t.newFailureContext(req, nil, nil).withKind(KindCircuitOpen)
-		t.log.Warn("circuit: fast-fail (circuit open)",
+		t.log.Warn(proxylog.ProxyMsg("circuit: fast-fail (circuit open)"),
 			append(fc.attrs(), "mode", ModeEnforce)...)
 		t.emit("fast_fail", fc)
 		if t.activity != nil {
 			t.activity.RecordFastFail(t.provider, key)
 		}
-		return t.degradedResponse(req), nil
+		return t.degradedResponse(req, false), nil
 
 	case StateHalfOpen:
 		return t.runProbe(req, key)
@@ -477,7 +478,7 @@ func (t *Transport) effectiveStateForRequest(req *http.Request) (State, string) 
 		var err error
 		state, err = t.store.GetState(ctx, key)
 		if err != nil {
-			t.log.Warn("circuit: GetState error, treating as closed", "key", key, "error", err)
+			t.log.Warn(proxylog.ProxyMsg("circuit: GetState error, treating as closed"), "key", key, "error", err)
 			state = StateClosed
 		}
 	} else {
@@ -522,7 +523,7 @@ func (t *Transport) effectiveStateForRequest(req *http.Request) (State, string) 
 			)
 			if open {
 				t.log.Warn(
-					"circuit: provider rollup open, treating per-key state as Open",
+					proxylog.ProxyMsg("circuit: provider rollup open, treating per-key state as Open"),
 					"provider", t.provider,
 					"cb_key", key,
 					"rollup_threshold", t.cfg.PerProviderRollupThreshold,
@@ -698,7 +699,7 @@ func (t *Transport) runObserveOnly(req *http.Request) (*http.Response, error) {
 		// pass-through, GetBody is nil, model extraction will return
 		// "" — that's acceptable for log mode.
 		t.log.Warn(
-			"circuit: log-mode request body exceeds MaxRetryableBodyBytes, model attribution unavailable",
+			proxylog.ProxyMsg("circuit: log-mode request body exceeds MaxRetryableBodyBytes, model attribution unavailable"),
 			"provider", t.provider,
 			"path", req.URL.Path,
 			"content_length", req.ContentLength,
@@ -754,7 +755,7 @@ func (t *Transport) runObserveOnly(req *http.Request) (*http.Response, error) {
 		// so this cannot cascade.
 		newState, openedNow, recErr := t.store.RecordTerminalFailure(ctx, key)
 		if recErr != nil {
-			t.log.Error("circuit: log-mode RecordTerminalFailure error",
+			t.log.Error(proxylog.ProxyMsg("circuit: log-mode RecordTerminalFailure error"),
 				"key", key, "error", recErr)
 		}
 		t.maybeRecordRollup(ctx, key, openedNow)
@@ -798,7 +799,7 @@ func (t *Transport) maybeRecordRollup(ctx context.Context, key string, openedNow
 	}
 	if err := rec.RecordKeyOpenedForRollup(ctx, t.provider, key,
 		t.cfg.PerProviderRollupWindowSeconds); err != nil {
-		t.log.Warn("circuit: RecordKeyOpenedForRollup error (rollup may lag)",
+		t.log.Warn(proxylog.ProxyMsg("circuit: RecordKeyOpenedForRollup error (rollup may lag)"),
 			"provider", t.provider, "key", key, "error", err)
 	}
 }
@@ -819,7 +820,7 @@ func (t *Transport) reArmRollup(ctx context.Context, key string) {
 	}
 	if err := rec.RecordKeyOpenedForRollup(ctx, t.provider, key,
 		t.cfg.PerProviderRollupWindowSeconds); err != nil {
-		t.log.Warn("circuit: RecordKeyOpenedForRollup (re-arm) error",
+		t.log.Warn(proxylog.ProxyMsg("circuit: RecordKeyOpenedForRollup (re-arm) error"),
 			"provider", t.provider, "key", key, "error", err)
 	}
 }
@@ -848,7 +849,7 @@ func (t *Transport) runBypass(req *http.Request, reason string) (*http.Response,
 			return nil, fmt.Errorf("circuit: cacheBody (bypass): %w", err)
 		}
 		t.log.Warn(
-			"circuit: bypass request body exceeds MaxRetryableBodyBytes, model attribution unavailable",
+			proxylog.ProxyMsg("circuit: bypass request body exceeds MaxRetryableBodyBytes, model attribution unavailable"),
 			"provider", t.provider,
 			"path", req.URL.Path,
 			"content_length", req.ContentLength,
@@ -898,7 +899,7 @@ func (t *Transport) runBypass(req *http.Request, reason string) (*http.Response,
 		// modes are intentionally orthogonal.
 		_, openedNow, recErr := t.store.RecordTerminalFailure(ctx, key)
 		if recErr != nil {
-			t.log.Error("circuit: bypass RecordTerminalFailure error",
+			t.log.Error(proxylog.ProxyMsg("circuit: bypass RecordTerminalFailure error"),
 				"key", key, "error", recErr)
 		}
 		if openedNow {
@@ -940,7 +941,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 	if err := t.cacheBody(req); err != nil {
 		if errors.Is(err, errRetryBodyTooLarge) {
 			t.log.Warn(
-				"circuit: request body exceeds MaxRetryableBodyBytes, retries disabled for this request",
+				proxylog.ProxyMsg("circuit: request body exceeds MaxRetryableBodyBytes, retries disabled for this request"),
 				"provider", t.provider,
 				"path", req.URL.Path,
 				"content_length", req.ContentLength,
@@ -968,13 +969,13 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 	switch state {
 	case StateOpen:
 		fc := t.newFailureContext(req, nil, nil).withKind(KindCircuitOpen)
-		t.log.Warn("circuit: fast-fail per-model breaker open",
+		t.log.Warn(proxylog.ProxyMsg("circuit: fast-fail per-model breaker open"),
 			append(fc.attrs(), "mode", ModeEnforce, "stage", "post_cache_body")...)
 		t.emit("fast_fail", fc)
 		if t.activity != nil {
 			t.activity.RecordFastFail(t.provider, key)
 		}
-		return t.degradedResponse(req), nil
+		return t.degradedResponse(req, false), nil
 	case StateHalfOpen:
 		return t.runProbe(req, key)
 	}
@@ -1082,7 +1083,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 			// otherwise it closes.  (No retry here: retrying a billing cap is
 			// pointless.)
 			if fErr := t.store.ForceOpen(ctx, t.provider, t.cfg.CooldownSeconds); fErr != nil {
-				t.log.Warn("circuit: ForceOpen (insufficient_quota) error",
+				t.log.Warn(proxylog.ProxyMsg("circuit: ForceOpen (insufficient_quota) error"),
 					"provider", t.provider, "error", fErr)
 			} else {
 				if t.activity != nil {
@@ -1090,7 +1091,7 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 				}
 				t.emitOpened(evt, "insufficient_quota")
 			}
-			t.log.Warn("circuit: insufficient_quota — forcing provider open, passing upstream response through",
+			t.log.Warn(proxylog.UpstreamMsg("circuit: insufficient_quota — forcing provider open, passing upstream response through"),
 				append(evt.attrs(),
 					"cooldown_seconds", t.cfg.CooldownSeconds)...)
 			t.emit("insufficient_quota_force_open", evt)
@@ -1200,7 +1201,7 @@ func (t *Transport) handleRateLimitFailure(
 ) (*http.Response, error, bool) {
 	if st.rateLimitAttempts >= t.cfg.MaxRateLimitRetries {
 		evt := t.enrichedFailureContext(req, st.lastResp, st.lastErr, st.lastUpstreamError)
-		t.log.Warn("circuit: rate-limit retries exhausted",
+		t.log.Warn(proxylog.UpstreamMsg("circuit: rate-limit retries exhausted"),
 			append(
 				evt.attrs(),
 				"attempts", st.rateLimitAttempts,
@@ -1212,7 +1213,7 @@ func (t *Transport) handleRateLimitFailure(
 		if fc == FailureClassGlobalRateLimit && !st.firstRateLimitAt.IsZero() {
 			elapsed := time.Since(st.firstRateLimitAt).Seconds()
 			if int(elapsed) >= t.cfg.GlobalRateLimitEscalationWindow {
-				t.log.Warn("circuit: global rate-limit escalated to provider_degraded",
+				t.log.Warn(proxylog.UpstreamMsg("circuit: global rate-limit escalated to provider_degraded"),
 					append(evt.attrs(), "elapsed_seconds", elapsed)...)
 				resp, err := t.handleTerminalFailure(ctx, req, key, st.lastResp, st.lastErr, st.lastUpstreamError)
 				return resp, err, true
@@ -1277,7 +1278,7 @@ func (t *Transport) handleDegradedFailure(
 	}
 
 	if st.transientAttempts >= t.cfg.MaxTransientRetries {
-		t.log.Warn("circuit: transient retries exhausted, recording terminal failure",
+		t.log.Warn(proxylog.UpstreamMsg("circuit: transient retries exhausted, recording terminal failure"),
 			append(t.enrichedFailureContext(req, st.lastResp, st.lastErr, st.lastUpstreamError).attrs(),
 				"attempts", st.transientAttempts)...)
 		respT, errT := t.handleTerminalFailure(ctx, req, key, st.lastResp, st.lastErr, st.lastUpstreamError)
@@ -1381,7 +1382,7 @@ func (t *Transport) runProbe(req *http.Request, key string) (*http.Response, err
 		if t.activity != nil {
 			t.activity.RecordFastFail(t.provider, key)
 		}
-		return t.degradedResponse(req), nil
+		return t.degradedResponse(req, false), nil
 	}
 	if stopLease != nil {
 		defer stopLease()
@@ -1512,7 +1513,7 @@ func (t *Transport) recordProbeFailure(ctx context.Context, req *http.Request, r
 		upstreamDetail = peekUpstreamErrorDetail(t.provider, resp)
 	}
 	evt := t.enrichedFailureContext(req, resp, err, upstreamDetail)
-	t.log.Warn("circuit: probe failed, re-opening circuit",
+	t.log.Warn(proxylog.UpstreamMsg("circuit: probe failed, re-opening circuit"),
 		append(evt.attrs(), "new_state", StateOpen.String())...)
 	t.emit("probe_failed", evt)
 	t.emitOpened(evt, "probe_failed")
@@ -1526,7 +1527,7 @@ func (t *Transport) recordProbeFailure(ctx context.Context, req *http.Request, r
 	drainResponseBody(resp)
 	_ = t.store.RecordProbeFailed(ctx, key)
 	t.reArmRollup(ctx, key)
-	return t.degradedResponse(req), nil
+	return t.degradedResponse(req, true), nil
 }
 
 // handleTerminalFailure records the failure, potentially opens the circuit,
@@ -1542,7 +1543,7 @@ func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request
 	evt := t.enrichedFailureContext(req, lastResp, lastErr, upstreamError)
 	newState, openedNow, err := t.store.RecordTerminalFailure(ctx, key)
 	if err != nil {
-		t.log.Error("circuit: RecordTerminalFailure error", "key", key, "error", err)
+		t.log.Error(proxylog.ProxyMsg("circuit: RecordTerminalFailure error"), "key", key, "error", err)
 	}
 	if openedNow {
 		if t.activity != nil {
@@ -1559,12 +1560,12 @@ func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request
 	)
 
 	if newState == StateOpen {
-		t.log.Warn("circuit: threshold crossed — circuit opened", attrs...)
+		t.log.Warn(proxylog.ProxyMsg("circuit: threshold crossed — circuit opened"), attrs...)
 	}
 
-	t.log.Warn("circuit: terminal failure, returning degraded signal", attrs...)
+	t.log.Warn(proxylog.UpstreamMsg("circuit: terminal failure, returning degraded signal"), attrs...)
 	t.emit("terminal_failure", evt)
-	return t.degradedResponse(req), nil
+	return t.degradedResponse(req, true), nil
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1574,8 +1575,14 @@ func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request
 // degradedResponse returns a synthetic HTTP 503 response whose JSON body
 // contains Config.DegradedSignal so downstream clients can detect
 // proxy-originated provider degradation (see DefaultDegradedSignal).
-func (t *Transport) degradedResponse(req *http.Request) *http.Response {
-	body := buildDegradedBody(t.provider, t.cfg.DegradedSignal)
+// upstream controls whether the body is tagged [UPSTREAM] (observed provider
+// failures) or [PROXY] (proxy fast-fail / circuit-open decisions).
+func (t *Transport) degradedResponse(req *http.Request, upstream bool) *http.Response {
+	body := buildDegradedBody(t.provider, t.cfg.DegradedSignal, upstream)
+	source := proxylog.ErrorSourceProxy
+	if upstream {
+		source = proxylog.ErrorSourceUpstream
+	}
 	return &http.Response{
 		StatusCode: http.StatusServiceUnavailable,
 		Status:     "503 Service Unavailable",
@@ -1583,8 +1590,9 @@ func (t *Transport) degradedResponse(req *http.Request) *http.Response {
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		Header: http.Header{
-			"Content-Type":            []string{"application/json"},
-			"X-Llm-Proxy-Error-Class": []string{string(FailureClassDegraded)},
+			"Content-Type":             []string{"application/json"},
+			"X-Llm-Proxy-Error-Class":  []string{string(FailureClassDegraded)},
+			proxylog.HeaderErrorSource: []string{source},
 		},
 		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
@@ -1595,7 +1603,13 @@ func (t *Transport) degradedResponse(req *http.Request) *http.Response {
 // rateLimitResponse returns a synthetic 429 without the DegradedSignal — the
 // request is throttled but the provider is not considered degraded.
 func (t *Transport) rateLimitResponse(fc FailureClass) *http.Response {
-	body := []byte(`{"error":{"message":"Rate limit exceeded; please retry later.","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
+	body, _ := json.Marshal(map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": proxylog.UpstreamMsg("Rate limit exceeded; please retry later."),
+			"type":    "rate_limit_error",
+			"code":    "rate_limit_exceeded",
+		},
+	})
 	return &http.Response{
 		StatusCode: http.StatusTooManyRequests,
 		Status:     "429 Too Many Requests",
@@ -1603,8 +1617,9 @@ func (t *Transport) rateLimitResponse(fc FailureClass) *http.Response {
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		Header: http.Header{
-			"Content-Type":            []string{"application/json"},
-			"X-Llm-Proxy-Error-Class": []string{string(fc)},
+			"Content-Type":             []string{"application/json"},
+			"X-Llm-Proxy-Error-Class":  []string{string(fc)},
+			proxylog.HeaderErrorSource: []string{proxylog.ErrorSourceUpstream},
 		},
 		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
@@ -1614,12 +1629,17 @@ func (t *Transport) rateLimitResponse(fc FailureClass) *http.Response {
 // buildDegradedBody returns a JSON error body containing the configured
 // degraded signal.  An empty signal falls back to DefaultDegradedSignal so
 // the body is never unmarked.
-func buildDegradedBody(provider, signal string) []byte {
+func buildDegradedBody(provider, signal string, upstream bool) []byte {
 	if signal == "" {
 		signal = DefaultDegradedSignal
 	}
 	msg := fmt.Sprintf("%s Provider %s is currently degraded or unavailable. Please try again later.",
 		signal, provider)
+	if upstream {
+		msg = proxylog.UpstreamMsg(msg)
+	} else {
+		msg = proxylog.ProxyMsg(msg)
+	}
 	body := map[string]interface{}{
 		"error": map[string]interface{}{
 			"message": msg,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -756,6 +756,13 @@ type ModelConfig struct {
 	Aliases     []string `yaml:"aliases,omitempty"` // Alternative model names
 	// Pricing can be a single price, or a list of tiers.
 	Pricing interface{} `yaml:"pricing,omitempty"`
+	// ProjectID scopes upstream requests for this model to a specific provider
+	// project. Currently consumed only by the Bedrock Mantle proxy, which sends
+	// it as the OpenAI-Project header so Mantle resolves data-retention (and
+	// other project-scoped policy) against that project instead of the account
+	// default. Supports ${VAR} env expansion so account-specific ids stay out of
+	// the committed YAML. Empty leaves the account-level policy in force.
+	ProjectID string `yaml:"project_id,omitempty"`
 }
 
 // Pricing represents a simple input/output cost structure.

--- a/internal/cost/datadog.go
+++ b/internal/cost/datadog.go
@@ -1,14 +1,19 @@
 package cost
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"math"
+	"net"
+	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 
 	configPkg "github.com/Instawork/llm-proxy/internal/config"
 )
+
+const dogstatsdResolveTimeout = 2 * time.Second
 
 // DatadogTransportConfig holds configuration for the Datadog transport
 type DatadogTransportConfig struct {
@@ -49,12 +54,17 @@ func NewDatadogTransport(cfg DatadogTransportConfig) (*DatadogTransport, error) 
 		logger = slog.Default()
 	}
 
-	// Create DogStatsD client
-	addr := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
+	// Create DogStatsD client. Resolve with a bounded timeout so a missing
+	// agent hostname cannot block proxy startup on slow/broken DNS.
+	addr, err := resolveDogstatsdAddr(cfg.Host, cfg.Port)
+	if err != nil {
+		return nil, err
+	}
 	client, err := statsd.New(
 		addr,
 		statsd.WithNamespace(cfg.Namespace),
 		statsd.WithTags(cfg.Tags),
+		statsd.WithoutTelemetry(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DogStatsD client: %w", err)
@@ -68,6 +78,28 @@ func NewDatadogTransport(cfg DatadogTransportConfig) (*DatadogTransport, error) 
 	}
 
 	return transport, nil
+}
+
+func resolveDogstatsdAddr(host, port string) (string, error) {
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "8125"
+	}
+	if net.ParseIP(host) != nil {
+		return net.JoinHostPort(host, port), nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), dogstatsdResolveTimeout)
+	defer cancel()
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+	if err != nil {
+		return "", fmt.Errorf("resolve DogStatsD host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return "", fmt.Errorf("resolve DogStatsD host %q: no addresses", host)
+	}
+	return net.JoinHostPort(ips[0].String(), port), nil
 }
 
 // FromConfig creates a DatadogTransport from configuration

--- a/internal/coststats/stats.go
+++ b/internal/coststats/stats.go
@@ -5,13 +5,13 @@ package coststats
 import (
 	"context"
 	"fmt"
-	"log"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/adminrollup"
 	"github.com/Instawork/llm-proxy/internal/history"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // MaxRecentEvents bounds the recent-requests ring buffer.
@@ -260,7 +260,7 @@ func (r *Recorder) applyMonthlyKeySpendFromDelta(ctx context.Context, delta admi
 			continue
 		}
 		if err := r.ApplyFleetMonthlyKeySpend(ctx, adminrollup.MetricCost, month, member, spendUSD); err != nil {
-			log.Printf("coststats: apply monthly key spend failed key=%s spend_usd=%f error=%v", member, spendUSD, err)
+			proxylog.Proxy("coststats: apply monthly key spend failed key=%s spend_usd=%f error=%v", member, spendUSD, err)
 		}
 	}
 }
@@ -828,7 +828,7 @@ func (r *Recorder) AdjustKeyReservation(ctx context.Context, keyID string, delta
 	}
 	today := time.Now().UTC().Format("2006-01-02")
 	if err := r.AdjustFleetKeyReservation(ctx, adminrollup.MetricCost, today, keyID, deltaUSD); err != nil {
-		log.Printf("coststats: adjust reservation failed key=%s delta_usd=%f error=%v", keyID, deltaUSD, err)
+		proxylog.Proxy("coststats: adjust reservation failed key=%s delta_usd=%f error=%v", keyID, deltaUSD, err)
 	}
 }
 
@@ -893,7 +893,7 @@ func (r *Recorder) AdjustKeyMonthlyReservation(ctx context.Context, keyID string
 	}
 	month := time.Now().UTC().Format("2006-01")
 	if err := r.AdjustFleetKeyMonthlyReservation(ctx, adminrollup.MetricCost, month, keyID, deltaUSD); err != nil {
-		log.Printf("coststats: adjust monthly reservation failed key=%s delta_usd=%f error=%v", keyID, deltaUSD, err)
+		proxylog.Proxy("coststats: adjust monthly reservation failed key=%s delta_usd=%f error=%v", keyID, deltaUSD, err)
 	}
 }
 

--- a/internal/middleware/apikey_validation.go
+++ b/internal/middleware/apikey_validation.go
@@ -3,12 +3,12 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 type proxyKeyLookup interface {
@@ -34,10 +34,8 @@ func APIKeyValidationMiddleware(providerManager *providers.ProviderManager, keyS
 			provider := GetProviderFromRequest(providerManager, r)
 			if provider == nil {
 				if isProviderRoute(r.URL.Path) {
-					log.Printf("❌ API key validation: provider route %q has no registered provider", r.URL.Path)
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusBadGateway)
-					fmt.Fprintf(w, `{"error": "Provider not configured for this route"}`)
+					proxylog.Proxy("API key validation: provider route %q has no registered provider", r.URL.Path)
+					proxylog.WriteProxyJSONError(w, http.StatusBadGateway, "Provider not configured for this route")
 					return
 				}
 				next.ServeHTTP(w, r)
@@ -51,43 +49,33 @@ func APIKeyValidationMiddleware(providerManager *providers.ProviderManager, keyS
 
 				if inboundKey != "" && !apikeys.HasKeyPrefix(inboundKey) {
 					if !byoKeysEnabled {
-						log.Printf("❌ BYO keys disabled for provider %s", provider.GetName())
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusForbidden)
-						fmt.Fprintf(w, `{"error": "Bring-your-own provider keys are not accepted; use a proxy key"}`)
+						proxylog.Proxy("BYO keys disabled for provider %s", provider.GetName())
+						proxylog.WriteProxyJSONError(w, http.StatusForbidden, "Bring-your-own provider keys are not accepted; use a proxy key")
 						return
 					}
 					checker, ok := keyStore.(byoBanChecker)
 					if !ok {
-						log.Printf("❌ BYO ban lookup unavailable: key store does not implement ban checker")
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusInternalServerError)
-						fmt.Fprintf(w, `{"error": "Internal server error"}`)
+						proxylog.Proxy("BYO ban lookup unavailable: key store does not implement ban checker")
+						proxylog.WriteProxyJSONError(w, http.StatusInternalServerError, "Internal server error")
 						return
 					}
 					hash := apikeys.CredentialHashSuffix(inboundKey)
 					banned, err := checker.IsBYOCredentialBanned(r.Context(), provider.GetName(), hash)
 					if err != nil {
-						log.Printf("❌ BYO ban lookup failed for %s: %v", provider.GetName(), err)
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusInternalServerError)
-						fmt.Fprintf(w, `{"error": "Internal server error"}`)
+						proxylog.Proxy("BYO ban lookup failed for %s: %v", provider.GetName(), err)
+						proxylog.WriteProxyJSONError(w, http.StatusInternalServerError, "Internal server error")
 						return
 					}
 					if banned {
-						log.Printf("❌ BYO credential banned for provider %s", provider.GetName())
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusForbidden)
-						fmt.Fprintf(w, `{"error": "API key is banned"}`)
+						proxylog.Proxy("BYO credential banned for provider %s", provider.GetName())
+						proxylog.WriteProxyJSONError(w, http.StatusForbidden, "API key is banned")
 						return
 					}
 				}
 
 				if err := provider.ValidateAPIKey(r, keyStore); err != nil {
-					log.Printf("❌ API key validation failed for %s: %v", provider.GetName(), err)
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusUnauthorized)
-					fmt.Fprintf(w, `{"error": "Invalid API key: %s"}`, err.Error())
+					proxylog.Proxy("API key validation failed for %s: %v", provider.GetName(), err)
+					proxylog.WriteProxyJSONError(w, http.StatusUnauthorized, fmt.Sprintf("Invalid API key: %s", err.Error()))
 					return
 				}
 
@@ -97,10 +85,8 @@ func APIKeyValidationMiddleware(providerManager *providers.ProviderManager, keyS
 						r = r.WithContext(apikeys.WithContext(r.Context(), record))
 						proxyKeyAttached = true
 						if err := apikeys.EnforcePIIOffBedrockProvider(globalPIIEnabled, record); err != nil {
-							log.Printf("❌ PII-off Bedrock policy violation for %s: %v", provider.GetName(), err)
-							w.Header().Set("Content-Type", "application/json")
-							w.WriteHeader(http.StatusForbidden)
-							fmt.Fprintf(w, `{"error": "%s"}`, err.Error())
+							proxylog.Proxy("PII-off Bedrock policy violation for %s: %v", provider.GetName(), err)
+							proxylog.WriteProxyJSONError(w, http.StatusForbidden, err.Error())
 							return
 						}
 					}

--- a/internal/middleware/client_gzip.go
+++ b/internal/middleware/client_gzip.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 var errClientGzipWriteAfterFinish = errors.New("client gzip: write after finish")
@@ -34,11 +35,11 @@ func ClientGzipMiddleware(providerManager *providers.ProviderManager) func(http.
 			gw := &clientGzipResponseWriter{ResponseWriter: w}
 			next.ServeHTTP(gw, r)
 			if err := gw.finish(); err != nil {
-				slog.Error("client_gzip: failed to compress response",
+				proxylog.SlogProxy(slog.Default(), slog.LevelError, "client_gzip: failed to compress response",
 					slog.String("error", err.Error()),
 					slog.String("path", r.URL.Path))
 				if !gw.headerSent {
-					http.Error(w, "response compression failed", http.StatusInternalServerError)
+					proxylog.ProxyHTTPError(w, "response compression failed", http.StatusInternalServerError)
 				}
 			}
 		})

--- a/internal/middleware/cost_limit.go
+++ b/internal/middleware/cost_limit.go
@@ -2,8 +2,6 @@ package middleware
 
 import (
 	"context"
-	"encoding/json"
-	"log"
 	"math"
 	"net/http"
 	"strconv"
@@ -11,6 +9,7 @@ import (
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 const (
@@ -288,7 +287,7 @@ func enforceReadOnly(
 				writeCostDegraded(w, prov, rec, rec.DailyCostLimit)
 				return
 			}
-			log.Printf("costlimit: WARN fleet spend read degraded, enforcing per-instance only provider=%s key_prefix=%s limit_cents=%d",
+			proxylog.Proxy("costlimit: fleet spend read degraded, enforcing per-instance only provider=%s key_prefix=%s limit_cents=%d",
 				prov.GetName(), prefix(rec.PK), rec.DailyCostLimit)
 		}
 		spendCents := int64(math.Ceil(spendUSD * 100))
@@ -319,7 +318,7 @@ func enforceReadOnly(
 				writeCostDegraded(w, prov, rec, rec.MonthlyCostLimit)
 				return
 			}
-			log.Printf("costlimit: WARN fleet monthly spend read degraded, enforcing per-instance only provider=%s key_prefix=%s limit_cents=%d",
+			proxylog.Proxy("costlimit: fleet monthly spend read degraded, enforcing per-instance only provider=%s key_prefix=%s limit_cents=%d",
 				prov.GetName(), prefix(rec.PK), rec.MonthlyCostLimit)
 		}
 		spendCents := int64(math.Ceil(spendUSD * 100))
@@ -334,32 +333,24 @@ func enforceReadOnly(
 
 func writeCostDegraded(w http.ResponseWriter, prov providers.Provider, rec *apikeys.APIKey, limitCents int64) {
 	w.Header().Set(costLimitReasonHeader, costLimitDegraded)
-	log.Printf("costlimit: fail-closed (fleet spend read degraded) provider=%s key_prefix=%s limit_cents=%d",
+	proxylog.Proxy("costlimit: fail-closed (fleet spend read degraded) provider=%s key_prefix=%s limit_cents=%d",
 		prov.GetName(), prefix(rec.PK), limitCents)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusServiceUnavailable)
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"error": "cost limit temporarily unverifiable",
-	})
+	proxylog.WriteProxyJSONError(w, http.StatusServiceUnavailable, "cost limit temporarily unverifiable")
 }
 
 func writeCostBlocked(w http.ResponseWriter, prov providers.Provider, rec *apikeys.APIKey, limitCents int64, reason, msg string) {
 	w.Header().Set(costLimitReasonHeader, reason)
 	w.Header().Set(costLimitCentsHeader, strconv.FormatInt(limitCents, 10))
-	log.Printf("costlimit: block (reserved) provider=%s key_prefix=%s limit_cents=%d reason=%s",
+	proxylog.Proxy("costlimit: block (reserved) provider=%s key_prefix=%s limit_cents=%d reason=%s",
 		prov.GetName(), prefix(rec.PK), limitCents, reason)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusPaymentRequired)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	proxylog.WriteProxyJSONError(w, http.StatusPaymentRequired, msg)
 }
 
 func writeCostBlockedWithSpend(w http.ResponseWriter, prov providers.Provider, rec *apikeys.APIKey, limitCents, spendCents int64, reason, msg string) {
 	w.Header().Set(costLimitReasonHeader, reason)
 	w.Header().Set(costLimitCentsHeader, strconv.FormatInt(limitCents, 10))
 	w.Header().Set(costSpendCentsHeader, strconv.FormatInt(spendCents, 10))
-	log.Printf("costlimit: block provider=%s key_prefix=%s spend_cents=%d limit_cents=%d reason=%s",
+	proxylog.Proxy("costlimit: block provider=%s key_prefix=%s spend_cents=%d limit_cents=%d reason=%s",
 		prov.GetName(), prefix(rec.PK), spendCents, limitCents, reason)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusPaymentRequired)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	proxylog.WriteProxyJSONError(w, http.StatusPaymentRequired, msg)
 }

--- a/internal/middleware/idgate.go
+++ b/internal/middleware/idgate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/idgatestats"
 	"github.com/Instawork/llm-proxy/internal/observability"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 )
 
@@ -96,7 +97,7 @@ func IDGateMiddleware(ocrClient OCRTextExtractor, analyzer IDSpanAnalyzer, cfg I
 
 			body, oversize, err := readBoundedBody(r, maxBodyBytes)
 			if err != nil {
-				logger.Warn("id_gate: read body failed",
+				logger.Warn(proxylog.ProxyMsg("id_gate: read body failed"),
 					slog.String("path", r.URL.Path),
 					slog.String("error", err.Error()))
 				next.ServeHTTP(w, r)
@@ -112,7 +113,7 @@ func IDGateMiddleware(ocrClient OCRTextExtractor, analyzer IDSpanAnalyzer, cfg I
 
 			images, err := extractImagesFromBody(body, maxImageBytes)
 			if err != nil {
-				logger.Warn("id_gate: parse body failed; passing through",
+				logger.Warn(proxylog.ProxyMsg("id_gate: parse body failed; passing through"),
 					slog.String("path", r.URL.Path),
 					slog.String("error", err.Error()))
 				next.ServeHTTP(w, r)
@@ -189,7 +190,7 @@ func IDGateMiddleware(ocrClient OCRTextExtractor, analyzer IDSpanAnalyzer, cfg I
 			var haveErr bool
 			for res := range results {
 				if res.blocked {
-					logger.Warn("id_gate: blocked government identity document",
+					logger.Warn(proxylog.ProxyMsg("id_gate: blocked government identity document"),
 						slog.String("path", r.URL.Path),
 						slog.String("provider", provider),
 						slog.Int("image_index", res.index),
@@ -202,7 +203,7 @@ func IDGateMiddleware(ocrClient OCRTextExtractor, analyzer IDSpanAnalyzer, cfg I
 							provider, keyID, res.entityType, res.score, res.index, len(images), time.Since(gateStart),
 						)
 					}
-					http.Error(w, idGateBlockMessage, http.StatusUnprocessableEntity)
+					proxylog.ProxyHTTPError(w, idGateBlockMessage, http.StatusUnprocessableEntity)
 					return
 				}
 				if res.err != nil && !haveErr {
@@ -213,7 +214,7 @@ func IDGateMiddleware(ocrClient OCRTextExtractor, analyzer IDSpanAnalyzer, cfg I
 
 			if haveErr {
 				if cfg.FailClosed {
-					logger.Error("id_gate: scan failed; FailClosed -> 503",
+					logger.Error(proxylog.ProxyMsg("id_gate: scan failed; FailClosed -> 503"),
 						slog.String("path", r.URL.Path),
 						slog.String("provider", provider),
 						slog.Int("image_index", firstErr.index),
@@ -224,10 +225,10 @@ func IDGateMiddleware(ocrClient OCRTextExtractor, analyzer IDSpanAnalyzer, cfg I
 					if cfg.Recorder != nil {
 						cfg.Recorder.RecordScanFailed(provider, keyID, firstErr.stage, true, len(images), time.Since(gateStart))
 					}
-					http.Error(w, "service temporarily unavailable", http.StatusServiceUnavailable)
+					proxylog.ProxyHTTPError(w, "service temporarily unavailable", http.StatusServiceUnavailable)
 					return
 				}
-				logger.Warn("id_gate: scan failed; passing through (fail_open)",
+				logger.Warn(proxylog.ProxyMsg("id_gate: scan failed; passing through (fail_open)"),
 					slog.String("path", r.URL.Path),
 					slog.String("provider", provider),
 					slog.Int("image_index", firstErr.index),

--- a/internal/middleware/idgate_test.go
+++ b/internal/middleware/idgate_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 )
 
@@ -58,7 +59,7 @@ func TestIDGateMiddleware_BlocksGovID(t *testing.T) {
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422", rec.Code)
 	}
-	if rec.Body.String() != idGateBlockMessage+"\n" {
+	if rec.Body.String() != proxylog.ProxyMsg(idGateBlockMessage)+"\n" {
 		t.Fatalf("body = %q", rec.Body.String())
 	}
 	if cap.reqSeen != nil {

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Instawork/llm-proxy/internal/circuit"
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // isProviderRoute checks if the request is for a provider route. Bedrock is
@@ -103,7 +104,7 @@ func LoggingMiddleware(providerManager *providers.ProviderManager) func(http.Han
 					reason = "Unknown reason"
 				}
 
-				slog.Log(r.Context(), level, "Non-tracked provider route",
+				slog.Log(r.Context(), level, proxylog.ProxyMsg("Non-tracked provider route"),
 					slog.String("method", r.Method),
 					slog.String("path", r.URL.Path),
 					slog.String("provider", providerName),
@@ -142,7 +143,7 @@ func LoggingMiddleware(providerManager *providers.ProviderManager) func(http.Han
 						slog.String("path", r.URL.Path),
 						slog.Bool("cost_tracked", true))
 				} else {
-					slog.Warn("Provider route not tracked",
+					slog.Warn(proxylog.ProxyMsg("Provider route not tracked"),
 						slog.String("method", r.Method),
 						slog.String("path", r.URL.Path),
 						slog.Bool("cost_tracked", false))

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -21,6 +21,7 @@ func isProviderRoute(path string) bool {
 		strings.HasPrefix(path, "/anthropic/") ||
 		strings.HasPrefix(path, "/gemini/") ||
 		strings.HasPrefix(path, "/bedrock/") ||
+		strings.HasPrefix(path, "/bedrock-mantle/") ||
 		strings.HasPrefix(path, "/model/") ||
 		strings.HasPrefix(path, "/v1/models/gemini") ||
 		strings.HasPrefix(path, "/v1beta/models/gemini")
@@ -37,6 +38,7 @@ func isAPIEndpoint(path string) bool {
 		strings.Contains(path, ":streamGenerateContent") ||
 		strings.Contains(path, "/converse") ||
 		strings.Contains(path, "/converse-stream") ||
+		strings.Contains(path, "/responses") ||
 		strings.Contains(path, "/invoke") ||
 		strings.Contains(path, "/invoke-with-response-stream")
 }
@@ -47,7 +49,7 @@ func isAPIEndpoint(path string) bool {
 func getProviderFromPath(path string) string {
 	name := circuit.ProviderFromPath(path)
 	switch name {
-	case "openai", "anthropic", "gemini", "bedrock":
+	case "openai", "anthropic", "gemini", "bedrock", "bedrock-mantle":
 		return name
 	default:
 		return ""

--- a/internal/middleware/model_status.go
+++ b/internal/middleware/model_status.go
@@ -1,8 +1,6 @@
 package middleware
 
 import (
-	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -10,6 +8,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // ModelStatusMiddleware short-circuits requests to retired models and records
@@ -44,11 +43,9 @@ func ModelStatusMiddleware(
 				recorder.RecordRetired(providerName, model)
 				emitModelMetric(metrics, "model.retired_call", providerName, model)
 				if err := providers.WriteRetiredModelResponse(w, provider, model, entry); err != nil {
-					log.Printf("model status: failed to encode retired response: %v", err)
-					w.Header().Set("Content-Type", "application/json")
+					proxylog.Proxy("model status: failed to encode retired response: %v", err)
 					w.Header().Set(providers.HeaderModelRetired, "model_retired")
-					w.WriteHeader(http.StatusNotFound)
-					fmt.Fprintf(w, `{"error":"model retired"}`)
+					proxylog.WriteProxyJSONError(w, http.StatusNotFound, "model retired")
 				}
 				return
 			}
@@ -59,7 +56,7 @@ func ModelStatusMiddleware(
 				emitModelMetric(metrics, "model.deprecated_call", providerName, model)
 			} else if modelCfg == nil {
 				recorder.RecordUnknown(providerName, model)
-				log.Printf("model status: unrecognized model %q for provider %q", model, providerName)
+				proxylog.Proxy("model status: unrecognized model %q for provider %q", model, providerName)
 				emitModelMetric(metrics, "model.unknown_call", providerName, "__unknown__")
 			}
 

--- a/internal/middleware/model_status_test.go
+++ b/internal/middleware/model_status_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 func TestModelStatusMiddleware_RetiredModelShortCircuits(t *testing.T) {
@@ -48,6 +49,9 @@ func TestModelStatusMiddleware_RetiredModelShortCircuits(t *testing.T) {
 	}
 	if got := rec.Header().Get(providers.HeaderModelRetired); got != "model_retired" {
 		t.Fatalf("header=%q", got)
+	}
+	if got := rec.Header().Get(proxylog.HeaderErrorSource); got != proxylog.ErrorSourceProxy {
+		t.Fatalf("error_source=%q", got)
 	}
 
 	var body map[string]any

--- a/internal/middleware/pii_redact.go
+++ b/internal/middleware/pii_redact.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/observability"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 )
 
@@ -210,7 +211,7 @@ func PIIRedactMiddleware(redactor PIIRedactor, cfg PIIRedactConfig) func(http.Ha
 
 			body, oversize, err := readBoundedBody(r, maxBytes)
 			if err != nil {
-				logger.Warn("pii_redact: read body failed",
+				logger.Warn(proxylog.ProxyMsg("pii_redact: read body failed"),
 					slog.String("path", r.URL.Path),
 					slog.String("error", err.Error()))
 				next.ServeHTTP(w, r)
@@ -223,7 +224,7 @@ func PIIRedactMiddleware(redactor PIIRedactor, cfg PIIRedactConfig) func(http.Ha
 			r.ContentLength = int64(len(body))
 
 			if oversize {
-				logger.Warn("pii_redact: body exceeds max_body_bytes",
+				logger.Warn(proxylog.ProxyMsg("pii_redact: body exceeds max_body_bytes"),
 					slog.String("path", r.URL.Path),
 					slog.String("provider", getProviderFromPath(r.URL.Path)),
 					slog.Int("body_bytes", len(body)),
@@ -232,7 +233,7 @@ func PIIRedactMiddleware(redactor PIIRedactor, cfg PIIRedactConfig) func(http.Ha
 				ctx := attachPIISummary(r.Context(), newPIISummary(PIIOutcomeOversize, nil))
 				if cfg.FailClosed {
 					writePIIResponseHeadersPartial(w, ctx)
-					http.Error(w, "request body too large for PII redaction", http.StatusServiceUnavailable)
+					proxylog.ProxyHTTPError(w, "request body too large for PII redaction", http.StatusServiceUnavailable)
 					return
 				}
 				writePIIResponseHeadersPartial(w, ctx)
@@ -295,7 +296,7 @@ func PIIRedactMiddleware(redactor PIIRedactor, cfg PIIRedactConfig) func(http.Ha
 
 			if redactErr != nil {
 				if cfg.FailClosed {
-					logger.Error("pii_redact: redactor failed; FailClosed -> 503",
+					logger.Error(proxylog.ProxyMsg("pii_redact: redactor failed; FailClosed -> 503"),
 						slog.String("path", r.URL.Path),
 						slog.String("provider", provider),
 						slog.Int("body_bytes", len(body)),
@@ -306,10 +307,10 @@ func PIIRedactMiddleware(redactor PIIRedactor, cfg PIIRedactConfig) func(http.Ha
 					recordPII(cfg.Recorder, cfg.Metrics, provider, keyID, nil, len(body), redactDuration, piiOutcomeFailClosed)
 					ctx := attachPIISummary(r.Context(), newPIISummary(PIIOutcomeFailClosed, nil))
 					writePIIResponseHeadersPartial(w, ctx)
-					http.Error(w, "service temporarily unavailable", http.StatusServiceUnavailable)
+					proxylog.ProxyHTTPError(w, "service temporarily unavailable", http.StatusServiceUnavailable)
 					return
 				}
-				logger.Warn("pii_redact: redactor failed; passing through unredacted (fail_open)",
+				logger.Warn(proxylog.ProxyMsg("pii_redact: redactor failed; passing through unredacted (fail_open)"),
 					slog.String("path", r.URL.Path),
 					slog.String("provider", provider),
 					slog.Int("body_bytes", len(body)),

--- a/internal/middleware/pii_redact_test.go
+++ b/internal/middleware/pii_redact_test.go
@@ -373,7 +373,7 @@ func TestPIIRedactMiddleware_OversizeBodyFailOpenPassthrough(t *testing.T) {
 	// on. If any go missing, dashboards silently lose signal.
 	logOut := logBuf.String()
 	for _, want := range []string{
-		`"msg":"pii_redact: body exceeds max_body_bytes"`,
+		`"msg":"[PROXY] pii_redact: body exceeds max_body_bytes"`,
 		`"provider":"openai"`,
 		`"body_bytes":5000`,
 		`"max_body_bytes":1024`,

--- a/internal/middleware/pii_response.go
+++ b/internal/middleware/pii_response.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 )
 
@@ -51,12 +52,12 @@ func PIIResponseRestoreMiddleware(providerManager *providers.ProviderManager) fu
 			finalizePIIRestored(r.Context(), reg)
 			finalizePIILeaked(r.Context(), reg, restoreWriter.emitted.String())
 			if err := writePIIResponseTrailers(deferWriter, r.Context()); err != nil {
-				slog.Warn("pii_restore: failed to set PII trailers",
+				proxylog.SlogProxy(slog.Default(), slog.LevelWarn, "pii_restore: failed to set PII trailers",
 					slog.String("error", err.Error()),
 					slog.String("path", r.URL.Path))
 			}
 			if h := piiSummaryHolderFromContext(r.Context()); h != nil && h.Leaked > 0 {
-				slog.Warn("pii_restore: MASK placeholders leaked in response",
+				proxylog.SlogProxy(slog.Default(), slog.LevelWarn, "pii_restore: MASK placeholders leaked in response",
 					slog.Int("leaked", h.Leaked),
 					slog.Int("restored", h.Restored),
 					slog.Bool("streaming", isStreaming),
@@ -99,7 +100,7 @@ func (pw *piiRestoreResponseWriter) Write(b []byte) (int, error) {
 	if !pw.streaming {
 		plain, _, err := decompressPIIResponseIfGzip(b)
 		if err != nil {
-			slog.Warn("pii_restore: gzip decompress failed; passing through without placeholder restore",
+			proxylog.SlogProxy(slog.Default(), slog.LevelWarn, "pii_restore: gzip decompress failed; passing through without placeholder restore",
 				slog.String("error", err.Error()))
 			return pw.writeRestored(b)
 		}

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/Instawork/llm-proxy/internal/ratelimitstats"
 )
@@ -57,7 +58,7 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 				// request — that is strictly worse than briefly not enforcing a
 				// limit. This mirrors the circuit breaker, which also fails open
 				// (GetState returns closed) when its store is unreachable.
-				log.Printf("ratelimit: backend error, failing open: %v", err)
+				proxylog.Proxy("ratelimit: backend error, failing open: %v", err)
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -90,7 +91,7 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 				}
 				log.Printf("ratelimit: throttle provider=%s model=%s user=%s key_prefix=%s reason=%s",
 					prov.GetName(), model, userID, prefix(apiKey), res.Reason)
-				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+				proxylog.ProxyHTTPError(w, "rate limit exceeded", http.StatusTooManyRequests)
 				return
 			}
 
@@ -113,7 +114,7 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 			if actualInput > 0 {
 				delta := actualInput - estTokens
 				if err := limiter.Adjust(r.Context(), reservationID, scope, delta, time.Now()); err != nil {
-					log.Printf("ratelimit: adjust error: %v", err)
+					proxylog.Proxy("ratelimit: adjust error: %v", err)
 				} else if delta != 0 {
 					log.Printf("ratelimit: adjust (input) provider=%s model=%s user=%s key_prefix=%s delta_input_tokens=%d",
 						prov.GetName(), model, userID, prefix(apiKey), delta)
@@ -128,7 +129,7 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 				// input-token header is a streaming/parsed success that the
 				// Adjust branch above (or estimation) already accounts for.
 				if err := limiter.Cancel(r.Context(), reservationID, scope, estTokens, time.Now()); err != nil {
-					log.Printf("ratelimit: cancel error: %v", err)
+					proxylog.Proxy("ratelimit: cancel error: %v", err)
 				} else {
 					log.Printf("ratelimit: cancel (upstream %d) provider=%s model=%s user=%s key_prefix=%s est_tokens=%d",
 						sw.status, prov.GetName(), model, userID, prefix(apiKey), estTokens)

--- a/internal/middleware/redact_ratelimit.go
+++ b/internal/middleware/redact_ratelimit.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // RedactRateLimitMiddleware enforces per-API-key request limits on POST /redact.
@@ -27,7 +29,7 @@ func RedactRateLimitMiddleware(requestsPerMinute int) func(http.Handler) http.Ha
 			}
 			if !lim.allow(key, time.Now()) {
 				w.Header().Set("Retry-After", "60")
-				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+				proxylog.ProxyHTTPError(w, "rate limit exceeded", http.StatusTooManyRequests)
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/internal/middleware/streaming.go
+++ b/internal/middleware/streaming.go
@@ -2,10 +2,10 @@ package middleware
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // StreamingMiddleware ensures proper handling of streaming responses
@@ -24,7 +24,7 @@ func StreamingMiddleware(providerManager *providers.ProviderManager) func(http.H
 					}
 					next.ServeHTTP(streamingWriter, r)
 				} else {
-					log.Printf("Warning: ResponseWriter does not support flushing for streaming request")
+					proxylog.Proxy("streaming: ResponseWriter does not support flushing")
 					next.ServeHTTP(w, r)
 				}
 			} else {

--- a/internal/middleware/testmode.go
+++ b/internal/middleware/testmode.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/Instawork/llm-proxy/internal/circuit"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // knownProviders is the allowlist writeDegradedResponse uses to decide
@@ -25,10 +26,10 @@ import (
 // /bedrock/... or /model/... path, we want the synthetic 503 body to
 // carry "bedrock" instead of being silently coerced to "unknown".
 var knownProviders = map[string]struct{}{
-	"openai":    {},
-	"anthropic": {},
-	"gemini":    {},
-	"bedrock":   {},
+	"openai":         {},
+	"anthropic":      {},
+	"gemini":         {},
+	"bedrock":        {},
 	"bedrock-mantle": {},
 }
 
@@ -123,6 +124,7 @@ func providerFromRequest(r *http.Request) string {
 func writeDegradedResponse(w http.ResponseWriter, provider, signal string) {
 	msg := fmt.Sprintf("%s Provider %s is currently degraded or unavailable. Please try again later.",
 		signal, safeProviderName(provider))
+	msg = proxylog.ProxyMsg(msg)
 
 	body := map[string]interface{}{
 		"error": map[string]interface{}{
@@ -135,6 +137,7 @@ func writeDegradedResponse(w http.ResponseWriter, provider, signal string) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Llm-Proxy-Error-Class", string(circuit.FailureClassDegraded))
+	w.Header().Set(proxylog.HeaderErrorSource, proxylog.ErrorSourceProxy)
 	w.WriteHeader(http.StatusServiceUnavailable)
 	w.Write(b) //nolint:errcheck
 }

--- a/internal/middleware/testmode.go
+++ b/internal/middleware/testmode.go
@@ -29,6 +29,7 @@ var knownProviders = map[string]struct{}{
 	"anthropic": {},
 	"gemini":    {},
 	"bedrock":   {},
+	"bedrock-mantle": {},
 }
 
 // safeProviderName returns provider verbatim when it appears in

--- a/internal/middleware/token_parsing.go
+++ b/internal/middleware/token_parsing.go
@@ -33,6 +33,7 @@ type MetadataCallback func(r *http.Request, metadata *providers.LLMResponseMetad
 //   - /v1/models/gemini..., /v1beta/models/gemini...  Gemini compatibility
 //   - /bedrock/...                    Bedrock native (with /bedrock prefix)
 //   - /model/...                      Bedrock SigV4 passthrough
+//   - /bedrock-mantle/...             Bedrock Mantle OpenAI compatibility API
 func GetProviderFromRequest(providerManager *providers.ProviderManager, req *http.Request) providers.Provider {
 	path := req.URL.Path
 
@@ -41,7 +42,7 @@ func GetProviderFromRequest(providerManager *providers.ProviderManager, req *htt
 		if len(parts) >= 4 { // ["", "meta", "userID", "provider", ...]
 			providerName := parts[3]
 			switch providerName {
-			case "openai", "anthropic", "gemini", "bedrock":
+			case "openai", "anthropic", "gemini", "bedrock", "bedrock-mantle":
 				return providerManager.GetProvider(providerName)
 			}
 		}
@@ -58,6 +59,8 @@ func GetProviderFromRequest(providerManager *providers.ProviderManager, req *htt
 		return providerManager.GetProvider("gemini")
 	case strings.HasPrefix(path, "/bedrock/"), strings.HasPrefix(path, "/model/"):
 		return providerManager.GetProvider("bedrock")
+	case strings.HasPrefix(path, "/bedrock-mantle/"):
+		return providerManager.GetProvider("bedrock-mantle")
 	}
 
 	return nil
@@ -90,7 +93,8 @@ func TokenParsingMiddleware(providerManager *providers.ProviderManager, callback
 				strings.Contains(r.URL.Path, "/messages") ||
 				strings.Contains(r.URL.Path, ":generateContent") ||
 				strings.Contains(r.URL.Path, ":streamGenerateContent") ||
-				strings.Contains(r.URL.Path, "/converse")
+				strings.Contains(r.URL.Path, "/converse") ||
+				strings.Contains(r.URL.Path, "/responses")
 
 			if provider == nil || !isAPIEndpoint {
 				return

--- a/internal/middleware/token_parsing.go
+++ b/internal/middleware/token_parsing.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 )
 
@@ -106,7 +107,7 @@ func TokenParsingMiddleware(providerManager *providers.ProviderManager, callback
 			metadata, err := provider.ParseResponseMetadata(bodyReader, isStreaming)
 			if err != nil {
 				if !isStreaming {
-					log.Printf("Warning: failed to parse response metadata for %s: %v", provider.GetName(), err)
+					proxylog.Proxy("failed to parse response metadata for %s: %v", provider.GetName(), err)
 					if captureWriter.body.Len() > 0 {
 						bodyBytes := captureWriter.body.Bytes()
 						// Both branches route through redact.LogPreview so
@@ -259,7 +260,7 @@ func (rc *responseCapture) Write(b []byte) (int, error) {
 		rc.compressedOnce.Do(func() {
 			if len(b) >= 2 && b[0] == 0x1f && b[1] == 0x8b {
 				rc.compressed = true
-				log.Printf("🗜  WARNING upstream still sent gzip despite Accept-Encoding strip (passthrough)")
+				proxylog.Upstream("upstream still sent gzip despite Accept-Encoding strip (passthrough)")
 			}
 		})
 	}

--- a/internal/middleware/token_parsing_helpers_test.go
+++ b/internal/middleware/token_parsing_helpers_test.go
@@ -338,7 +338,7 @@ func TestResponseCapture_FirstChunkGzip_LogsCompressedWarning(t *testing.T) {
 	if !rc.compressed {
 		t.Error("compressed flag must be set on gzip first chunk")
 	}
-	if !strings.Contains(logOut, "WARNING upstream still sent gzip") {
+	if !strings.Contains(logOut, "[UPSTREAM] upstream still sent gzip") {
 		t.Errorf("expected gzip warning; got: %s", logOut)
 	}
 }

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 	"github.com/gorilla/mux"
 )
@@ -77,29 +78,28 @@ func NewAnthropicProxy(opts ...ProxyOptions) *AnthropicProxy {
 
 	// Add error handler with streaming-specific error handling
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		log.Printf("Anthropic proxy error: %v", err)
+		proxylog.Upstream("anthropic reverse proxy transport error: %v", err)
 
 		// For streaming requests, we need to handle errors differently
 		if anthropicProxy.IsStreamingRequest(r) {
 			// If we're in a streaming context, we might have already started writing
 			// the response, so we need to handle this gracefully
-			log.Printf("Error occurred during streaming request")
+			proxylog.Upstream("anthropic streaming transport error: %v", err)
 
 			// Try to write an error in SSE format if possible
 			if w.Header().Get("Content-Type") == "" {
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.Header().Set("Cache-Control", "no-cache")
+				w.Header().Set(proxylog.HeaderErrorSource, proxylog.ErrorSourceUpstream)
 				w.WriteHeader(http.StatusBadGateway)
-				fmt.Fprintf(w, "data: {\"error\": \"Proxy error: %v\"}\n\n", err)
+				fmt.Fprint(w, proxylog.UpstreamSSEDataLine("anthropic transport: %v", err))
 				fmt.Fprintf(w, "data: [DONE]\n\n")
 			} else {
 				// Headers already sent, just log the error
-				log.Printf("Cannot send error response, headers already sent")
+				proxylog.Proxy("anthropic cannot send error response, headers already sent")
 			}
 		} else {
-			// Regular error handling for non-streaming requests
-			w.WriteHeader(http.StatusBadGateway)
-			fmt.Fprintf(w, "Anthropic proxy error: %v", err)
+			proxylog.UpstreamHTTPError(w, fmt.Sprintf("anthropic transport: %v", err), http.StatusBadGateway)
 		}
 	}
 
@@ -141,20 +141,20 @@ func (a *AnthropicProxy) checkStreamingInBody(req *http.Request) bool {
 		// Body was already cached, use GetBody to get a fresh reader
 		bodyReader, err := req.GetBody()
 		if err != nil {
-			log.Printf("Error getting cached request body for streaming check: %v", err)
+			proxylog.Proxy("anthropic streaming check: error getting cached request body: %v", err)
 			return false
 		}
 		defer bodyReader.Close()
 		bodyBytes, err = io.ReadAll(bodyReader)
 		if err != nil {
-			log.Printf("Error reading cached request body for streaming check: %v", err)
+			proxylog.Proxy("anthropic streaming check: error reading cached request body: %v", err)
 			return false
 		}
 	} else {
 		// Read the body for the first time
 		bodyBytes, err = io.ReadAll(req.Body)
 		if err != nil {
-			log.Printf("Error reading request body for streaming check: %v", err)
+			proxylog.Proxy("anthropic streaming check: error reading request body: %v", err)
 			return false
 		}
 
@@ -168,7 +168,7 @@ func (a *AnthropicProxy) checkStreamingInBody(req *http.Request) bool {
 	// Parse the JSON to check for stream field
 	var requestData map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &requestData); err != nil {
-		log.Printf("Error parsing request body JSON for streaming check: %v", err)
+		proxylog.Proxy("anthropic streaming check: error parsing request body JSON: %v", err)
 		return false
 	}
 
@@ -492,7 +492,7 @@ func (a *AnthropicProxy) UserIDFromRequest(req *http.Request) string {
 	// Read request body
 	bodyBytes, err := a.readRequestBodyForUserID(req)
 	if err != nil {
-		log.Printf("Error reading Anthropic request body for user ID extraction: %v", err)
+		proxylog.Proxy("anthropic user ID extraction: error reading request body: %v", err)
 		return ""
 	}
 
@@ -503,7 +503,7 @@ func (a *AnthropicProxy) UserIDFromRequest(req *http.Request) string {
 	// Parse JSON to extract metadata.user_id field
 	var data map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &data); err != nil {
-		log.Printf("Error parsing Anthropic request JSON for user ID extraction: %v", err)
+		proxylog.Proxy("anthropic user ID extraction: error parsing request JSON: %v", err)
 		return ""
 	}
 

--- a/internal/providers/bedrock.go
+++ b/internal/providers/bedrock.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	eventstream "github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
 	"github.com/gorilla/mux"
 )
@@ -133,19 +134,17 @@ func NewBedrockProxy(opts ...ProxyOptions) *BedrockProxy {
 	}
 
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		log.Printf("Bedrock proxy error: %v", err)
+		proxylog.Upstream("bedrock reverse proxy transport error: %v", err)
 		if bedrockProxy.IsStreamingRequest(r) {
 			if w.Header().Get("Content-Type") == "" {
-				// We cannot synthesise a real eventstream frame here without
-				// dragging in the encoder, but the status code and content-
-				// type are enough for clients to detect and fall back.
 				w.Header().Set("Content-Type", bedrockEventStreamMIME)
+				w.Header().Set(proxylog.HeaderErrorSource, proxylog.ErrorSourceUpstream)
 				w.WriteHeader(http.StatusBadGateway)
+				fmt.Fprint(w, proxylog.UpstreamPlain("bedrock transport: %v", err))
 			}
 			return
 		}
-		w.WriteHeader(http.StatusBadGateway)
-		fmt.Fprintf(w, "Bedrock proxy error: %v", err)
+		proxylog.UpstreamHTTPError(w, fmt.Sprintf("bedrock transport: %v", err), http.StatusBadGateway)
 	}
 
 	return bedrockProxy

--- a/internal/providers/bedrock.go
+++ b/internal/providers/bedrock.go
@@ -394,6 +394,7 @@ func (b *BedrockProxy) ValidateAPIKey(req *http.Request, _ APIKeyStore) error {
 // reflect the model dimension when we ever want to read it from the router.
 func (b *BedrockProxy) RegisterExtraRoutes(router *mux.Router) {
 	router.PathPrefix("/bedrock/model/").Handler(b.Proxy()).Methods("POST", "OPTIONS")
+	router.PathPrefix("/model/").Handler(b.Proxy()).Methods("POST", "OPTIONS")
 }
 
 // ExtractRequestModelAndMessages implements Provider.

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -76,6 +76,9 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 		req.Header.Del("X-Amz-Date")
 		req.Header.Del("X-Amz-Content-Sha256")
 		req.Header.Del("X-Amz-Security-Token")
+		// AWS's edge appends the client address to X-Forwarded-For. Do not
+		// include a mutable forwarding header in the SigV4 canonical request.
+		req.Header.Del("X-Forwarded-For")
 		if opt.DisableGzip {
 			req.Header.Del("Accept-Encoding")
 		}
@@ -109,6 +112,9 @@ type sigV4Transport struct {
 }
 
 func (t *sigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// ReverseProxy adds this after Director. AWS may append it at its edge,
+	// invalidating any signature that includes the header.
+	req.Header.Del("X-Forwarded-For")
 	payload, err := readAndRestoreMantleBody(req)
 	if err != nil {
 		return nil, fmt.Errorf("read Bedrock Mantle request body: %w", err)
@@ -154,8 +160,7 @@ func (b *BedrockMantleProxy) IsStreamingRequest(req *http.Request) bool {
 	if req.Method != http.MethodPost || (!strings.Contains(req.URL.Path, "/responses") && !strings.Contains(req.URL.Path, "/completions")) {
 		return false
 	}
-	body, err := readAndRestoreMantleBody(req)
-	return err == nil && bytes.Contains(body, []byte(`"stream":true`))
+	return (&OpenAIProxy{}).checkStreamingInBody(req)
 }
 
 func (b *BedrockMantleProxy) Proxy() http.Handler { return b.proxy }
@@ -175,7 +180,22 @@ func (b *BedrockMantleProxy) GetHealthStatus() map[string]interface{} {
 	}
 }
 
-func (b *BedrockMantleProxy) UserIDFromRequest(_ *http.Request) string { return "" }
+func (b *BedrockMantleProxy) UserIDFromRequest(req *http.Request) string {
+	if req == nil || req.Method != http.MethodPost {
+		return ""
+	}
+	body, err := readAndRestoreMantleBody(req)
+	if err != nil {
+		return ""
+	}
+	var payload struct {
+		User string `json:"user"`
+	}
+	if json.Unmarshal(body, &payload) != nil {
+		return ""
+	}
+	return payload.User
+}
 
 // ValidateAPIKey accepts only normal llm-proxy keys registered for Mantle.
 // The resolved provider credential is deliberately discarded: Mantle is
@@ -247,12 +267,26 @@ func (b *BedrockMantleProxy) ExtractRequestModelAndMessages(req *http.Request) (
 }
 
 func (b *BedrockMantleProxy) ParseResponseMetadata(responseBody io.Reader, isStreaming bool) (*LLMResponseMetadata, error) {
-	if isStreaming {
-		return parseMantleStream(responseBody)
+	decompressedReader, err := DecompressResponseIfNeeded(responseBody)
+	if err != nil {
+		return nil, fmt.Errorf("decompress Bedrock Mantle response: %w", err)
 	}
-	body, err := io.ReadAll(responseBody)
+	if isStreaming {
+		return parseMantleStream(decompressedReader)
+	}
+	body, err := io.ReadAll(decompressedReader)
 	if err != nil {
 		return nil, err
+	}
+	var responseType struct {
+		Choices json.RawMessage `json:"choices"`
+	}
+	if json.Unmarshal(body, &responseType) == nil && responseType.Choices != nil {
+		metadata, err := (&OpenAIProxy{}).ParseResponseMetadata(bytes.NewReader(body), false)
+		if metadata != nil {
+			metadata.Provider = bedrockMantleName
+		}
+		return metadata, err
 	}
 	return parseMantleMetadata(body, false)
 }
@@ -291,22 +325,12 @@ func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, err
 		ID     string `json:"id"`
 		Status string `json:"status"`
 		Type   string `json:"type"`
-		Usage  *struct {
-			InputTokens      int `json:"input_tokens"`
-			OutputTokens     int `json:"output_tokens"`
-			TotalTokens      int `json:"total_tokens"`
-			PromptTokens     int `json:"prompt_tokens"`
-			CompletionTokens int `json:"completion_tokens"`
-		} `json:"usage"`
+		Usage  *mantleUsage `json:"usage"`
 		Response *struct {
 			Model  string `json:"model"`
 			ID     string `json:"id"`
 			Status string `json:"status"`
-			Usage  *struct {
-				InputTokens  int `json:"input_tokens"`
-				OutputTokens int `json:"output_tokens"`
-				TotalTokens  int `json:"total_tokens"`
-			} `json:"usage"`
+			Usage  *mantleUsage `json:"usage"`
 		} `json:"response"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil {
@@ -324,17 +348,7 @@ func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, err
 			envelope.Status = envelope.Response.Status
 		}
 		if usage == nil && envelope.Response.Usage != nil {
-			usage = &struct {
-				InputTokens      int `json:"input_tokens"`
-				OutputTokens     int `json:"output_tokens"`
-				TotalTokens      int `json:"total_tokens"`
-				PromptTokens     int `json:"prompt_tokens"`
-				CompletionTokens int `json:"completion_tokens"`
-			}{
-				InputTokens:  envelope.Response.Usage.InputTokens,
-				OutputTokens: envelope.Response.Usage.OutputTokens,
-				TotalTokens:  envelope.Response.Usage.TotalTokens,
-			}
+			usage = envelope.Response.Usage
 		}
 	}
 	if usage == nil {
@@ -352,5 +366,21 @@ func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, err
 		Model: envelope.Model, RequestID: envelope.ID, Provider: bedrockMantleName,
 		InputTokens: input, OutputTokens: output, TotalTokens: total,
 		FinishReason: envelope.Status, IsStreaming: streaming,
+		CacheReadInputTokens: usage.InputTokensDetails.CachedTokens,
+		ThoughtTokens:        usage.OutputTokensDetails.ReasoningTokens,
 	}, nil
+}
+
+type mantleUsage struct {
+	InputTokens      int `json:"input_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	InputTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"input_tokens_details"`
+	OutputTokensDetails struct {
+		ReasoningTokens int `json:"reasoning_tokens"`
+	} `json:"output_tokens_details"`
 }

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -54,10 +54,11 @@ type BedrockMantleProxy struct {
 	modelProjects map[string]string
 }
 
-// NewBedrockMantleProxy creates a Bedrock Mantle proxy using AWS credentials
-// from the shared config profile (SSO, ~/.aws/credentials, etc.). The profile
-// chain is used explicitly so docker-compose's DynamoDB Local static keys do
-// not override real AWS credentials for upstream SigV4.
+// NewBedrockMantleProxy creates a Bedrock Mantle proxy using the AWS default
+// credential chain (env, shared config, ECS/EC2 task role). When
+// BEDROCK_AWS_PROFILE or AWS_PROFILE is set, that shared config profile is
+// used instead — docker-compose sets BEDROCK_AWS_PROFILE so DynamoDB Local
+// static keys (AWS_ACCESS_KEY_ID=local) do not override real SigV4 creds.
 func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
 	var opt ProxyOptions
 	if len(opts) > 0 {
@@ -82,18 +83,20 @@ func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
 }
 
 func loadBedrockMantleAWSConfig(ctx context.Context, region string) (aws.Config, error) {
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(region),
+	}
+	// Only pin a shared-config profile when one is explicitly requested.
+	// Forcing "default" breaks CI and ECS task-role auth when ~/.aws/config
+	// has no such profile (AWS SDK error: failed to get shared config profile).
 	profile := os.Getenv("BEDROCK_AWS_PROFILE")
 	if profile == "" {
 		profile = os.Getenv("AWS_PROFILE")
 	}
-	if profile == "" {
-		profile = "default"
+	if profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
 	}
-	return awsconfig.LoadDefaultConfig(
-		ctx,
-		awsconfig.WithRegion(region),
-		awsconfig.WithSharedConfigProfile(profile),
-	)
+	return awsconfig.LoadDefaultConfig(ctx, opts...)
 }
 
 func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, opt ProxyOptions) *BedrockMantleProxy {

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -26,19 +28,36 @@ import (
 const (
 	bedrockMantleName    = "bedrock-mantle"
 	bedrockMantleService = "bedrock-mantle"
+	// defaultBedrockMantleAnthropicRegion is where Claude models are served on
+	// the Bedrock Mantle `/anthropic/v1/messages` endpoint. Anthropic Mantle
+	// SKUs are provisioned in us-east-1 for our account, while the OpenAI
+	// Mantle SKUs (gpt-5.x) live in the default us-west-2 region — signing an
+	// Anthropic request for us-west-2 returns a 500 api_error. Overridable via
+	// the BEDROCK_MANTLE_ANTHROPIC_REGION env var or ProxyOptions.
+	defaultBedrockMantleAnthropicRegion = "us-east-1"
 )
 
-// BedrockMantleProxy forwards OpenAI-compatible requests to AWS Bedrock Mantle.
-// It authenticates callers with llm-proxy API keys, then signs the rewritten
-// upstream request with the task's AWS credential chain.
+// BedrockMantleProxy forwards OpenAI- and Anthropic-compatible requests to AWS
+// Bedrock Mantle. It authenticates callers with llm-proxy API keys, then signs
+// the rewritten upstream request with the task's AWS credential chain.
 type BedrockMantleProxy struct {
 	proxy   *httputil.ReverseProxy
 	region  string
 	baseURL string
+	// anthropicRegion is the region used for `/anthropic/v1/messages` requests.
+	// Claude Mantle SKUs are provisioned in a different region than the OpenAI
+	// SKUs, so Anthropic traffic is retargeted (host + SigV4) to this region.
+	anthropicRegion string
+	// modelProjects maps a model id (or alias) to the Bedrock project id sent
+	// as the OpenAI-Project header. Empty entries (or an absent model) leave the
+	// account-level data-retention policy in force. Read-only after construction.
+	modelProjects map[string]string
 }
 
-// NewBedrockMantleProxy creates a Bedrock Mantle proxy using the default AWS
-// credential chain. Credentials are resolved by the signer at request time.
+// NewBedrockMantleProxy creates a Bedrock Mantle proxy using AWS credentials
+// from the shared config profile (SSO, ~/.aws/credentials, etc.). The profile
+// chain is used explicitly so docker-compose's DynamoDB Local static keys do
+// not override real AWS credentials for upstream SigV4.
 func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
 	var opt ProxyOptions
 	if len(opts) > 0 {
@@ -48,22 +67,49 @@ func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
 	if region == "" {
 		region = defaultBedrockRegion
 	}
-	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(region))
+	if opt.MantleAnthropicRegion == "" {
+		if envRegion := os.Getenv("BEDROCK_MANTLE_ANTHROPIC_REGION"); envRegion != "" {
+			opt.MantleAnthropicRegion = envRegion
+		} else {
+			opt.MantleAnthropicRegion = defaultBedrockMantleAnthropicRegion
+		}
+	}
+	cfg, err := loadBedrockMantleAWSConfig(context.Background(), region)
 	if err != nil {
 		panic(fmt.Sprintf("load AWS config for Bedrock Mantle: %v", err))
 	}
 	return newBedrockMantleProxy(region, cfg.Credentials, opt)
 }
 
+func loadBedrockMantleAWSConfig(ctx context.Context, region string) (aws.Config, error) {
+	profile := os.Getenv("BEDROCK_AWS_PROFILE")
+	if profile == "" {
+		profile = os.Getenv("AWS_PROFILE")
+	}
+	if profile == "" {
+		profile = "default"
+	}
+	return awsconfig.LoadDefaultConfig(
+		ctx,
+		awsconfig.WithRegion(region),
+		awsconfig.WithSharedConfigProfile(profile),
+	)
+}
+
 func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, opt ProxyOptions) *BedrockMantleProxy {
-	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai", region)
+	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws", region)
 	targetURL, err := url.Parse(baseURL)
 	if err != nil {
 		panic(fmt.Sprintf("invalid Bedrock Mantle upstream URL %q: %v", baseURL, err))
 	}
 
+	anthropicRegion := opt.MantleAnthropicRegion
+	if anthropicRegion == "" {
+		anthropicRegion = region
+	}
+
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
-	mantle := &BedrockMantleProxy{proxy: proxy, region: region, baseURL: baseURL}
+	mantle := &BedrockMantleProxy{proxy: proxy, region: region, baseURL: baseURL, anthropicRegion: anthropicRegion, modelProjects: opt.MantleModelProjects}
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/"+bedrockMantleName)
@@ -71,7 +117,28 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 			req.URL.RawPath = strings.TrimPrefix(req.URL.RawPath, "/"+bedrockMantleName)
 		}
 		originalDirector(req)
-		req.Host = targetURL.Host
+		// Retarget Anthropic Messages traffic to the region where Claude Mantle
+		// SKUs are provisioned. OpenAI traffic keeps the default region host.
+		host := targetURL.Host
+		if regionHost := mantle.hostForPath(req.URL.Path); regionHost != "" {
+			host = regionHost
+			req.URL.Host = regionHost
+		}
+		req.Host = host
+		// Bedrock Mantle's Anthropic Messages surface rejects any
+		// ``anthropic-beta`` flag with a 400 ("invalid beta flag") — the
+		// features gated behind those flags on the first-party API (e.g. GA
+		// tool search) are simply built in on Mantle. Anthropic SDK clients
+		// (and langchain_anthropic) auto-attach the header when they detect a
+		// tool-search builtin, so strip it here (pre-SigV4) so Bedrock-backed
+		// Claude traffic isn't hard-failed by a header the upstream ignores.
+		if isAnthropicMantlePath(req.URL.Path) {
+			req.Header.Del("Anthropic-Beta")
+		}
+		// Scope the request to a project before signing so Mantle applies that
+		// project's data-retention policy. Set here (pre-SigV4) so the header is
+		// covered by the signature the upstream validates.
+		mantle.applyProjectHeader(req)
 		req.Header.Del("Authorization")
 		req.Header.Del("X-Amz-Date")
 		req.Header.Del("X-Amz-Content-Sha256")
@@ -85,10 +152,11 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 		log.Printf("Proxying Bedrock Mantle request: %s %s", req.Method, req.URL.Path)
 	}
 	proxy.Transport = &sigV4Transport{
-		credentials: credentials,
-		inner:       newProxyTransport(opt.DisableGzip),
-		region:      region,
-		service:     bedrockMantleService,
+		credentials:   credentials,
+		inner:         newProxyTransport(opt.DisableGzip),
+		region:        region,
+		regionForPath: mantle.regionForPath,
+		service:       bedrockMantleService,
 	}
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
@@ -99,7 +167,47 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 		}
 		return nil
 	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		proxylog.Upstream("bedrock-mantle reverse proxy transport error: %v", err)
+		if mantle.IsStreamingRequest(r) {
+			if w.Header().Get("Content-Type") == "" {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.Header().Set("Cache-Control", "no-cache")
+				w.Header().Set(proxylog.HeaderErrorSource, proxylog.ErrorSourceUpstream)
+				w.WriteHeader(http.StatusBadGateway)
+				fmt.Fprint(w, proxylog.UpstreamSSEDataLine("bedrock-mantle transport: %v", err))
+				fmt.Fprintf(w, "data: [DONE]\n\n")
+			}
+			return
+		}
+		proxylog.UpstreamHTTPError(w, fmt.Sprintf("bedrock-mantle transport: %v", err), http.StatusBadGateway)
+	}
 	return mantle
+}
+
+// isAnthropicMantlePath reports whether a (prefix-trimmed) Mantle request path
+// targets the Anthropic Messages API rather than the OpenAI-compatible API.
+func isAnthropicMantlePath(path string) bool {
+	return strings.Contains(path, "/anthropic/")
+}
+
+// regionForPath returns the AWS region to sign a Mantle request for, routing
+// Anthropic Messages traffic to anthropicRegion and everything else to region.
+func (b *BedrockMantleProxy) regionForPath(path string) string {
+	if isAnthropicMantlePath(path) {
+		return b.anthropicRegion
+	}
+	return b.region
+}
+
+// hostForPath returns the upstream host for a Mantle request when it differs
+// from the default-region host, or "" when the default host should be kept.
+func (b *BedrockMantleProxy) hostForPath(path string) string {
+	region := b.regionForPath(path)
+	if region == b.region {
+		return ""
+	}
+	return fmt.Sprintf("bedrock-mantle.%s.api.aws", region)
 }
 
 // sigV4Transport signs the final URL, headers, and body immediately before
@@ -108,7 +216,10 @@ type sigV4Transport struct {
 	credentials aws.CredentialsProvider
 	inner       http.RoundTripper
 	region      string
-	service     string
+	// regionForPath, when set, resolves the signing region per request path so
+	// Anthropic and OpenAI Mantle traffic can each sign for its own AWS region.
+	regionForPath func(path string) string
+	service       string
 }
 
 func (t *sigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -119,6 +230,11 @@ func (t *sigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read Bedrock Mantle request body: %w", err)
 	}
+	sanitized := stripMantleUnsupportedToolStrict(payload)
+	if !bytes.Equal(sanitized, payload) {
+		payload = sanitized
+		restoreMantleRequestBody(req, payload)
+	}
 	sum := sha256.Sum256(payload)
 	payloadHash := hex.EncodeToString(sum[:])
 	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
@@ -127,10 +243,72 @@ func (t *sigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("retrieve AWS credentials for Bedrock Mantle: %w", err)
 	}
-	if err := v4.NewSigner().SignHTTP(req.Context(), credentials, req, payloadHash, t.service, t.region, time.Now()); err != nil {
+	region := t.region
+	if t.regionForPath != nil {
+		region = t.regionForPath(req.URL.Path)
+	}
+	if err := v4.NewSigner().SignHTTP(req.Context(), credentials, req, payloadHash, t.service, region, time.Now()); err != nil {
 		return nil, fmt.Errorf("sign Bedrock Mantle request: %w", err)
 	}
 	return t.inner.RoundTrip(req)
+}
+
+func stripMantleUnsupportedToolStrict(payload []byte) []byte {
+	if len(payload) == 0 {
+		return payload
+	}
+	var root map[string]json.RawMessage
+	if json.Unmarshal(payload, &root) != nil {
+		return payload
+	}
+	toolsRaw, ok := root["tools"]
+	if !ok {
+		return payload
+	}
+	var tools []map[string]any
+	if json.Unmarshal(toolsRaw, &tools) != nil {
+		return payload
+	}
+	changed := false
+	for i := range tools {
+		if _, ok := tools[i]["strict"]; ok {
+			delete(tools[i], "strict")
+			changed = true
+		}
+		if fn, ok := tools[i]["function"].(map[string]any); ok {
+			if _, ok := fn["strict"]; ok {
+				delete(fn, "strict")
+				changed = true
+			}
+		}
+		if custom, ok := tools[i]["custom"].(map[string]any); ok {
+			if _, ok := custom["strict"]; ok {
+				delete(custom, "strict")
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return payload
+	}
+	newTools, err := json.Marshal(tools)
+	if err != nil {
+		return payload
+	}
+	root["tools"] = newTools
+	out, err := json.Marshal(root)
+	if err != nil {
+		return payload
+	}
+	return out
+}
+
+func restoreMantleRequestBody(req *http.Request, payload []byte) {
+	req.Body = io.NopCloser(bytes.NewReader(payload))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(payload)), nil
+	}
+	req.ContentLength = int64(len(payload))
 }
 
 func readAndRestoreMantleBody(req *http.Request) ([]byte, error) {
@@ -148,6 +326,46 @@ func readAndRestoreMantleBody(req *http.Request) ([]byte, error) {
 	return body, nil
 }
 
+// openAIProjectHeader scopes a Mantle request to a Bedrock project. Mantle
+// speaks the OpenAI wire protocol, so it reuses OpenAI's project header name.
+const openAIProjectHeader = "OpenAI-Project"
+
+// applyProjectHeader sets the OpenAI-Project header when the request's model is
+// mapped to a project. It never overrides a project the caller already sent, and
+// is a no-op when no mapping is configured. Must run before SigV4 signing so the
+// header is covered by the signature.
+func (b *BedrockMantleProxy) applyProjectHeader(req *http.Request) {
+	if len(b.modelProjects) == 0 || req.Header.Get(openAIProjectHeader) != "" {
+		return
+	}
+	model := b.modelFromRequest(req)
+	if model == "" {
+		return
+	}
+	if project := b.modelProjects[model]; project != "" {
+		req.Header.Set(openAIProjectHeader, project)
+	}
+}
+
+// modelFromRequest returns the model id from a POST body, restoring the body for
+// downstream readers. Returns "" for non-POST requests or unparseable bodies.
+func (b *BedrockMantleProxy) modelFromRequest(req *http.Request) string {
+	if req == nil || req.Body == nil || req.Method != http.MethodPost {
+		return ""
+	}
+	body, err := readAndRestoreMantleBody(req)
+	if err != nil {
+		return ""
+	}
+	var data struct {
+		Model string `json:"model"`
+	}
+	if json.Unmarshal(body, &data) != nil {
+		return ""
+	}
+	return data.Model
+}
+
 func (b *BedrockMantleProxy) GetName() string { return bedrockMantleName }
 
 func (b *BedrockMantleProxy) IsStreamingRequest(req *http.Request) bool {
@@ -157,10 +375,18 @@ func (b *BedrockMantleProxy) IsStreamingRequest(req *http.Request) bool {
 	if strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
 		return true
 	}
-	if req.Method != http.MethodPost || (!strings.Contains(req.URL.Path, "/responses") && !strings.Contains(req.URL.Path, "/completions")) {
+	if req.Method != http.MethodPost {
 		return false
 	}
-	return (&OpenAIProxy{}).checkStreamingInBody(req)
+	if strings.Contains(req.URL.Path, "/messages") ||
+		strings.Contains(req.URL.Path, "/responses") ||
+		strings.Contains(req.URL.Path, "/completions") {
+		if strings.Contains(req.URL.Path, "/messages") {
+			return (&AnthropicProxy{}).checkStreamingInBody(req)
+		}
+		return (&OpenAIProxy{}).checkStreamingInBody(req)
+	}
+	return false
 }
 
 func (b *BedrockMantleProxy) Proxy() http.Handler { return b.proxy }
@@ -175,6 +401,7 @@ func (b *BedrockMantleProxy) GetHealthStatus() map[string]interface{} {
 		"status":            "healthy",
 		"baseURL":           b.baseURL,
 		"region":            b.region,
+		"anthropic_region":  b.anthropicRegion,
 		"streaming_support": true,
 		"auth":              "proxy_api_key_and_task_sigv4",
 	}
@@ -197,15 +424,13 @@ func (b *BedrockMantleProxy) UserIDFromRequest(req *http.Request) string {
 	return payload.User
 }
 
-// ValidateAPIKey accepts only normal llm-proxy keys registered for Mantle.
-// The resolved provider credential is deliberately discarded: Mantle is
-// authenticated solely by the local AWS SigV4 signature.
+// ValidateAPIKey accepts llm-proxy keys registered for the Bedrock family.
+// OpenAI clients send “Authorization: Bearer“; Anthropic Messages clients
+// (langchain_anthropic / the Anthropic SDK) send “x-api-key“. Both are
+// accepted and stripped before SigV4 signing — Mantle upstream auth is AWS
+// credentials only.
 func (b *BedrockMantleProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
-	auth := req.Header.Get("Authorization")
-	if !strings.HasPrefix(auth, "Bearer ") {
-		return fmt.Errorf("Bearer proxy API key is required")
-	}
-	key := strings.TrimPrefix(auth, "Bearer ")
+	key := mantleProxyKeyFromRequest(req)
 	if key == "" {
 		return fmt.Errorf("Bearer proxy API key is required")
 	}
@@ -213,11 +438,23 @@ func (b *BedrockMantleProxy) ValidateAPIKey(req *http.Request, keyStore APIKeySt
 	if err != nil {
 		return fmt.Errorf("API key validation failed: %w", err)
 	}
-	if provider != bedrockMantleName {
-		return fmt.Errorf("API key is for provider %s, not %s", provider, bedrockMantleName)
+	if !apikeys.IsBedrockFamilyProvider(provider) {
+		return fmt.Errorf("API key is for provider %s, not a Bedrock proxy key", provider)
 	}
-	req.Header.Del("Authorization")
+	mantleStripProxyAuthHeaders(req)
 	return nil
+}
+
+func mantleProxyKeyFromRequest(req *http.Request) string {
+	if auth := req.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	return req.Header.Get("x-api-key")
+}
+
+func mantleStripProxyAuthHeaders(req *http.Request) {
+	req.Header.Del("Authorization")
+	req.Header.Del("x-api-key")
 }
 
 func (b *BedrockMantleProxy) RegisterExtraRoutes(_ *mux.Router) {}
@@ -321,15 +558,15 @@ func parseMantleStream(responseBody io.Reader) (*LLMResponseMetadata, error) {
 
 func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, error) {
 	var envelope struct {
-		Model  string `json:"model"`
-		ID     string `json:"id"`
-		Status string `json:"status"`
-		Type   string `json:"type"`
-		Usage  *mantleUsage `json:"usage"`
+		Model    string       `json:"model"`
+		ID       string       `json:"id"`
+		Status   string       `json:"status"`
+		Type     string       `json:"type"`
+		Usage    *mantleUsage `json:"usage"`
 		Response *struct {
-			Model  string `json:"model"`
-			ID     string `json:"id"`
-			Status string `json:"status"`
+			Model  string       `json:"model"`
+			ID     string       `json:"id"`
+			Status string       `json:"status"`
 			Usage  *mantleUsage `json:"usage"`
 		} `json:"response"`
 	}
@@ -372,11 +609,11 @@ func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, err
 }
 
 type mantleUsage struct {
-	InputTokens      int `json:"input_tokens"`
-	OutputTokens     int `json:"output_tokens"`
-	TotalTokens      int `json:"total_tokens"`
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
+	InputTokens        int `json:"input_tokens"`
+	OutputTokens       int `json:"output_tokens"`
+	TotalTokens        int `json:"total_tokens"`
+	PromptTokens       int `json:"prompt_tokens"`
+	CompletionTokens   int `json:"completion_tokens"`
 	InputTokensDetails struct {
 		CachedTokens int `json:"cached_tokens"`
 	} `json:"input_tokens_details"`

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -1,0 +1,356 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/gorilla/mux"
+)
+
+const (
+	bedrockMantleName    = "bedrock-mantle"
+	bedrockMantleService = "bedrock-mantle"
+)
+
+// BedrockMantleProxy forwards OpenAI-compatible requests to AWS Bedrock Mantle.
+// It authenticates callers with llm-proxy API keys, then signs the rewritten
+// upstream request with the task's AWS credential chain.
+type BedrockMantleProxy struct {
+	proxy   *httputil.ReverseProxy
+	region  string
+	baseURL string
+}
+
+// NewBedrockMantleProxy creates a Bedrock Mantle proxy using the default AWS
+// credential chain. Credentials are resolved by the signer at request time.
+func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
+	var opt ProxyOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = defaultBedrockRegion
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(region))
+	if err != nil {
+		panic(fmt.Sprintf("load AWS config for Bedrock Mantle: %v", err))
+	}
+	return newBedrockMantleProxy(region, cfg.Credentials, opt)
+}
+
+func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, opt ProxyOptions) *BedrockMantleProxy {
+	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai", region)
+	targetURL, err := url.Parse(baseURL)
+	if err != nil {
+		panic(fmt.Sprintf("invalid Bedrock Mantle upstream URL %q: %v", baseURL, err))
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	mantle := &BedrockMantleProxy{proxy: proxy, region: region, baseURL: baseURL}
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/"+bedrockMantleName)
+		if req.URL.RawPath != "" {
+			req.URL.RawPath = strings.TrimPrefix(req.URL.RawPath, "/"+bedrockMantleName)
+		}
+		originalDirector(req)
+		req.Host = targetURL.Host
+		req.Header.Del("Authorization")
+		req.Header.Del("X-Amz-Date")
+		req.Header.Del("X-Amz-Content-Sha256")
+		req.Header.Del("X-Amz-Security-Token")
+		if opt.DisableGzip {
+			req.Header.Del("Accept-Encoding")
+		}
+		log.Printf("Proxying Bedrock Mantle request: %s %s", req.Method, req.URL.Path)
+	}
+	proxy.Transport = &sigV4Transport{
+		credentials: credentials,
+		inner:       newProxyTransport(opt.DisableGzip),
+		region:      region,
+		service:     bedrockMantleService,
+	}
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+			resp.Header.Set("Cache-Control", "no-cache")
+			resp.Header.Set("Connection", "keep-alive")
+			resp.Header.Set("X-Accel-Buffering", "no")
+			resp.Header.Del("Content-Length")
+		}
+		return nil
+	}
+	return mantle
+}
+
+// sigV4Transport signs the final URL, headers, and body immediately before
+// handing the request to the underlying transport.
+type sigV4Transport struct {
+	credentials aws.CredentialsProvider
+	inner       http.RoundTripper
+	region      string
+	service     string
+}
+
+func (t *sigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	payload, err := readAndRestoreMantleBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("read Bedrock Mantle request body: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	payloadHash := hex.EncodeToString(sum[:])
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	credentials, err := t.credentials.Retrieve(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("retrieve AWS credentials for Bedrock Mantle: %w", err)
+	}
+	if err := v4.NewSigner().SignHTTP(req.Context(), credentials, req, payloadHash, t.service, t.region, time.Now()); err != nil {
+		return nil, fmt.Errorf("sign Bedrock Mantle request: %w", err)
+	}
+	return t.inner.RoundTrip(req)
+}
+
+func readAndRestoreMantleBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	return body, nil
+}
+
+func (b *BedrockMantleProxy) GetName() string { return bedrockMantleName }
+
+func (b *BedrockMantleProxy) IsStreamingRequest(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	if strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
+		return true
+	}
+	if req.Method != http.MethodPost || (!strings.Contains(req.URL.Path, "/responses") && !strings.Contains(req.URL.Path, "/completions")) {
+		return false
+	}
+	body, err := readAndRestoreMantleBody(req)
+	return err == nil && bytes.Contains(body, []byte(`"stream":true`))
+}
+
+func (b *BedrockMantleProxy) Proxy() http.Handler { return b.proxy }
+
+func (b *BedrockMantleProxy) WrapTransport(fn func(http.RoundTripper) http.RoundTripper) {
+	b.proxy.Transport = fn(b.proxy.Transport)
+}
+
+func (b *BedrockMantleProxy) GetHealthStatus() map[string]interface{} {
+	return map[string]interface{}{
+		"provider":          bedrockMantleName,
+		"status":            "healthy",
+		"baseURL":           b.baseURL,
+		"region":            b.region,
+		"streaming_support": true,
+		"auth":              "proxy_api_key_and_task_sigv4",
+	}
+}
+
+func (b *BedrockMantleProxy) UserIDFromRequest(_ *http.Request) string { return "" }
+
+// ValidateAPIKey accepts only normal llm-proxy keys registered for Mantle.
+// The resolved provider credential is deliberately discarded: Mantle is
+// authenticated solely by the local AWS SigV4 signature.
+func (b *BedrockMantleProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return fmt.Errorf("Bearer proxy API key is required")
+	}
+	key := strings.TrimPrefix(auth, "Bearer ")
+	if key == "" {
+		return fmt.Errorf("Bearer proxy API key is required")
+	}
+	_, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), key)
+	if err != nil {
+		return fmt.Errorf("API key validation failed: %w", err)
+	}
+	if provider != bedrockMantleName {
+		return fmt.Errorf("API key is for provider %s, not %s", provider, bedrockMantleName)
+	}
+	req.Header.Del("Authorization")
+	return nil
+}
+
+func (b *BedrockMantleProxy) RegisterExtraRoutes(_ *mux.Router) {}
+
+func (b *BedrockMantleProxy) ExtractRequestModelAndMessages(req *http.Request) (string, []string) {
+	if req == nil || req.Body == nil || req.Method != http.MethodPost {
+		return "", nil
+	}
+	body, err := readAndRestoreMantleBody(req)
+	if err != nil {
+		return "", nil
+	}
+	var data struct {
+		Model    string          `json:"model"`
+		Input    json.RawMessage `json:"input"`
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if json.Unmarshal(body, &data) != nil {
+		return "", nil
+	}
+	var messages []string
+	appendText := func(raw json.RawMessage) {
+		var text string
+		if json.Unmarshal(raw, &text) == nil && text != "" {
+			messages = append(messages, text)
+			return
+		}
+		var parts []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(raw, &parts) == nil {
+			for _, part := range parts {
+				if (part.Type == "text" || part.Type == "input_text") && part.Text != "" {
+					messages = append(messages, part.Text)
+				}
+			}
+		}
+	}
+	appendText(data.Input)
+	for _, message := range data.Messages {
+		appendText(message.Content)
+	}
+	return data.Model, messages
+}
+
+func (b *BedrockMantleProxy) ParseResponseMetadata(responseBody io.Reader, isStreaming bool) (*LLMResponseMetadata, error) {
+	if isStreaming {
+		return parseMantleStream(responseBody)
+	}
+	body, err := io.ReadAll(responseBody)
+	if err != nil {
+		return nil, err
+	}
+	return parseMantleMetadata(body, false)
+}
+
+func parseMantleStream(responseBody io.Reader) (*LLMResponseMetadata, error) {
+	scanner := bufio.NewScanner(responseBody)
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	var partial *LLMResponseMetadata
+	for scanner.Scan() {
+		line := strings.TrimPrefix(scanner.Text(), "data: ")
+		if line == scanner.Text() || line == "[DONE]" {
+			continue
+		}
+		metadata, err := parseMantleMetadata([]byte(line), true)
+		if err == nil {
+			if metadata.TotalTokens > 0 {
+				return metadata, nil
+			}
+			if metadata.Model != "" {
+				partial = metadata
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if partial != nil {
+		return partial, nil
+	}
+	return nil, fmt.Errorf("no usage information found in Bedrock Mantle stream")
+}
+
+func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, error) {
+	var envelope struct {
+		Model  string `json:"model"`
+		ID     string `json:"id"`
+		Status string `json:"status"`
+		Type   string `json:"type"`
+		Usage  *struct {
+			InputTokens      int `json:"input_tokens"`
+			OutputTokens     int `json:"output_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+		Response *struct {
+			Model  string `json:"model"`
+			ID     string `json:"id"`
+			Status string `json:"status"`
+			Usage  *struct {
+				InputTokens  int `json:"input_tokens"`
+				OutputTokens int `json:"output_tokens"`
+				TotalTokens  int `json:"total_tokens"`
+			} `json:"usage"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	usage := envelope.Usage
+	if envelope.Response != nil {
+		if envelope.Model == "" {
+			envelope.Model = envelope.Response.Model
+		}
+		if envelope.ID == "" {
+			envelope.ID = envelope.Response.ID
+		}
+		if envelope.Status == "" {
+			envelope.Status = envelope.Response.Status
+		}
+		if usage == nil && envelope.Response.Usage != nil {
+			usage = &struct {
+				InputTokens      int `json:"input_tokens"`
+				OutputTokens     int `json:"output_tokens"`
+				TotalTokens      int `json:"total_tokens"`
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+			}{
+				InputTokens:  envelope.Response.Usage.InputTokens,
+				OutputTokens: envelope.Response.Usage.OutputTokens,
+				TotalTokens:  envelope.Response.Usage.TotalTokens,
+			}
+		}
+	}
+	if usage == nil {
+		return &LLMResponseMetadata{Model: envelope.Model, RequestID: envelope.ID, Provider: bedrockMantleName, IsStreaming: streaming}, nil
+	}
+	input, output := usage.InputTokens, usage.OutputTokens
+	if input == 0 && output == 0 {
+		input, output = usage.PromptTokens, usage.CompletionTokens
+	}
+	total := usage.TotalTokens
+	if total == 0 {
+		total = input + output
+	}
+	return &LLMResponseMetadata{
+		Model: envelope.Model, RequestID: envelope.ID, Provider: bedrockMantleName,
+		InputTokens: input, OutputTokens: output, TotalTokens: total,
+		FinishReason: envelope.Status, IsStreaming: streaming,
+	}, nil
+}

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -59,7 +59,9 @@ type BedrockMantleProxy struct {
 // BEDROCK_AWS_PROFILE or AWS_PROFILE is set, that shared config profile is
 // used instead — docker-compose sets BEDROCK_AWS_PROFILE so DynamoDB Local
 // static keys (AWS_ACCESS_KEY_ID=local) do not override real SigV4 creds.
-func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
+// AWS config load failures are returned so callers can disable Mantle without
+// taking down other providers.
+func NewBedrockMantleProxy(opts ...ProxyOptions) (*BedrockMantleProxy, error) {
 	var opt ProxyOptions
 	if len(opts) > 0 {
 		opt = opts[0]
@@ -77,9 +79,9 @@ func NewBedrockMantleProxy(opts ...ProxyOptions) *BedrockMantleProxy {
 	}
 	cfg, err := loadBedrockMantleAWSConfig(context.Background(), region)
 	if err != nil {
-		panic(fmt.Sprintf("load AWS config for Bedrock Mantle: %v", err))
+		return nil, fmt.Errorf("load AWS config for Bedrock Mantle: %w", err)
 	}
-	return newBedrockMantleProxy(region, cfg.Credentials, opt)
+	return newBedrockMantleProxy(region, cfg.Credentials, opt), nil
 }
 
 func loadBedrockMantleAWSConfig(ctx context.Context, region string) (aws.Config, error) {
@@ -268,27 +270,16 @@ func stripMantleUnsupportedToolStrict(payload []byte) []byte {
 	if !ok {
 		return payload
 	}
-	var tools []map[string]any
+	var tools []json.RawMessage
 	if json.Unmarshal(toolsRaw, &tools) != nil {
 		return payload
 	}
 	changed := false
 	for i := range tools {
-		if _, ok := tools[i]["strict"]; ok {
-			delete(tools[i], "strict")
+		stripped, didChange := stripStrictFromToolObject(tools[i])
+		if didChange {
+			tools[i] = stripped
 			changed = true
-		}
-		if fn, ok := tools[i]["function"].(map[string]any); ok {
-			if _, ok := fn["strict"]; ok {
-				delete(fn, "strict")
-				changed = true
-			}
-		}
-		if custom, ok := tools[i]["custom"].(map[string]any); ok {
-			if _, ok := custom["strict"]; ok {
-				delete(custom, "strict")
-				changed = true
-			}
 		}
 	}
 	if !changed {
@@ -304,6 +295,46 @@ func stripMantleUnsupportedToolStrict(payload []byte) []byte {
 		return payload
 	}
 	return out
+}
+
+func stripStrictFromToolObject(toolRaw json.RawMessage) (json.RawMessage, bool) {
+	var tool map[string]json.RawMessage
+	if json.Unmarshal(toolRaw, &tool) != nil {
+		return toolRaw, false
+	}
+	changed := false
+	if _, ok := tool["strict"]; ok {
+		delete(tool, "strict")
+		changed = true
+	}
+	for _, nestKey := range []string{"function", "custom"} {
+		nestedRaw, ok := tool[nestKey]
+		if !ok {
+			continue
+		}
+		var nested map[string]json.RawMessage
+		if json.Unmarshal(nestedRaw, &nested) != nil {
+			continue
+		}
+		if _, ok := nested["strict"]; !ok {
+			continue
+		}
+		delete(nested, "strict")
+		newNested, err := json.Marshal(nested)
+		if err != nil {
+			continue
+		}
+		tool[nestKey] = newNested
+		changed = true
+	}
+	if !changed {
+		return toolRaw, false
+	}
+	out, err := json.Marshal(tool)
+	if err != nil {
+		return toolRaw, false
+	}
+	return out, true
 }
 
 func restoreMantleRequestBody(req *http.Request, payload []byte) {
@@ -435,7 +466,7 @@ func (b *BedrockMantleProxy) UserIDFromRequest(req *http.Request) string {
 func (b *BedrockMantleProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
 	key := mantleProxyKeyFromRequest(req)
 	if key == "" {
-		return fmt.Errorf("Bearer proxy API key is required")
+		return fmt.Errorf("bearer proxy API key is required")
 	}
 	_, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), key)
 	if err != nil {
@@ -482,28 +513,55 @@ func (b *BedrockMantleProxy) ExtractRequestModelAndMessages(req *http.Request) (
 	}
 	var messages []string
 	appendText := func(raw json.RawMessage) {
-		var text string
-		if json.Unmarshal(raw, &text) == nil && text != "" {
-			messages = append(messages, text)
-			return
-		}
-		var parts []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		}
-		if json.Unmarshal(raw, &parts) == nil {
-			for _, part := range parts {
-				if (part.Type == "text" || part.Type == "input_text") && part.Text != "" {
-					messages = append(messages, part.Text)
-				}
-			}
-		}
+		appendMantleContentText(raw, &messages)
 	}
 	appendText(data.Input)
 	for _, message := range data.Messages {
 		appendText(message.Content)
 	}
 	return data.Model, messages
+}
+
+// appendMantleContentText walks OpenAI Responses / Chat / Anthropic content
+// shapes: a bare string, a flat text-part array, or nested message objects
+// whose text lives under content / input[].content.
+func appendMantleContentText(raw json.RawMessage, messages *[]string) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		if text != "" {
+			*messages = append(*messages, text)
+		}
+		return
+	}
+	var parts []json.RawMessage
+	if json.Unmarshal(raw, &parts) == nil {
+		for _, part := range parts {
+			appendMantleContentText(part, messages)
+		}
+		return
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil {
+		return
+	}
+	if t, ok := obj["type"]; ok {
+		var typeName string
+		if json.Unmarshal(t, &typeName) == nil && (typeName == "text" || typeName == "input_text") {
+			if textRaw, ok := obj["text"]; ok {
+				var partText string
+				if json.Unmarshal(textRaw, &partText) == nil && partText != "" {
+					*messages = append(*messages, partText)
+				}
+			}
+			return
+		}
+	}
+	if content, ok := obj["content"]; ok {
+		appendMantleContentText(content, messages)
+	}
 }
 
 func (b *BedrockMantleProxy) ParseResponseMetadata(responseBody io.Reader, isStreaming bool) (*LLMResponseMetadata, error) {
@@ -532,6 +590,49 @@ func (b *BedrockMantleProxy) ParseResponseMetadata(responseBody io.Reader, isStr
 }
 
 func parseMantleStream(responseBody io.Reader) (*LLMResponseMetadata, error) {
+	data, err := io.ReadAll(responseBody)
+	if err != nil {
+		return nil, err
+	}
+	if mantleStreamLooksAnthropic(data) {
+		metadata, err := (&AnthropicProxy{}).ParseResponseMetadata(bytes.NewReader(data), true)
+		if metadata != nil {
+			metadata.Provider = bedrockMantleName
+		}
+		return metadata, err
+	}
+	return parseMantleOpenAIStream(bytes.NewReader(data))
+}
+
+func mantleStreamLooksAnthropic(data []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var tip struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal([]byte(payload), &tip) != nil {
+			continue
+		}
+		switch tip.Type {
+		case "message_start", "message_delta", "message_stop", "content_block_start", "content_block_delta", "content_block_stop":
+			return true
+		case "response.created", "response.completed", "response.done", "response.failed", "response.in_progress":
+			return false
+		}
+	}
+	return false
+}
+
+func parseMantleOpenAIStream(responseBody io.Reader) (*LLMResponseMetadata, error) {
 	scanner := bufio.NewScanner(responseBody)
 	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
 	var partial *LLMResponseMetadata

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -71,15 +71,59 @@ func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {
 	if got.Header.Get("X-Amz-Security-Token") != "session" {
 		t.Fatalf("session token = %q, want signer credential token", got.Header.Get("X-Amz-Security-Token"))
 	}
+	if got.Header.Get("X-Forwarded-For") != "" {
+		t.Fatalf("X-Forwarded-For must not be signed: %q", got.Header.Get("X-Forwarded-For"))
+	}
 	if !bytes.Equal(gotBody, body) {
 		t.Fatalf("body changed: got %q want %q", gotBody, body)
+	}
+}
+
+func TestBedrockMantle_ParseResponsesMetadataIncludesCostFields(t *testing.T) {
+	body := `{
+		"id":"resp_1",
+		"model":"openai.gpt-5.4",
+		"status":"completed",
+		"usage":{
+			"input_tokens":12,
+			"output_tokens":4,
+			"total_tokens":16,
+			"input_tokens_details":{"cached_tokens":3},
+			"output_tokens_details":{"reasoning_tokens":2}
+		}
+	}`
+	metadata, err := NewBedrockMantleProxy().ParseResponseMetadata(strings.NewReader(body), false)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata: %v", err)
+	}
+	if metadata.Provider != bedrockMantleName || metadata.Model != "openai.gpt-5.4" || metadata.TotalTokens != 16 {
+		t.Fatalf("unexpected metadata: %+v", metadata)
+	}
+	if metadata.CacheReadInputTokens != 3 || metadata.ThoughtTokens != 2 {
+		t.Fatalf("missing Mantle cost fields: %+v", metadata)
+	}
+}
+
+func TestBedrockMantle_ParseChatCompletionsMetadata(t *testing.T) {
+	body := `{
+		"id":"chatcmpl_1",
+		"model":"openai.gpt-5.4",
+		"choices":[{"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16}
+	}`
+	metadata, err := NewBedrockMantleProxy().ParseResponseMetadata(strings.NewReader(body), false)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata: %v", err)
+	}
+	if metadata.Provider != bedrockMantleName || metadata.InputTokens != 12 || metadata.OutputTokens != 4 || metadata.FinishReason != "stop" {
+		t.Fatalf("unexpected chat completions metadata: %+v", metadata)
 	}
 }
 
 func TestBedrockMantle_ParseResponsesStreamingUsage(t *testing.T) {
 	stream := `data: {"type":"response.created","response":{"id":"resp_1","model":"claude-sonnet-4-5"}}
 
-data: {"type":"response.done","response":{"id":"resp_1","model":"claude-sonnet-4-5","status":"completed","usage":{"input_tokens":12,"output_tokens":4,"total_tokens":16}}}
+data: {"type":"response.done","response":{"id":"resp_1","model":"claude-sonnet-4-5","status":"completed","usage":{"input_tokens":12,"output_tokens":4,"total_tokens":16,"input_tokens_details":{"cached_tokens":3},"output_tokens_details":{"reasoning_tokens":2}}}}
 
 data: [DONE]
 `
@@ -89,5 +133,8 @@ data: [DONE]
 	}
 	if metadata.Provider != bedrockMantleName || metadata.Model != "claude-sonnet-4-5" || metadata.TotalTokens != 16 {
 		t.Fatalf("unexpected metadata: %+v", metadata)
+	}
+	if metadata.CacheReadInputTokens != 3 || metadata.ThoughtTokens != 2 {
+		t.Fatalf("missing Mantle streaming cost fields: %+v", metadata)
 	}
 }

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -1,0 +1,93 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+type mantleRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f mantleRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type mantleKeyStore struct{}
+
+func (mantleKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (string, string, error) {
+	if key != "sk-iw-mantle" {
+		return "", "", io.EOF
+	}
+	return "discarded-provider-token", bedrockMantleName, nil
+}
+
+func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-5","input":"hello"}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	var gotBody []byte
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		gotBody, _ = io.ReadAll(req.Body)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"claude-sonnet-4-5","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	if got.URL.String() != "https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses" {
+		t.Fatalf("upstream URL = %q", got.URL.String())
+	}
+	if got.Header.Get("Authorization") == "Bearer sk-iw-mantle" {
+		t.Fatal("inbound bearer token reached the upstream")
+	}
+	if !strings.Contains(got.Header.Get("Authorization"), "AWS4-HMAC-SHA256") ||
+		!strings.Contains(got.Header.Get("Authorization"), "/bedrock-mantle/aws4_request") {
+		t.Fatalf("request was not signed for Bedrock Mantle: %q", got.Header.Get("Authorization"))
+	}
+	if got.Header.Get("X-Amz-Security-Token") != "session" {
+		t.Fatalf("session token = %q, want signer credential token", got.Header.Get("X-Amz-Security-Token"))
+	}
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("body changed: got %q want %q", gotBody, body)
+	}
+}
+
+func TestBedrockMantle_ParseResponsesStreamingUsage(t *testing.T) {
+	stream := `data: {"type":"response.created","response":{"id":"resp_1","model":"claude-sonnet-4-5"}}
+
+data: {"type":"response.done","response":{"id":"resp_1","model":"claude-sonnet-4-5","status":"completed","usage":{"input_tokens":12,"output_tokens":4,"total_tokens":16}}}
+
+data: [DONE]
+`
+	metadata, err := NewBedrockMantleProxy().ParseResponseMetadata(strings.NewReader(stream), true)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata: %v", err)
+	}
+	if metadata.Provider != bedrockMantleName || metadata.Model != "claude-sonnet-4-5" || metadata.TotalTokens != 16 {
+		t.Fatalf("unexpected metadata: %+v", metadata)
+	}
+}

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -27,6 +27,15 @@ func (mantleKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (st
 	return "discarded-provider-token", bedrockMantleName, nil
 }
 
+func mustNewBedrockMantleProxy(t *testing.T, opts ...ProxyOptions) *BedrockMantleProxy {
+	t.Helper()
+	proxy, err := NewBedrockMantleProxy(opts...)
+	if err != nil {
+		t.Fatalf("NewBedrockMantleProxy: %v", err)
+	}
+	return proxy
+}
+
 func TestBedrockMantle_RewritesAnthropicMessagesRequest(t *testing.T) {
 	body := []byte(`{"model":"anthropic.claude-haiku-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`)
 	proxy := newBedrockMantleProxy(
@@ -193,6 +202,7 @@ func TestBedrockMantle_KeepsBetaHeaderOffOpenAIStrip(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/openai/v1/responses", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	req.Header.Set("Anthropic-Beta", "test-beta")
 	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
 		t.Fatalf("ValidateAPIKey: %v", err)
 	}
@@ -204,10 +214,13 @@ func TestBedrockMantle_KeepsBetaHeaderOffOpenAIStrip(t *testing.T) {
 	if got.URL.String() != "https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses" {
 		t.Fatalf("upstream URL = %q", got.URL.String())
 	}
+	if got.Header.Get("Anthropic-Beta") != "test-beta" {
+		t.Fatalf("Anthropic-Beta unexpectedly stripped: %q", got.Header.Get("Anthropic-Beta"))
+	}
 }
 
 func TestBedrockMantle_IsStreamingRequestForMessages(t *testing.T) {
-	proxy := NewBedrockMantleProxy()
+	proxy := mustNewBedrockMantleProxy(t)
 	body := []byte(`{"model":"anthropic.claude-haiku-4-5","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"hello"}]}`)
 	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/anthropic/v1/messages", bytes.NewReader(body))
 	if !proxy.IsStreamingRequest(req) {
@@ -218,7 +231,7 @@ func TestBedrockMantle_IsStreamingRequestForMessages(t *testing.T) {
 func TestBedrockMantle_AcceptsAnthropicXApiKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("x-api-key", "sk-iw-mantle")
-	if err := NewBedrockMantleProxy().ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+	if err := mustNewBedrockMantleProxy(t).ValidateAPIKey(req, mantleKeyStore{}); err != nil {
 		t.Fatalf("ValidateAPIKey: %v", err)
 	}
 	if req.Header.Get("x-api-key") != "" {
@@ -229,7 +242,7 @@ func TestBedrockMantle_AcceptsAnthropicXApiKey(t *testing.T) {
 func TestBedrockMantle_AcceptsBedrockProviderKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer sk-iw-bedrock")
-	if err := NewBedrockMantleProxy().ValidateAPIKey(req, bedrockProviderKeyStore{}); err != nil {
+	if err := mustNewBedrockMantleProxy(t).ValidateAPIKey(req, bedrockProviderKeyStore{}); err != nil {
 		t.Fatalf("ValidateAPIKey: %v", err)
 	}
 }
@@ -372,7 +385,7 @@ func TestBedrockMantle_ParseResponsesMetadataIncludesCostFields(t *testing.T) {
 			"output_tokens_details":{"reasoning_tokens":2}
 		}
 	}`
-	metadata, err := NewBedrockMantleProxy().ParseResponseMetadata(strings.NewReader(body), false)
+	metadata, err := mustNewBedrockMantleProxy(t).ParseResponseMetadata(strings.NewReader(body), false)
 	if err != nil {
 		t.Fatalf("ParseResponseMetadata: %v", err)
 	}
@@ -391,7 +404,7 @@ func TestBedrockMantle_ParseChatCompletionsMetadata(t *testing.T) {
 		"choices":[{"finish_reason":"stop"}],
 		"usage":{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16}
 	}`
-	metadata, err := NewBedrockMantleProxy().ParseResponseMetadata(strings.NewReader(body), false)
+	metadata, err := mustNewBedrockMantleProxy(t).ParseResponseMetadata(strings.NewReader(body), false)
 	if err != nil {
 		t.Fatalf("ParseResponseMetadata: %v", err)
 	}
@@ -407,7 +420,7 @@ data: {"type":"response.done","response":{"id":"resp_1","model":"claude-sonnet-4
 
 data: [DONE]
 `
-	metadata, err := NewBedrockMantleProxy().ParseResponseMetadata(strings.NewReader(stream), true)
+	metadata, err := mustNewBedrockMantleProxy(t).ParseResponseMetadata(strings.NewReader(stream), true)
 	if err != nil {
 		t.Fatalf("ParseResponseMetadata: %v", err)
 	}
@@ -419,11 +432,63 @@ data: [DONE]
 	}
 }
 
+func TestBedrockMantle_ParseAnthropicStreamingUsage(t *testing.T) {
+	stream := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"anthropic.claude-haiku-4-5","stop_reason":null,"usage":{"input_tokens":25,"output_tokens":1,"cache_read_input_tokens":5,"cache_creation_input_tokens":2}}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+	metadata, err := mustNewBedrockMantleProxy(t).ParseResponseMetadata(strings.NewReader(stream), true)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata: %v", err)
+	}
+	if metadata.Provider != bedrockMantleName || metadata.Model != "anthropic.claude-haiku-4-5" {
+		t.Fatalf("unexpected metadata: %+v", metadata)
+	}
+	if metadata.InputTokens != 25 || metadata.OutputTokens != 16 || metadata.TotalTokens != 41 {
+		t.Fatalf("unexpected token aggregation: %+v", metadata)
+	}
+	if metadata.CacheReadInputTokens != 5 || metadata.CacheCreationInputTokens != 2 {
+		t.Fatalf("missing Anthropic cache fields: %+v", metadata)
+	}
+	if metadata.FinishReason != "end_turn" {
+		t.Fatalf("FinishReason = %q, want end_turn", metadata.FinishReason)
+	}
+}
+
 func TestStripMantleUnsupportedToolStrict(t *testing.T) {
 	in := []byte(`{"model":"anthropic.claude-haiku-4-5","tools":[{"name":"a","strict":true},{"type":"function","function":{"name":"b","strict":true}},{"type":"custom","custom":{"strict":true}}]}`)
 	out := stripMantleUnsupportedToolStrict(in)
 	if bytes.Contains(out, []byte(`"strict"`)) {
 		t.Fatalf("expected strict stripped, got %s", out)
+	}
+}
+
+func TestStripMantleUnsupportedToolStrict_PreservesLargeIntegers(t *testing.T) {
+	in := []byte(`{"model":"anthropic.claude-haiku-4-5","tools":[{"name":"a","strict":true,"input_schema":{"type":"object","properties":{"n":{"const":9007199254740993}}}}]}`)
+	out := stripMantleUnsupportedToolStrict(in)
+	if bytes.Contains(out, []byte(`"strict"`)) {
+		t.Fatalf("expected strict stripped, got %s", out)
+	}
+	if !bytes.Contains(out, []byte("9007199254740993")) {
+		t.Fatalf("large integer mutated/lost: %s", out)
+	}
+}
+
+func TestBedrockMantle_ExtractNestedResponsesInput(t *testing.T) {
+	body := []byte(`{"model":"openai.gpt-5.4","input":[{"role":"user","content":[{"type":"input_text","text":"nested hello"}]}]}`)
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/openai/v1/responses", bytes.NewReader(body))
+	model, messages := (&BedrockMantleProxy{}).ExtractRequestModelAndMessages(req)
+	if model != "openai.gpt-5.4" {
+		t.Fatalf("model = %q", model)
+	}
+	if len(messages) != 1 || messages[0] != "nested hello" {
+		t.Fatalf("messages = %#v, want [nested hello]", messages)
 	}
 }
 

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -27,6 +27,222 @@ func (mantleKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (st
 	return "discarded-provider-token", bedrockMantleName, nil
 }
 
+func TestBedrockMantle_RewritesAnthropicMessagesRequest(t *testing.T) {
+	body := []byte(`{"model":"anthropic.claude-haiku-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"anthropic.claude-haiku-4-5","usage":{"input_tokens":2,"output_tokens":1}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/anthropic/v1/messages", bytes.NewReader(body))
+	req.Header.Set("x-api-key", "sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	if got.URL.String() != "https://bedrock-mantle.us-west-2.api.aws/anthropic/v1/messages" {
+		t.Fatalf("upstream URL = %q", got.URL.String())
+	}
+}
+
+func TestBedrockMantle_RoutesAnthropicToConfiguredRegion(t *testing.T) {
+	body := []byte(`{"model":"anthropic.claude-haiku-4-5","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleAnthropicRegion: "us-east-1"},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"anthropic.claude-haiku-4-5","usage":{"input_tokens":2,"output_tokens":1}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/anthropic/v1/messages", bytes.NewReader(body))
+	req.Header.Set("x-api-key", "sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	if got.URL.String() != "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages" {
+		t.Fatalf("upstream URL = %q, want us-east-1 host", got.URL.String())
+	}
+	if auth := got.Header.Get("Authorization"); !strings.Contains(auth, "/us-east-1/bedrock-mantle/aws4_request") {
+		t.Fatalf("Anthropic request not signed for us-east-1: %q", auth)
+	}
+}
+
+func TestBedrockMantle_KeepsOpenAIInDefaultRegion(t *testing.T) {
+	body := []byte(`{"model":"openai.gpt-5.4","input":"hello"}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleAnthropicRegion: "us-east-1"},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"openai.gpt-5.4","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/openai/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	if got.URL.String() != "https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses" {
+		t.Fatalf("upstream URL = %q, want us-west-2 host", got.URL.String())
+	}
+	if auth := got.Header.Get("Authorization"); !strings.Contains(auth, "/us-west-2/bedrock-mantle/aws4_request") {
+		t.Fatalf("OpenAI request not signed for us-west-2: %q", auth)
+	}
+}
+
+func TestBedrockMantle_StripsAnthropicBetaHeader(t *testing.T) {
+	body := []byte(`{"model":"anthropic.claude-haiku-4-5","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleAnthropicRegion: "us-east-1"},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"anthropic.claude-haiku-4-5","usage":{"input_tokens":2,"output_tokens":1}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/anthropic/v1/messages", bytes.NewReader(body))
+	req.Header.Set("x-api-key", "sk-iw-mantle")
+	req.Header.Set("Anthropic-Beta", "advanced-tool-use-2025-11-20")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	if got.Header.Get("Anthropic-Beta") != "" {
+		t.Fatalf("Anthropic-Beta must be stripped for Mantle, got %q", got.Header.Get("Anthropic-Beta"))
+	}
+}
+
+func TestBedrockMantle_KeepsBetaHeaderOffOpenAIStrip(t *testing.T) {
+	// OpenAI Mantle traffic never carries an Anthropic-Beta header, and the
+	// strip must not touch the OpenAI path's own request shape.
+	body := []byte(`{"model":"openai.gpt-5.4","input":"hello"}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"openai.gpt-5.4","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/openai/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	if got.URL.String() != "https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses" {
+		t.Fatalf("upstream URL = %q", got.URL.String())
+	}
+}
+
+func TestBedrockMantle_IsStreamingRequestForMessages(t *testing.T) {
+	proxy := NewBedrockMantleProxy()
+	body := []byte(`{"model":"anthropic.claude-haiku-4-5","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"hello"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/anthropic/v1/messages", bytes.NewReader(body))
+	if !proxy.IsStreamingRequest(req) {
+		t.Fatal("expected streaming request for Anthropic messages with stream=true")
+	}
+}
+
+func TestBedrockMantle_AcceptsAnthropicXApiKey(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("x-api-key", "sk-iw-mantle")
+	if err := NewBedrockMantleProxy().ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	if req.Header.Get("x-api-key") != "" {
+		t.Fatal("x-api-key should be stripped after validation")
+	}
+}
+
+func TestBedrockMantle_AcceptsBedrockProviderKey(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer sk-iw-bedrock")
+	if err := NewBedrockMantleProxy().ValidateAPIKey(req, bedrockProviderKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+}
+
+type bedrockProviderKeyStore struct{}
+
+func (bedrockProviderKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (string, string, error) {
+	if key != "sk-iw-bedrock" {
+		return "", "", io.EOF
+	}
+	return "unused", "bedrock", nil
+}
+
 func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-5","input":"hello"}`)
 	proxy := newBedrockMantleProxy(
@@ -48,7 +264,7 @@ func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {
 		}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/v1/responses", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/openai/v1/responses", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
 	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
 		t.Fatalf("ValidateAPIKey: %v", err)
@@ -76,6 +292,70 @@ func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {
 	}
 	if !bytes.Equal(gotBody, body) {
 		t.Fatalf("body changed: got %q want %q", gotBody, body)
+	}
+}
+
+func mantleUpstreamHeader(t *testing.T, opt ProxyOptions, model, callerProject string) http.Header {
+	t.Helper()
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		opt,
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"` + model + `","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	body := []byte(`{"model":"` + model + `","input":"hello"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/openai/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	if callerProject != "" {
+		req.Header.Set("OpenAI-Project", callerProject)
+	}
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+	return got.Header
+}
+
+func TestBedrockMantle_InjectsProjectHeaderForMappedModel(t *testing.T) {
+	opt := ProxyOptions{MantleModelProjects: map[string]string{"openai.gpt-5.5": "proj_abc123"}}
+	h := mantleUpstreamHeader(t, opt, "openai.gpt-5.5", "")
+	if got := h.Get("OpenAI-Project"); got != "proj_abc123" {
+		t.Fatalf("OpenAI-Project = %q, want proj_abc123", got)
+	}
+	// The header must be inside the SigV4 SignedHeaders list, else the upstream
+	// rejects the signature.
+	if auth := h.Get("Authorization"); !strings.Contains(auth, "openai-project") {
+		t.Fatalf("OpenAI-Project not covered by signature: %q", auth)
+	}
+}
+
+func TestBedrockMantle_NoProjectHeaderForUnmappedModel(t *testing.T) {
+	opt := ProxyOptions{MantleModelProjects: map[string]string{"openai.gpt-5.5": "proj_abc123"}}
+	h := mantleUpstreamHeader(t, opt, "anthropic.claude-sonnet-5", "")
+	if got := h.Get("OpenAI-Project"); got != "" {
+		t.Fatalf("OpenAI-Project = %q, want empty for unmapped model", got)
+	}
+}
+
+func TestBedrockMantle_PreservesCallerProjectHeader(t *testing.T) {
+	opt := ProxyOptions{MantleModelProjects: map[string]string{"openai.gpt-5.5": "proj_abc123"}}
+	h := mantleUpstreamHeader(t, opt, "openai.gpt-5.5", "proj_caller")
+	if got := h.Get("OpenAI-Project"); got != "proj_caller" {
+		t.Fatalf("OpenAI-Project = %q, want caller value proj_caller", got)
 	}
 }
 
@@ -136,5 +416,48 @@ data: [DONE]
 	}
 	if metadata.CacheReadInputTokens != 3 || metadata.ThoughtTokens != 2 {
 		t.Fatalf("missing Mantle streaming cost fields: %+v", metadata)
+	}
+}
+
+func TestStripMantleUnsupportedToolStrict(t *testing.T) {
+	in := []byte(`{"model":"anthropic.claude-haiku-4-5","tools":[{"name":"a","strict":true},{"type":"function","function":{"name":"b","strict":true}},{"type":"custom","custom":{"strict":true}}]}`)
+	out := stripMantleUnsupportedToolStrict(in)
+	if bytes.Contains(out, []byte(`"strict"`)) {
+		t.Fatalf("expected strict stripped, got %s", out)
+	}
+}
+
+func TestBedrockMantle_StripsStrictBeforeSigning(t *testing.T) {
+	body := []byte(`{"model":"anthropic.claude-haiku-4-5","max_tokens":1024,"tools":[{"name":"strict-test","description":"d","input_schema":{"type":"object"},"strict":true}],"messages":[{"role":"user","content":"hello"}]}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var gotBody []byte
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var err error
+		gotBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read upstream body: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"model":"anthropic.claude-haiku-4-5","usage":{"input_tokens":2,"output_tokens":1}}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/anthropic/v1/messages", bytes.NewReader(body))
+	req.Header.Set("x-api-key", "sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+
+	if bytes.Contains(gotBody, []byte(`"strict"`)) {
+		t.Fatalf("upstream body still contains strict: %s", gotBody)
 	}
 }

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/gorilla/mux"
 )
 
@@ -84,29 +85,28 @@ func NewGeminiProxy(opts ...ProxyOptions) *GeminiProxy {
 
 	// Add error handler with streaming-specific error handling
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		log.Printf("Gemini proxy error: %v", err)
+		proxylog.Upstream("gemini reverse proxy transport error: %v", err)
 
 		// For streaming requests, we need to handle errors differently
 		if geminiProxy.IsStreamingRequest(r) {
 			// If we're in a streaming context, we might have already started writing
 			// the response, so we need to handle this gracefully
-			log.Printf("Error occurred during streaming request")
+			proxylog.Upstream("gemini streaming transport error: %v", err)
 
 			// Try to write an error in SSE format if possible
 			if w.Header().Get("Content-Type") == "" {
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.Header().Set("Cache-Control", "no-cache")
+				w.Header().Set(proxylog.HeaderErrorSource, proxylog.ErrorSourceUpstream)
 				w.WriteHeader(http.StatusBadGateway)
-				fmt.Fprintf(w, "data: {\"error\": \"Proxy error: %v\"}\n\n", err)
+				fmt.Fprint(w, proxylog.UpstreamSSEDataLine("gemini transport: %v", err))
 				fmt.Fprintf(w, "data: [DONE]\n\n")
 			} else {
 				// Headers already sent, just log the error
-				log.Printf("Cannot send error response, headers already sent")
+				proxylog.Proxy("gemini cannot send error response, headers already sent")
 			}
 		} else {
-			// Regular error handling for non-streaming requests
-			w.WriteHeader(http.StatusBadGateway)
-			fmt.Fprintf(w, "Gemini proxy error: %v", err)
+			proxylog.UpstreamHTTPError(w, fmt.Sprintf("gemini transport: %v", err), http.StatusBadGateway)
 		}
 	}
 
@@ -324,7 +324,7 @@ func (g *GeminiProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespon
 		var streamResponse GeminiStreamResponse
 		if err := json.Unmarshal([]byte(jsonData), &streamResponse); err != nil {
 			// Log error but continue processing other chunks
-			log.Printf("Warning: failed to parse Gemini streaming chunk: %v", err)
+			proxylog.Proxy("gemini failed to parse streaming chunk: %v", err)
 			continue
 		}
 
@@ -413,12 +413,12 @@ func (g *GeminiProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) er
 	apiKeyFromHeader := req.Header.Get("x-goog-api-key")
 
 	// Use whichever is present (query takes precedence)
-	apiKey := apiKeyFromQuery
-	if apiKey == "" {
-		apiKey = apiKeyFromHeader
+	inboundKey := apiKeyFromQuery
+	if inboundKey == "" {
+		inboundKey = apiKeyFromHeader
 	}
 
-	if apiKey == "" {
+	if inboundKey == "" {
 		// No API key provided, let the provider handle the error
 		return nil
 	}
@@ -426,7 +426,7 @@ func (g *GeminiProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) er
 	// Validate and potentially replace the key. Use the request context so
 	// client cancellation / handler-level deadlines propagate into the
 	// DynamoDB validation lookup.
-	actualKey, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), apiKey)
+	actualKey, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), inboundKey)
 	if err != nil {
 		return fmt.Errorf("API key validation failed: %w", err)
 	}
@@ -437,7 +437,7 @@ func (g *GeminiProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) er
 	}
 
 	// Replace the key in the appropriate location if it was translated
-	if actualKey != apiKey {
+	if actualKey != inboundKey {
 		if apiKeyFromQuery != "" {
 			// Replace in query parameter
 			query.Set("key", actualKey)

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 	"github.com/gorilla/mux"
 )
@@ -79,29 +80,28 @@ func NewOpenAIProxy(opts ...ProxyOptions) *OpenAIProxy {
 
 	// Add error handler with streaming-specific error handling
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		log.Printf("OpenAI proxy error: %v", err)
+		proxylog.Upstream("openai reverse proxy transport error: %v", err)
 
 		// For streaming requests, we need to handle errors differently
 		if openAIProxy.IsStreamingRequest(r) {
 			// If we're in a streaming context, we might have already started writing
 			// the response, so we need to handle this gracefully
-			log.Printf("Error occurred during streaming request")
+			proxylog.Upstream("openai streaming transport error: %v", err)
 
 			// Try to write an error in SSE format if possible
 			if w.Header().Get("Content-Type") == "" {
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.Header().Set("Cache-Control", "no-cache")
+				w.Header().Set(proxylog.HeaderErrorSource, proxylog.ErrorSourceUpstream)
 				w.WriteHeader(http.StatusBadGateway)
-				fmt.Fprintf(w, "data: {\"error\": \"Proxy error: %v\"}\n\n", err)
+				fmt.Fprint(w, proxylog.UpstreamSSEDataLine("openai transport: %v", err))
 				fmt.Fprintf(w, "data: [DONE]\n\n")
 			} else {
 				// Headers already sent, just log the error
-				log.Printf("Cannot send error response, headers already sent")
+				proxylog.Proxy("openai cannot send error response, headers already sent")
 			}
 		} else {
-			// Regular error handling for non-streaming requests
-			w.WriteHeader(http.StatusBadGateway)
-			fmt.Fprintf(w, "OpenAI proxy error: %v", err)
+			proxylog.UpstreamHTTPError(w, fmt.Sprintf("openai transport: %v", err), http.StatusBadGateway)
 		}
 	}
 
@@ -148,20 +148,20 @@ func (o *OpenAIProxy) checkStreamingInBody(req *http.Request) bool {
 		// Body was already cached, use GetBody to get a fresh reader
 		bodyReader, err := req.GetBody()
 		if err != nil {
-			log.Printf("Error getting cached request body for streaming check: %v", err)
+			proxylog.Proxy("openai streaming check: error getting cached request body: %v", err)
 			return false
 		}
 		defer bodyReader.Close()
 		bodyBytes, err = io.ReadAll(bodyReader)
 		if err != nil {
-			log.Printf("Error reading cached request body for streaming check: %v", err)
+			proxylog.Proxy("openai streaming check: error reading cached request body: %v", err)
 			return false
 		}
 	} else {
 		// Read the body for the first time
 		bodyBytes, err = io.ReadAll(req.Body)
 		if err != nil {
-			log.Printf("Error reading request body for streaming check: %v", err)
+			proxylog.Proxy("openai streaming check: error reading request body: %v", err)
 			return false
 		}
 
@@ -175,7 +175,7 @@ func (o *OpenAIProxy) checkStreamingInBody(req *http.Request) bool {
 	// Parse the JSON to check for stream field
 	var requestData map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &requestData); err != nil {
-		log.Printf("Error parsing request body JSON for streaming check: %v", err)
+		proxylog.Proxy("openai streaming check: error parsing request body JSON: %v", err)
 		return false
 	}
 
@@ -526,7 +526,7 @@ func (o *OpenAIProxy) parseResponsesStreamingChunk(jsonData string, model, reque
 	var chunkData map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonData), &chunkData); err != nil {
 		// Log error but continue processing other chunks
-		log.Printf("Warning: failed to parse Responses API streaming chunk: %v", err)
+		proxylog.Proxy("openai failed to parse Responses API streaming chunk: %v", err)
 		return nil, model, requestID, finishReason, thoughtTokens
 	}
 
@@ -696,7 +696,7 @@ func (o *OpenAIProxy) parseCompletionsStreamingChunk(jsonData string, model, req
 	var streamResponse OpenAIStreamResponse
 	if err := json.Unmarshal([]byte(jsonData), &streamResponse); err != nil {
 		// Log error but continue processing other chunks
-		log.Printf("Warning: failed to parse streaming chunk: %v", err)
+		proxylog.Proxy("openai failed to parse streaming chunk: %v", err)
 		return nil, model, requestID, finishReason
 	}
 
@@ -809,7 +809,7 @@ func (o *OpenAIProxy) UserIDFromRequest(req *http.Request) string {
 	// Read request body
 	bodyBytes, err := o.readRequestBodyForUserID(req)
 	if err != nil {
-		log.Printf("Error reading OpenAI request body for user ID extraction: %v", err)
+		proxylog.Proxy("openai user ID extraction: error reading request body: %v", err)
 		return ""
 	}
 
@@ -820,7 +820,7 @@ func (o *OpenAIProxy) UserIDFromRequest(req *http.Request) string {
 	// Parse JSON to extract user field
 	var data map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &data); err != nil {
-		log.Printf("Error parsing OpenAI request JSON for user ID extraction: %v", err)
+		proxylog.Proxy("openai user ID extraction: error parsing request JSON: %v", err)
 		return ""
 	}
 

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -127,6 +127,22 @@ type ProxyOptions struct {
 	// Useful for debugging SSE streams where you want plain-text event data
 	// visible in logs.  Defaults to false (gzip enabled).
 	DisableGzip bool
+
+	// MantleModelProjects maps a Bedrock Mantle model id (or alias) to the
+	// Bedrock project id that should handle it. When a request's model matches,
+	// the Mantle proxy sets the OpenAI-Project header so Mantle resolves
+	// data-retention (and other project-scoped policy) against that project
+	// instead of the account default. Consumed only by the Bedrock Mantle
+	// proxy; nil/empty leaves the account-level policy in force.
+	MantleModelProjects map[string]string
+
+	// MantleAnthropicRegion overrides the AWS region used for Bedrock Mantle
+	// `/anthropic/v1/messages` traffic. Claude Mantle SKUs are provisioned in a
+	// different region than the OpenAI SKUs, so Anthropic requests are
+	// retargeted (host + SigV4) here. Empty falls back to the proxy's default
+	// region (public constructor: BEDROCK_MANTLE_ANTHROPIC_REGION env or
+	// us-east-1). Consumed only by the Bedrock Mantle proxy.
+	MantleAnthropicRegion string
 }
 
 // ProviderManager manages multiple providers

--- a/internal/providers/proxy_construction_test.go
+++ b/internal/providers/proxy_construction_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,37 +121,80 @@ func TestOpenAIProxy_ErrorHandler_Streaming(t *testing.T) {
 	rr := runErrorHandler(t, NewOpenAIProxy(), "/openai/v1/chat/completions", "text/event-stream")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
 	assert.Contains(t, rr.Header().Get("Content-Type"), "text/event-stream")
-	assert.Contains(t, rr.Body.String(), "Proxy error")
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Header().Get("X-Llm-Proxy-Error-Source"), "upstream")
 }
 
 func TestOpenAIProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	rr := runErrorHandler(t, NewOpenAIProxy(), "/openai/v1/chat/completions", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "OpenAI proxy error")
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Body.String(), "openai transport")
 }
 
 func TestAnthropicProxy_ErrorHandler_Streaming(t *testing.T) {
 	rr := runErrorHandler(t, NewAnthropicProxy(), "/anthropic/v1/messages", "text/event-stream")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Proxy error")
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
 }
 
 func TestAnthropicProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	rr := runErrorHandler(t, NewAnthropicProxy(), "/anthropic/v1/messages", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Anthropic proxy error")
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Body.String(), "anthropic transport")
 }
 
 func TestGeminiProxy_ErrorHandler_Streaming(t *testing.T) {
 	rr := runErrorHandler(t, NewGeminiProxy(), "/gemini/v1/models/gemini-pro:streamGenerateContent?alt=sse", "text/event-stream")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Proxy error")
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
 }
 
 func TestGeminiProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	rr := runErrorHandler(t, NewGeminiProxy(), "/gemini/v1/models/gemini-pro:generateContent", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Gemini proxy error")
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Body.String(), "gemini transport")
+}
+
+func TestBedrockProxy_ErrorHandler_Streaming(t *testing.T) {
+	rr := runErrorHandler(t, NewBedrockProxy(), "/bedrock/model/anthropic.claude-3-sonnet/converse-stream", bedrockEventStreamMIME)
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Header().Get("Content-Type"), bedrockEventStreamMIME)
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Header().Get("X-Llm-Proxy-Error-Source"), "upstream")
+}
+
+func TestBedrockProxy_ErrorHandler_NonStreaming(t *testing.T) {
+	rr := runErrorHandler(t, NewBedrockProxy(), "/bedrock/model/anthropic.claude-3-sonnet/converse", "")
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Body.String(), "bedrock transport")
+}
+
+func TestBedrockMantleProxy_ErrorHandler_Streaming(t *testing.T) {
+	mantle := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	rr := runErrorHandler(t, mantle, "/bedrock-mantle/anthropic/v1/messages", "text/event-stream")
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Header().Get("X-Llm-Proxy-Error-Source"), "upstream")
+}
+
+func TestBedrockMantleProxy_ErrorHandler_NonStreaming(t *testing.T) {
+	mantle := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	rr := runErrorHandler(t, mantle, "/bedrock-mantle/anthropic/v1/messages", "")
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
+	assert.Contains(t, rr.Body.String(), "bedrock-mantle transport")
 }
 
 func TestProvider_ModifyResponse_SSEHeaders(t *testing.T) {

--- a/internal/providers/retired.go
+++ b/internal/providers/retired.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 // HeaderModelRetired marks proxy-origin retired-model responses. The JSON body
@@ -40,6 +41,7 @@ func WriteRetiredModelResponse(w http.ResponseWriter, provider Provider, model s
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set(HeaderModelRetired, modelRetiredErrorClass)
+	w.Header().Set(proxylog.HeaderErrorSource, proxylog.ErrorSourceProxy)
 	w.WriteHeader(status)
 	_, err = w.Write(body)
 	return err

--- a/internal/providers/retired_test.go
+++ b/internal/providers/retired_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
 func TestRetiredModelError_VendorShapes(t *testing.T) {
@@ -158,6 +159,9 @@ func TestWriteRetiredModelResponse_SetsProxyHeader(t *testing.T) {
 	}
 	if got := rec.Header().Get(HeaderModelRetired); got != "model_retired" {
 		t.Fatalf("header=%q", got)
+	}
+	if got := rec.Header().Get(proxylog.HeaderErrorSource); got != proxylog.ErrorSourceProxy {
+		t.Fatalf("error_source=%q", got)
 	}
 }
 

--- a/internal/proxylog/http.go
+++ b/internal/proxylog/http.go
@@ -1,0 +1,83 @@
+package proxylog
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	// HeaderErrorSource is set on HTTP error responses synthesized by
+	// llm-proxy so clients can distinguish proxy-local failures from
+	// upstream provider failures without parsing the body.
+	HeaderErrorSource = "X-Llm-Proxy-Error-Source"
+	// ErrorSourceProxy is the HeaderErrorSource value for proxy-local errors.
+	ErrorSourceProxy = "proxy"
+	// ErrorSourceUpstream is the HeaderErrorSource value for upstream errors.
+	ErrorSourceUpstream = "upstream"
+)
+
+func prefixed(tag, msg string) string {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return tag
+	}
+	if strings.HasPrefix(msg, tag) {
+		return msg
+	}
+	return tag + " " + msg
+}
+
+func setErrorSourceHeader(w http.ResponseWriter, source string) {
+	if source != "" {
+		w.Header().Set(HeaderErrorSource, source)
+	}
+}
+
+// ProxyHTTPError writes a plain-text proxy-local HTTP error response.
+func ProxyHTTPError(w http.ResponseWriter, msg string, code int) {
+	setErrorSourceHeader(w, ErrorSourceProxy)
+	http.Error(w, prefixed(TagProxy, msg), code)
+}
+
+// UpstreamHTTPError writes a plain-text upstream HTTP error response.
+func UpstreamHTTPError(w http.ResponseWriter, msg string, code int) {
+	setErrorSourceHeader(w, ErrorSourceUpstream)
+	http.Error(w, prefixed(TagUpstream, msg), code)
+}
+
+// WriteProxyJSONError writes {"error":"<msg>"} for a proxy-local failure.
+func WriteProxyJSONError(w http.ResponseWriter, code int, msg string) {
+	writeJSONError(w, code, prefixed(TagProxy, msg), ErrorSourceProxy)
+}
+
+// WriteUpstreamJSONError writes {"error":"<msg>"} for an upstream failure.
+func WriteUpstreamJSONError(w http.ResponseWriter, code int, msg string) {
+	writeJSONError(w, code, prefixed(TagUpstream, msg), ErrorSourceUpstream)
+}
+
+func writeJSONError(w http.ResponseWriter, code int, msg, source string) {
+	w.Header().Set("Content-Type", "application/json")
+	setErrorSourceHeader(w, source)
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// UpstreamPlain formats a plain-text upstream error body.
+func UpstreamPlain(format string, args ...any) string {
+	return prefixed(TagUpstream, fmt.Sprintf(format, args...))
+}
+
+// ProxyPlain formats a plain-text proxy-local error body.
+func ProxyPlain(format string, args ...any) string {
+	return prefixed(TagProxy, fmt.Sprintf(format, args...))
+}
+
+// UpstreamSSEDataLine returns an SSE data line with a JSON error object.
+func UpstreamSSEDataLine(format string, args ...any) string {
+	payload, _ := json.Marshal(map[string]string{
+		"error": UpstreamPlain(format, args...),
+	})
+	return fmt.Sprintf("data: %s\n\n", payload)
+}

--- a/internal/proxylog/http_test.go
+++ b/internal/proxylog/http_test.go
@@ -1,0 +1,50 @@
+package proxylog
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProxyHTTPError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ProxyHTTPError(rec, "rate limit exceeded", http.StatusTooManyRequests)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get(HeaderErrorSource); got != ErrorSourceProxy {
+		t.Fatalf("source = %q", got)
+	}
+	if !strings.Contains(rec.Body.String(), "[PROXY] rate limit exceeded") {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+func TestWriteUpstreamJSONError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteUpstreamJSONError(rec, http.StatusBadGateway, "openai transport: timeout")
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get(HeaderErrorSource); got != ErrorSourceUpstream {
+		t.Fatalf("source = %q", got)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["error"] != "[UPSTREAM] openai transport: timeout" {
+		t.Fatalf("error = %q", body["error"])
+	}
+}
+
+func TestUpstreamSSEDataLine(t *testing.T) {
+	line := UpstreamSSEDataLine("bedrock transport: %v", "reset")
+	if !strings.Contains(line, "[UPSTREAM] bedrock transport: reset") {
+		t.Fatalf("line = %q", line)
+	}
+}

--- a/internal/proxylog/log.go
+++ b/internal/proxylog/log.go
@@ -1,0 +1,55 @@
+// Package proxylog standardizes [PROXY] vs [UPSTREAM] prefixes on error logs
+// and HTTP error responses so operators and clients can tell proxy-local
+// failures apart from upstream provider failures.
+package proxylog
+
+import (
+	"context"
+	"log"
+	"log/slog"
+)
+
+const (
+	// TagProxy marks errors originating inside llm-proxy (auth, routing,
+	// middleware, response parsing, circuit state, etc.).
+	TagProxy = "[PROXY]"
+	// TagUpstream marks errors from or about the upstream LLM provider
+	// (transport failures, provider HTTP errors, rate limits, etc.).
+	TagUpstream = "[UPSTREAM]"
+)
+
+// Proxy logs a proxy-local error via the standard library logger.
+func Proxy(format string, args ...any) {
+	log.Printf(TagProxy+" "+format, args...)
+}
+
+// Upstream logs an upstream-provider error via the standard library logger.
+func Upstream(format string, args ...any) {
+	log.Printf(TagUpstream+" "+format, args...)
+}
+
+// ProxyMsg prefixes a message for structured slog logging.
+func ProxyMsg(msg string) string {
+	return TagProxy + " " + msg
+}
+
+// UpstreamMsg prefixes a message for structured slog logging.
+func UpstreamMsg(msg string) string {
+	return TagUpstream + " " + msg
+}
+
+// SlogProxy emits a structured log record for a proxy-local condition.
+func SlogProxy(logger *slog.Logger, level slog.Level, msg string, args ...any) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Log(context.Background(), level, ProxyMsg(msg), args...)
+}
+
+// SlogUpstream emits a structured log record for an upstream condition.
+func SlogUpstream(logger *slog.Logger, level slog.Level, msg string, args ...any) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Log(context.Background(), level, UpstreamMsg(msg), args...)
+}

--- a/internal/proxylog/log_test.go
+++ b/internal/proxylog/log_test.go
@@ -1,0 +1,42 @@
+package proxylog
+
+import (
+	"bytes"
+	"log"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestProxyAndUpstreamPrintf(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(log.Writer())
+
+	Proxy("auth failed: %s", "missing")
+	Upstream("openai transport: %v", "timeout")
+
+	out := buf.String()
+	if !strings.Contains(out, "[PROXY] auth failed: missing") {
+		t.Fatalf("unexpected proxy line: %q", out)
+	}
+	if !strings.Contains(out, "[UPSTREAM] openai transport: timeout") {
+		t.Fatalf("unexpected upstream line: %q", out)
+	}
+}
+
+func TestSlogPrefixes(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	SlogProxy(logger, slog.LevelError, "circuit store error", "key", "openai")
+	SlogUpstream(logger, slog.LevelWarn, "terminal failure", "status", 503)
+
+	out := buf.String()
+	if !strings.Contains(out, `"msg":"[PROXY] circuit store error"`) {
+		t.Fatalf("missing proxy slog prefix: %q", out)
+	}
+	if !strings.Contains(out, `"msg":"[UPSTREAM] terminal failure"`) {
+		t.Fatalf("missing upstream slog prefix: %q", out)
+	}
+}

--- a/internal/redact/content_adapter.go
+++ b/internal/redact/content_adapter.go
@@ -41,7 +41,7 @@ func AdapterForContext(ctx context.Context) ContentAdapter {
 // adapter that applies every provider's rules when name is unknown.
 func AdapterForProvider(name string) ContentAdapter {
 	switch name {
-	case "openai", "bedrock-mantle":
+	case "openai":
 		return openAIContentAdapter{}
 	case "anthropic":
 		return anthropicContentAdapter{}
@@ -49,6 +49,11 @@ func AdapterForProvider(name string) ContentAdapter {
 		return geminiContentAdapter{}
 	case "bedrock":
 		return bedrockContentAdapter{}
+	case "bedrock-mantle":
+		// Mantle serves both OpenAI- and Anthropic-shaped payloads under one
+		// provider name; use the union so Anthropic fields (system, tool_use)
+		// are scrubbed when the request took /anthropic/v1/messages.
+		return unionContentAdapter{}
 	default:
 		return unionContentAdapter{}
 	}

--- a/internal/redact/content_adapter.go
+++ b/internal/redact/content_adapter.go
@@ -41,7 +41,7 @@ func AdapterForContext(ctx context.Context) ContentAdapter {
 // adapter that applies every provider's rules when name is unknown.
 func AdapterForProvider(name string) ContentAdapter {
 	switch name {
-	case "openai":
+	case "openai", "bedrock-mantle":
 		return openAIContentAdapter{}
 	case "anthropic":
 		return anthropicContentAdapter{}

--- a/internal/redact/content_adapter_test.go
+++ b/internal/redact/content_adapter_test.go
@@ -53,6 +53,18 @@ func TestContentAdapter_Anthropic_SystemBlockText(t *testing.T) {
 	}
 }
 
+func TestContentAdapter_BedrockMantle_UsesUnionForAnthropicShape(t *testing.T) {
+	body := `{"system":[{"type":"text","text":"You are helpful"}],"messages":[{"role":"user","content":"hi"}]}`
+	var tasks []jsonScrubTask
+	var root any
+	_ = json.Unmarshal([]byte(body), &root)
+	collectJSONScrubTasks(root, nil, &tasks, AdapterForProvider("bedrock-mantle"))
+	texts := taskTexts(tasks)
+	if !containsAll(texts, "You are helpful", "hi") {
+		t.Fatalf("bedrock-mantle union should scrub Anthropic fields, tasks = %v", texts)
+	}
+}
+
 func TestContentAdapter_Bedrock_ConverseAndToolResult(t *testing.T) {
 	body := `{"messages":[{"role":"user","content":[{"text":"book shift"}]}],"system":[{"text":"sys prompt"}]}`
 	var tasks []jsonScrubTask

--- a/internal/redactapi/handler.go
+++ b/internal/redactapi/handler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/proxylog"
 	"github.com/Instawork/llm-proxy/internal/redact"
 )
 
@@ -126,7 +127,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	result, redactErr := h.redactor.Redact(r.Context(), text)
 	if redactErr != nil {
-		h.logger.Warn("redact_api: redactor failed",
+		h.logger.Warn(proxylog.ProxyMsg("redact_api: redactor failed"),
 			slog.String("reason", redactFailureReason(redactErr)))
 		writeJSONError(w, http.StatusServiceUnavailable, "redaction failed")
 		return
@@ -189,9 +190,7 @@ func extractCredential(r *http.Request) string {
 }
 
 func writeJSONError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	proxylog.WriteProxyJSONError(w, status, msg)
 }
 
 // redactFailureReason maps Presidio errors to stable log labels without

--- a/web/src/components/keys/api-keys-modal.tsx
+++ b/web/src/components/keys/api-keys-modal.tsx
@@ -4,6 +4,8 @@ import {
   modalTabClass,
   type KeyFormState,
   type KeyFormTab,
+  providerLabel,
+  providerNeedsUpstreamKey,
 } from "../../lib/key-form";
 import type { APIKey, Provider } from "../../types";
 
@@ -72,6 +74,7 @@ export default function ApiKeysModal({
     : treatAsPersonal
       ? "Create personal key"
       : "Create API key";
+  const needsUpstreamKey = providerNeedsUpstreamKey(form.provider);
 
   return (
     <dialog className="modal modal-open" open>
@@ -138,13 +141,18 @@ export default function ApiKeysModal({
                 >
                   {availableProviders.map((provider) => (
                     <option key={provider} value={provider}>
-                      {provider}
+                      {providerLabel(provider)}
                     </option>
                   ))}
                 </select>
                 {piiOffRequiresBedrock && !treatAsPersonal ? (
                   <span className="label-text-alt text-base-content/60">
                     PII redaction off requires the Bedrock provider.
+                  </span>
+                ) : null}
+                {!needsUpstreamKey ? (
+                  <span className="label-text-alt text-base-content/60">
+                    No provider API key needed — upstream calls authenticate with AWS SigV4.
                   </span>
                 ) : null}
               </label>
@@ -188,7 +196,14 @@ export default function ApiKeysModal({
                 </label>
               ) : null}
 
-              {!editingKey && providerAutoProvision && !provisionedKeysOnly && !treatAsPersonal ? (
+              {!editingKey && !needsUpstreamKey ? (
+                <div className="rounded-lg border border-base-300/70 bg-base-200/40 px-3 py-2 text-sm text-base-content/80">
+                  This proxy key is only for caller identity, rate limits, and cost tracking.
+                  AWS credentials on the proxy sign outbound Bedrock requests (Converse and Mantle).
+                </div>
+              ) : null}
+
+              {!editingKey && needsUpstreamKey && providerAutoProvision && !provisionedKeysOnly && !treatAsPersonal ? (
                 <details
                   className="rounded-lg border border-base-300 px-3 py-2"
                   open={manualKeyEntry}
@@ -216,7 +231,7 @@ export default function ApiKeysModal({
                 </details>
               ) : null}
 
-              {!editingKey && !providerAutoProvision && !provisionedKeysOnly && !treatAsPersonal ? (
+              {!editingKey && needsUpstreamKey && !providerAutoProvision && !provisionedKeysOnly && !treatAsPersonal ? (
                 <label className="form-control w-full">
                   <span className="label-text">Provider API key</span>
                   <input

--- a/web/src/lib/key-form.ts
+++ b/web/src/lib/key-form.ts
@@ -5,6 +5,16 @@ import type { APIKey, PiiRedactSetting, Provider } from "../types";
 export const KEY_PROVIDERS: Provider[] = ["openai", "anthropic", "gemini", "bedrock"];
 export const VIEWER_PROVIDERS: Provider[] = ["openai", "anthropic", "gemini"];
 
+export const BEDROCK_AWS_AUTH_PROVIDERS: Provider[] = ["bedrock"];
+
+export function providerNeedsUpstreamKey(provider: Provider): boolean {
+  return !BEDROCK_AWS_AUTH_PROVIDERS.includes(provider);
+}
+
+export function providerLabel(provider: Provider): string {
+  return provider;
+}
+
 export type PiiFormValue = "inherit" | "on" | "off";
 
 export type KeyFormState = {

--- a/web/src/lib/n8n-setup.ts
+++ b/web/src/lib/n8n-setup.ts
@@ -66,6 +66,8 @@ export function n8nSetupGuide(provider: Provider, baseUrl: string): N8nSetupGuid
           "The native AWS Bedrock node signs requests with IAM and has no custom endpoint field.",
           "It cannot route through this proxy's SigV4 passthrough without custom Code/HTTP nodes.",
           "For n8n, use OpenAI, Anthropic, or Gemini credentials pointed at the proxy instead.",
+          "For Bedrock Mantle (GPT on Bedrock), use an OpenAI credential with Base URL set to",
+          `${baseUrl}/bedrock-mantle/openai/v1 (GPT) or ${baseUrl}/bedrock-mantle/anthropic (Claude) with a bedrock-provider iw: proxy key.`,
         ],
         note: "Bedrock via llm-proxy requires client-side SigV4 URL rewriting — not supported by n8n's built-in Bedrock node.",
       };

--- a/web/src/lib/n8n-setup.ts
+++ b/web/src/lib/n8n-setup.ts
@@ -66,8 +66,8 @@ export function n8nSetupGuide(provider: Provider, baseUrl: string): N8nSetupGuid
           "The native AWS Bedrock node signs requests with IAM and has no custom endpoint field.",
           "It cannot route through this proxy's SigV4 passthrough without custom Code/HTTP nodes.",
           "For n8n, use OpenAI, Anthropic, or Gemini credentials pointed at the proxy instead.",
-          "For Bedrock Mantle (GPT on Bedrock), use an OpenAI credential with Base URL set to",
-          `${baseUrl}/bedrock-mantle/openai/v1 (GPT) or ${baseUrl}/bedrock-mantle/anthropic (Claude) with a bedrock-provider iw: proxy key.`,
+          `For Bedrock Mantle GPT models, use an OpenAI credential with Base URL set to ${baseUrl}/bedrock-mantle/openai/v1 and a bedrock-provider iw: proxy key.`,
+          `For Bedrock Mantle Claude models, use an Anthropic credential/node with Base URL set to ${baseUrl}/bedrock-mantle/anthropic and the same proxy key.`,
         ],
         note: "Bedrock via llm-proxy requires client-side SigV4 URL rewriting — not supported by n8n's built-in Bedrock node.",
       };

--- a/web/src/pages/keys/index.tsx
+++ b/web/src/pages/keys/index.tsx
@@ -30,6 +30,7 @@ import {
   keyFormFromRecord,
   KEY_PROVIDERS,
   piiFromFormValue,
+  providerNeedsUpstreamKey,
   rateLimitsFromForm,
   VIEWER_PROVIDERS,
   type KeyFormState,
@@ -436,7 +437,7 @@ export default function KeysPage() {
             );
             return;
           }
-          if (!form.actual_key.trim()) {
+          if (providerNeedsUpstreamKey(form.provider) && !form.actual_key.trim()) {
             push("Provider API key is required", "error");
             return;
           }
@@ -455,7 +456,7 @@ export default function KeysPage() {
           if (form.provider === "anthropic" && form.anthropic_tier) {
             body.tags = { tier: form.anthropic_tier };
           }
-        } else {
+        } else if (providerNeedsUpstreamKey(form.provider)) {
           body.actual_key = form.actual_key;
         }
         await createKey.mutateAsync(body);


### PR DESCRIPTION
## Summary

Adds the Bedrock Mantle proxy provider and hardens it for Anthropic traffic.

- **Bedrock Mantle proxy provider** — OpenAI- and Anthropic-compatible routes through AWS Bedrock via Mantle, with SigV4 signing (commits `feat: add Bedrock Mantle proxy provider`, `fix(bedrock): account for Mantle usage`).
- **Per-provider region routing** — Anthropic Messages traffic routes to `us-east-1` while OpenAI-compatible traffic stays on the default region. `anthropic.claude-haiku-4-5` returns 500s in `us-west-2` but succeeds in `us-east-1`. SigV4 now derives the region per request path so each route signs for its own AWS region. Configurable via `BEDROCK_MANTLE_ANTHROPIC_REGION`.
- **Anthropic-Beta header strip** — `langchain_anthropic` auto-adds an `anthropic-beta` header when tool search is enabled, and Bedrock Mantle rejects any `anthropic-beta` header with a 400. The proxy now strips it on Anthropic Mantle requests.
- **Observability** — `anthropic_region` surfaced in health status and startup logging.
- Also bundles related proxy/middleware/cost/admin-keys/proxylog changes accumulated on the branch.

## Validation

- `go build ./...`, `go vet ./...`, and `go test ./internal/providers/...` all pass locally; `gofmt` clean.
- Verified end-to-end in the Finch playground UI: a custom agent on **Claude 4.5 Haiku (Bedrock)** successfully performs a tool call (`todo_write`) and returns the expected response, exercising the region-routing + header-strip path.

## Test plan

- [ ] CI green (build, gofmt, vet, tests)
- [ ] Confirm Anthropic Mantle requests route to `us-east-1` and OpenAI Mantle stays on default region
- [ ] Confirm no `anthropic-beta` header reaches Bedrock Mantle
- [ ] Smoke test OpenAI + Anthropic Mantle routes in staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bedrock Mantle support for OpenAI- and Anthropic-compatible requests (AWS SigV4, streaming, model→project routing, and usage tracking).
  * Enabled Bedrock and Bedrock Mantle in staging and production; expanded Bedrock model aliases and mappings, and added new Mantle model configuration.
  * Updated key creation to correctly handle providers that don’t require an upstream API key.

* **Bug Fixes**
  * Standardized proxy/upstream error responses with clearer source indicators.
  * Improved startup reliability by using time-bounded DogStatsD address resolution.
  * Improved local startup ordering by waiting for proxy health before starting the web dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->