### PR TITLE
fix(bedrock-mantle): strip Cloudflare/client hop headers before SigV4

### DIFF
--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -159,9 +159,10 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 		req.Header.Del("X-Amz-Date")
 		req.Header.Del("X-Amz-Content-Sha256")
 		req.Header.Del("X-Amz-Security-Token")
-		// AWS's edge appends the client address to X-Forwarded-For. Do not
-		// include a mutable forwarding header in the SigV4 canonical request.
-		req.Header.Del("X-Forwarded-For")
+		// Drop CDN/client hop headers before SigV4. Cloudflare (in front of
+		// llm.instawork.com) and OpenAI SDKs inject headers that must not be
+		// forwarded or signed — otherwise Mantle returns 401 InvalidSignature.
+		stripMantleClientHopHeaders(req)
 		if opt.DisableGzip {
 			req.Header.Del("Accept-Encoding")
 		}
@@ -239,9 +240,9 @@ type sigV4Transport struct {
 }
 
 func (t *sigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// ReverseProxy adds this after Director. AWS may append it at its edge,
-	// invalidating any signature that includes the header.
-	req.Header.Del("X-Forwarded-For")
+	// ReverseProxy may re-add X-Forwarded-For after Director; strip hop headers
+	// again immediately before signing so they never enter the canonical request.
+	stripMantleClientHopHeaders(req)
 	payload, err := readAndRestoreMantleBody(req)
 	if err != nil {
 		return nil, fmt.Errorf("read Bedrock Mantle request body: %w", err)
@@ -517,6 +518,47 @@ func mantleProxyKeyFromRequest(req *http.Request) string {
 func mantleStripProxyAuthHeaders(req *http.Request) {
 	req.Header.Del("Authorization")
 	req.Header.Del("x-api-key")
+}
+
+// mantleClientHopHeaderNames are exact header names (canonical MIME keys) that
+// must not be forwarded to Bedrock Mantle or included in SigV4 SignedHeaders.
+var mantleClientHopHeaderNames = []string{
+	"Cookie",
+	"Set-Cookie",
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Connection",
+	"Transfer-Encoding",
+	"Upgrade",
+	"Te",
+	"Trailer",
+	"Via",
+	"CDN-Loop",
+	"Priority",
+	"True-Client-IP",
+	"X-Forwarded-For",
+	"X-Forwarded-Port",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Host",
+	"X-Real-IP",
+	"X-Bot-Score",
+}
+
+// stripMantleClientHopHeaders removes Cloudflare, forwarding, and SDK telemetry
+// headers so the AWS SigV4 signer only covers Mantle-relevant headers.
+func stripMantleClientHopHeaders(req *http.Request) {
+	if req == nil {
+		return
+	}
+	for _, name := range mantleClientHopHeaderNames {
+		req.Header.Del(name)
+	}
+	for name := range req.Header {
+		lower := strings.ToLower(name)
+		if strings.HasPrefix(lower, "cf-") || strings.HasPrefix(lower, "x-stainless-") {
+			req.Header.Del(name)
+		}
+	}
 }
 
 func (b *BedrockMantleProxy) RegisterExtraRoutes(_ *mux.Router) {}

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -388,6 +388,79 @@ func TestBedrockMantle_RewritesStripsAndSignsRequest(t *testing.T) {
 	}
 }
 
+func TestBedrockMantle_StripsCloudflareAndClientHopHeadersBeforeSigning(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-5","input":"hello"}`)
+	proxy := newBedrockMantleProxy(
+		"us-west-2",
+		credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+		ProxyOptions{},
+	)
+	signerTransport := proxy.proxy.Transport.(*sigV4Transport)
+	var got *http.Request
+	signerTransport.inner = mantleRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://proxy/bedrock-mantle/openai/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	// Headers Cloudflare / OpenAI SDKs inject in front of llm.instawork.com.
+	req.Header.Set("CDN-Loop", "cloudflare; loops=1")
+	req.Header.Set("CF-Connecting-IP", "73.143.211.71")
+	req.Header.Set("CF-IPCountry", "US")
+	req.Header.Set("CF-Ray", "a1c2110829e6aff6-SEA")
+	req.Header.Set("CF-Visitor", `{"scheme":"https"}`)
+	req.Header.Set("Cookie", "__cf_bm=example")
+	req.Header.Set("X-Bot-Score", "1")
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("X-Forwarded-Port", "3600")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Stainless-Lang", "python")
+	req.Header.Set("X-Stainless-Package-Version", "2.37.0")
+	req.Header.Set("X-Stainless-Runtime", "CPython")
+	if err := proxy.ValidateAPIKey(req, mantleKeyStore{}); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	proxy.Proxy().ServeHTTP(httptest.NewRecorder(), req)
+	if got == nil {
+		t.Fatal("upstream transport was not called")
+	}
+
+	forbidden := []string{
+		"CDN-Loop", "CF-Connecting-IP", "CF-IPCountry", "CF-Ray", "CF-Visitor",
+		"Cookie", "X-Bot-Score", "X-Forwarded-For", "X-Forwarded-Port",
+		"X-Forwarded-Proto", "X-Stainless-Lang", "X-Stainless-Package-Version",
+		"X-Stainless-Runtime",
+	}
+	for _, name := range forbidden {
+		if got.Header.Get(name) != "" {
+			t.Fatalf("%s must be stripped before upstream, got %q", name, got.Header.Get(name))
+		}
+	}
+	auth := strings.ToLower(got.Header.Get("Authorization"))
+	for _, needle := range []string{
+		"cdn-loop", "cf-ray", "cf-connecting-ip", "cookie", "x-bot-score",
+		"x-forwarded-for", "x-forwarded-port", "x-forwarded-proto", "x-stainless-",
+	} {
+		if strings.Contains(auth, needle) {
+			t.Fatalf("SignedHeaders must not include %q: %s", needle, got.Header.Get("Authorization"))
+		}
+	}
+	if got.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("Content-Type should be preserved, got %q", got.Header.Get("Content-Type"))
+	}
+	if !strings.Contains(got.Header.Get("Authorization"), "AWS4-HMAC-SHA256") {
+		t.Fatalf("request was not SigV4-signed: %q", got.Header.Get("Authorization"))
+	}
+}
+
 func mantleUpstreamHeader(t *testing.T, opt ProxyOptions, model, callerProject string) http.Header {
 	t.Helper()
 	proxy := newBedrockMantleProxy(


### PR DESCRIPTION
## Summary
- Requests through `llm.instawork.com` hit Cloudflare first; CF + OpenAI SDK hop headers (`cf-*`, `cdn-loop`, `cookie`, `x-forwarded-*`, `x-bot-score`, `x-stainless-*`) were left on the Mantle upstream request.
- The AWS SigV4 signer includes every remaining header, so Mantle returned `401 invalid_api_key` / InvalidSignature (canonical string listed those CF headers).
- Strip hop/client headers in Director and again in `sigV4Transport.RoundTrip` immediately before signing. Preserve Mantle-relevant headers (`Content-Type`, `OpenAI-Project`, etc.).

## Test plan
- [x] Unit test injects CF/SDK headers and asserts they are absent upstream and not in `SignedHeaders`
- [x] `go test -race ./internal/providers/ -run BedrockMantle`
- [ ] Deploy llm-proxy; retry Finch playground via `llm.instawork.com` with a Bedrock Mantle model
- [ ] Confirm local `localhost:9002` Mantle path still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request signing reliability for Bedrock Mantle integrations by removing CDN, proxy, and client telemetry headers that could invalidate signatures.
  * Preserved required request headers, including `Content-Type`, while ensuring excluded headers are not forwarded or included in signatures.

* **Tests**
  * Added coverage verifying that Cloudflare and client-hop headers are removed before requests are signed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->