### PR TITLE
feat(bedrock-mantle): keyless sidecar auth via task SigV4

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1314,6 +1314,7 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 	if mantleCfg, ok := yamlConfig.Providers["bedrock-mantle"]; ok && mantleCfg.Enabled {
 		mantleOpts := proxyOpts
 		mantleOpts.MantleModelProjects = buildMantleModelProjects(mantleCfg)
+		mantleOpts.MantleTaskSigV4Auth = strings.EqualFold(strings.TrimSpace(mantleCfg.Auth), config.ProviderAuthTaskSigV4)
 		var mantleErr error
 		bedrockMantle, mantleErr = providers.NewBedrockMantleProxy(mantleOpts)
 		if mantleErr != nil {
@@ -1326,7 +1327,7 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 				logger.Info("☁️  Bedrock Mantle project routing: ENABLED", "models", len(mantleOpts.MantleModelProjects))
 			}
 			mantleHealth := bedrockMantle.GetHealthStatus()
-			logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", mantleHealth["region"], "anthropic_region", mantleHealth["anthropic_region"])
+			logger.Info("☁️  Bedrock Mantle provider: ENABLED", "region", mantleHealth["region"], "anthropic_region", mantleHealth["anthropic_region"], "auth", mantleHealth["auth"])
 		}
 	} else {
 		logger.Info("☁️  Bedrock Mantle provider: DISABLED (set providers.bedrock-mantle.enabled: true to enable)")

--- a/configs/sidecar.yml
+++ b/configs/sidecar.yml
@@ -13,8 +13,17 @@
 # admin_dashboard block below, the rollups sub-block must be restated here. The
 # standalone dashboard then reflects all sidecar traffic; we just don't serve the
 # UI from here.
+#
+# Bedrock Mantle upstream auth is task-role SigV4. On the co-located sidecar we
+# trust localhost/task networking, so callers need not present an iw-* Bedrock
+# key (empty or a non-iw placeholder is accepted). Standalone llm-proxy keeps
+# requiring a registered Bedrock-family proxy key.
 
 enabled: true
+
+providers:
+  bedrock-mantle:
+    auth: task_sigv4
 
 features:
   byo_keys:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -742,10 +742,25 @@ func redactedRedisURL(u string) string {
 	return parsed.String()
 }
 
+// Provider auth modes for providers that support alternatives to proxy keys.
+const (
+	// ProviderAuthProxyAPIKey is the default: callers must present an iw-* key.
+	ProviderAuthProxyAPIKey = "proxy_api_key"
+	// ProviderAuthTaskSigV4 skips inbound proxy-key auth when the caller sends
+	// no key (or a non-iw placeholder). Upstream auth remains task-role SigV4.
+	// Only valid for bedrock-mantle on sidecar deployments (history.role=sidecar).
+	ProviderAuthTaskSigV4 = "task_sigv4"
+)
+
 // ProviderConfig represents configuration for a specific provider
 type ProviderConfig struct {
 	Enabled bool                   `yaml:"enabled"`
 	Models  map[string]ModelConfig `yaml:"models"`
+	// Auth selects caller authentication for providers that support more than
+	// the default proxy-key path. Empty / "proxy_api_key" require an iw-* key.
+	// "task_sigv4" (bedrock-mantle + sidecar only) trusts the local network and
+	// authenticates upstream with the task role.
+	Auth string `yaml:"auth,omitempty"`
 }
 
 // ModelConfig represents configuration for a specific model
@@ -1145,6 +1160,31 @@ func (c *YAMLConfig) Validate() error {
 		return fmt.Errorf("invalid retired_models configuration: %w", err)
 	}
 
+	if err := c.validateProviderAuth(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *YAMLConfig) validateProviderAuth() error {
+	for name, provider := range c.Providers {
+		auth := strings.TrimSpace(provider.Auth)
+		switch auth {
+		case "", ProviderAuthProxyAPIKey:
+			continue
+		case ProviderAuthTaskSigV4:
+			if name != "bedrock-mantle" {
+				return fmt.Errorf("providers.%s.auth=%s is only supported for bedrock-mantle", name, ProviderAuthTaskSigV4)
+			}
+			if c.Features.History.Role != "sidecar" {
+				return fmt.Errorf("providers.bedrock-mantle.auth=%s requires features.history.role=sidecar", ProviderAuthTaskSigV4)
+			}
+		default:
+			return fmt.Errorf("providers.%s.auth: unknown value %q (want %s or %s)",
+				name, auth, ProviderAuthProxyAPIKey, ProviderAuthTaskSigV4)
+		}
+	}
 	return nil
 }
 

--- a/internal/config/loading_test.go
+++ b/internal/config/loading_test.go
@@ -447,6 +447,12 @@ func TestRealEnvConfigs_ProductionSidecarProfile(t *testing.T) {
 		"sidecar profile must disable the admin dashboard")
 	assert.Equal(t, "none", cfg.Features.History.Backend,
 		"sidecar profile must disable row-history writes")
+	assert.Equal(t, "sidecar", cfg.Features.History.Role,
+		"sidecar profile must set history.role=sidecar")
 	assert.True(t, cfg.Features.BYOKeys.Enabled,
 		"sidecar profile must allow BYO provider keys")
+	assert.True(t, cfg.Providers["bedrock-mantle"].Enabled,
+		"production Mantle enablement must survive the sidecar profile overlay")
+	assert.Equal(t, ProviderAuthTaskSigV4, cfg.Providers["bedrock-mantle"].Auth,
+		"sidecar profile must set bedrock-mantle.auth=task_sigv4")
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -61,6 +61,31 @@ func TestValidate_NoProvidersErrors(t *testing.T) {
 	assert.Error(t, c.Validate())
 }
 
+func TestValidate_ProviderAuthTaskSigV4(t *testing.T) {
+	c := &YAMLConfig{
+		Providers: map[string]ProviderConfig{
+			"bedrock-mantle": {Enabled: true, Auth: ProviderAuthTaskSigV4},
+		},
+	}
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "history.role=sidecar")
+
+	c.Features.History.Role = "sidecar"
+	require.NoError(t, c.Validate())
+
+	c.Providers["openai"] = ProviderConfig{Enabled: true, Auth: ProviderAuthTaskSigV4}
+	err = c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only supported for bedrock-mantle")
+
+	delete(c.Providers, "openai")
+	c.Providers["bedrock-mantle"] = ProviderConfig{Enabled: true, Auth: "nope"}
+	err = c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown value")
+}
+
 func TestValidateRateLimiting_AllBranches(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -52,6 +52,10 @@ type BedrockMantleProxy struct {
 	// as the OpenAI-Project header. Empty entries (or an absent model) leave the
 	// account-level data-retention policy in force. Read-only after construction.
 	modelProjects map[string]string
+	// taskSigV4Auth allows missing / non-iw caller credentials on trusted
+	// sidecars (providers.bedrock-mantle.auth=task_sigv4). Upstream auth is
+	// still SigV4 from the task role.
+	taskSigV4Auth bool
 }
 
 // NewBedrockMantleProxy creates a Bedrock Mantle proxy using the AWS default
@@ -114,7 +118,14 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
-	mantle := &BedrockMantleProxy{proxy: proxy, region: region, baseURL: baseURL, anthropicRegion: anthropicRegion, modelProjects: opt.MantleModelProjects}
+	mantle := &BedrockMantleProxy{
+		proxy:           proxy,
+		region:          region,
+		baseURL:         baseURL,
+		anthropicRegion: anthropicRegion,
+		modelProjects:   opt.MantleModelProjects,
+		taskSigV4Auth:   opt.MantleTaskSigV4Auth,
+	}
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/"+bedrockMantleName)
@@ -430,6 +441,10 @@ func (b *BedrockMantleProxy) WrapTransport(fn func(http.RoundTripper) http.Round
 }
 
 func (b *BedrockMantleProxy) GetHealthStatus() map[string]interface{} {
+	auth := "proxy_api_key_and_task_sigv4"
+	if b.taskSigV4Auth {
+		auth = "task_sigv4"
+	}
 	return map[string]interface{}{
 		"provider":          bedrockMantleName,
 		"status":            "healthy",
@@ -437,7 +452,7 @@ func (b *BedrockMantleProxy) GetHealthStatus() map[string]interface{} {
 		"region":            b.region,
 		"anthropic_region":  b.anthropicRegion,
 		"streaming_support": true,
-		"auth":              "proxy_api_key_and_task_sigv4",
+		"auth":              auth,
 	}
 }
 
@@ -463,20 +478,33 @@ func (b *BedrockMantleProxy) UserIDFromRequest(req *http.Request) string {
 // (langchain_anthropic / the Anthropic SDK) send “x-api-key“. Both are
 // accepted and stripped before SigV4 signing — Mantle upstream auth is AWS
 // credentials only.
+//
+// When taskSigV4Auth is set (sidecar profile), an empty credential or a
+// non-iw placeholder is also accepted: the co-located app is trusted, and
+// the proxy signs upstream with the task role.
 func (b *BedrockMantleProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
 	key := mantleProxyKeyFromRequest(req)
 	if key == "" {
+		if b.taskSigV4Auth {
+			return nil
+		}
 		return fmt.Errorf("bearer proxy API key is required")
 	}
 	_, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), key)
 	if err != nil {
 		return fmt.Errorf("API key validation failed: %w", err)
 	}
-	if !apikeys.IsBedrockFamilyProvider(provider) {
-		return fmt.Errorf("API key is for provider %s, not a Bedrock proxy key", provider)
+	if apikeys.IsBedrockFamilyProvider(provider) {
+		mantleStripProxyAuthHeaders(req)
+		return nil
 	}
-	mantleStripProxyAuthHeaders(req)
-	return nil
+	// Sidecar placeholder / non-proxy credential: strip and proceed. Real iw-*
+	// keys for the wrong provider still fail so misconfigured keys are loud.
+	if b.taskSigV4Auth && !apikeys.HasKeyPrefix(key) {
+		mantleStripProxyAuthHeaders(req)
+		return nil
+	}
+	return fmt.Errorf("API key is for provider %s, not a Bedrock proxy key", provider)
 }
 
 func mantleProxyKeyFromRequest(req *http.Request) string {

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -247,6 +247,71 @@ func TestBedrockMantle_AcceptsBedrockProviderKey(t *testing.T) {
 	}
 }
 
+func TestBedrockMantle_TaskSigV4AuthAllowsMissingKey(t *testing.T) {
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleTaskSigV4Auth: true},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey with empty key: %v", err)
+	}
+}
+
+func TestBedrockMantle_TaskSigV4AuthAllowsPlaceholderKey(t *testing.T) {
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleTaskSigV4Auth: true},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer bedrock-sidecar")
+	if err := proxy.ValidateAPIKey(req, passthroughKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey with placeholder: %v", err)
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Fatal("placeholder Authorization should be stripped before SigV4")
+	}
+}
+
+func TestBedrockMantle_TaskSigV4AuthStillValidatesProxyKeys(t *testing.T) {
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleTaskSigV4Auth: true},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey with Mantle proxy key: %v", err)
+	}
+}
+
+func TestBedrockMantle_TaskSigV4AuthRejectsWrongProviderProxyKey(t *testing.T) {
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleTaskSigV4Auth: true},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer sk-iw-openai")
+	if err := proxy.ValidateAPIKey(req, openaiProxyKeyStore{}); err == nil {
+		t.Fatal("expected wrong-provider iw-* key to fail")
+	}
+}
+
+func TestBedrockMantle_HealthAuthReflectsTaskSigV4(t *testing.T) {
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{MantleTaskSigV4Auth: true},
+	)
+	if got := proxy.GetHealthStatus()["auth"]; got != "task_sigv4" {
+		t.Fatalf("auth=%v, want task_sigv4", got)
+	}
+}
+
 type bedrockProviderKeyStore struct{}
 
 func (bedrockProviderKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (string, string, error) {
@@ -254,6 +319,21 @@ func (bedrockProviderKeyStore) ValidateAndGetActualKey(_ context.Context, key st
 		return "", "", io.EOF
 	}
 	return "unused", "bedrock", nil
+}
+
+type passthroughKeyStore struct{}
+
+func (passthroughKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (string, string, error) {
+	return key, "", nil
+}
+
+type openaiProxyKeyStore struct{}
+
+func (openaiProxyKeyStore) ValidateAndGetActualKey(_ context.Context, key string) (string, string, error) {
+	if key != "sk-iw-openai" {
+		return "", "", io.EOF
+	}
+	return "sk-openai", "openai", nil
 }
 
 func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -143,6 +143,12 @@ type ProxyOptions struct {
 	// region (public constructor: BEDROCK_MANTLE_ANTHROPIC_REGION env or
 	// us-east-1). Consumed only by the Bedrock Mantle proxy.
 	MantleAnthropicRegion string
+
+	// MantleTaskSigV4Auth allows Bedrock Mantle callers with no iw-* key (or a
+	// non-proxy placeholder) when the sidecar trusts the local network and
+	// authenticates upstream with the task role. Standalone proxies leave this
+	// false so Mantle still requires a registered Bedrock-family proxy key.
+	MantleTaskSigV4Auth bool
 }
 
 // ProviderManager manages multiple providers


### PR DESCRIPTION
## Summary
- Add `providers.bedrock-mantle.auth: task_sigv4` for sidecar deployments so Mantle accepts empty/non-`iw-*` credentials and still signs upstream with the task role.
- Wire that mode into `configs/sidecar.yml`; standalone production/staging continue requiring a Bedrock-family proxy key.
- Validate that `task_sigv4` is only allowed for Mantle when `features.history.role=sidecar`.

## Test plan
- [x] `go test -race ./internal/providers/ -run BedrockMantle_TaskSigV4`
- [x] `go test -race ./internal/config/ -run 'ProviderAuth|Sidecar'`
- [x] `go run ./cmd/config-validator/`
- [ ] Deploy sidecar profile and confirm Mantle works without `BEDROCK_API_KEY` from a co-located app (Finch companion change)
- [ ] Confirm standalone llm-proxy still rejects Mantle without an `iw-*` Bedrock key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting provider authentication modes.
  * Bedrock Mantle sidecar deployments can authenticate through task-based signing without requiring a proxy key.
  * Mantle health information now reports the active authentication mode.

* **Bug Fixes**
  * Improved validation and handling of missing, placeholder, and provider-specific authentication credentials.
  * Added configuration checks to reject unsupported authentication combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->