### PR TITLE
fix(dev): default Mantle OpenAI project to us-west-2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,9 @@ services:
       - AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL:-http://dynamodb:8000}
       # Bedrock Mantle SigV4 uses ~/.aws profile creds, not the DynamoDB Local keys above.
       - BEDROCK_AWS_PROFILE=${BEDROCK_AWS_PROFILE:-default}
+      # us-west-2 Mantle project with data_retention.mode=default (account ZDR
+      # otherwise blocks openai.gpt-5.4/5.5). Override or leave empty for other accounts.
+      - LLM_PROXY_BEDROCK_MANTLE_OPENAI_PROJECT_ID=${LLM_PROXY_BEDROCK_MANTLE_OPENAI_PROJECT_ID:-proj_ntg46rjkspf6j5olbzw4}
       # Override the YAML default analyzer_url for the docker-compose
       # network. The sidecar service hostname `presidio` resolves only
       # over this network; production ECS task definitions point at


### PR DESCRIPTION
## Summary
- Defaults `LLM_PROXY_BEDROCK_MANTLE_OPENAI_PROJECT_ID` in docker-compose to `proj_ntg46rjkspf6j5olbzw4` (us-west-2 `openai-default-retention`).
- Matches the production fix: OpenAI Mantle SKUs are invoked in us-west-2, so the project must exist there (the old us-east-1 id caused 404s).

Companion infra: https://github.com/Instawork/infrastructure/pull/3315

## Test plan
- [x] Recreated local `llm-proxy` container; env shows new project id
- [x] `POST /bedrock-mantle/openai/v1/responses` with `openai.gpt-5.4` → 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added support for specifying the Mantle project ID used by the LLM proxy.
  * Clarified configuration guidance for project/account data-retention settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->