### PR TITLE
feat(upstream): configurable response header timeout, default 5m

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1289,22 +1289,32 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 	bedrock *providers.BedrockProxy,
 	bedrockMantle *providers.BedrockMantleProxy,
 ) {
-	proxyOpts := providers.ProxyOptions{DisableGzip: disableGzip}
+	baseOpts := providers.ProxyOptions{DisableGzip: disableGzip}
 	if disableGzip {
 		logProxyWarn("Gzip disabled: Accept-Encoding stripped and transport compression off (debug mode)")
 	}
+	logger.Info("Upstream response header timeout",
+		"default", yamlConfig.DefaultResponseHeaderTimeout().String())
 
-	openAI = providers.NewOpenAIProxy(proxyOpts)
+	openAIOpts := baseOpts
+	openAIOpts.ResponseHeaderTimeout = yamlConfig.ResponseHeaderTimeoutFor("openai")
+	openAI = providers.NewOpenAIProxy(openAIOpts)
 	globalProviderManager.RegisterProvider(openAI)
 
-	anthropic = providers.NewAnthropicProxy(proxyOpts)
+	anthropicOpts := baseOpts
+	anthropicOpts.ResponseHeaderTimeout = yamlConfig.ResponseHeaderTimeoutFor("anthropic")
+	anthropic = providers.NewAnthropicProxy(anthropicOpts)
 	globalProviderManager.RegisterProvider(anthropic)
 
-	gemini = providers.NewGeminiProxy(proxyOpts)
+	geminiOpts := baseOpts
+	geminiOpts.ResponseHeaderTimeout = yamlConfig.ResponseHeaderTimeoutFor("gemini")
+	gemini = providers.NewGeminiProxy(geminiOpts)
 	globalProviderManager.RegisterProvider(gemini)
 
 	if bedrockCfg, ok := yamlConfig.Providers["bedrock"]; ok && bedrockCfg.Enabled {
-		bedrock = providers.NewBedrockProxy(proxyOpts)
+		bedrockOpts := baseOpts
+		bedrockOpts.ResponseHeaderTimeout = yamlConfig.ResponseHeaderTimeoutFor("bedrock")
+		bedrock = providers.NewBedrockProxy(bedrockOpts)
 		globalProviderManager.RegisterProvider(bedrock)
 		circuitBreakerProviders = append(circuitBreakerProviders, "bedrock")
 		logger.Info("☁️  Bedrock provider: ENABLED", "region", bedrock.Region())
@@ -1312,7 +1322,8 @@ func registerProviders(yamlConfig *config.YAMLConfig, disableGzip bool) (
 		logger.Info("☁️  Bedrock provider: DISABLED (set providers.bedrock.enabled: true to enable)")
 	}
 	if mantleCfg, ok := yamlConfig.Providers["bedrock-mantle"]; ok && mantleCfg.Enabled {
-		mantleOpts := proxyOpts
+		mantleOpts := baseOpts
+		mantleOpts.ResponseHeaderTimeout = yamlConfig.ResponseHeaderTimeoutFor("bedrock-mantle")
 		mantleOpts.MantleModelProjects = buildMantleModelProjects(mantleCfg)
 		mantleOpts.MantleTaskSigV4Auth = strings.EqualFold(strings.TrimSpace(mantleCfg.Auth), config.ProviderAuthTaskSigV4)
 		var mantleErr error

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -92,6 +92,15 @@ features:
   # client_gzip:
   #   enabled: false
   # ---------------------------------------------------------------------------
+  # Upstream provider HTTP transport
+  # ---------------------------------------------------------------------------
+  # How long the proxy waits for the first response header from an LLM provider
+  # before returning 502. Must stay <= Cloudflare origin read timeout and the
+  # dedicated ALB idle_timeout (typically 300s when aligned). Override per
+  # provider with providers.<name>.response_header_timeout_seconds.
+  upstream:
+    response_header_timeout_seconds: 300
+  # ---------------------------------------------------------------------------
   # Government ID gate (OCR sidecar + Presidio on embedded chat images)
   # ---------------------------------------------------------------------------
   id_gate:
@@ -257,6 +266,8 @@ retired_models:
 providers:
   openai:
     enabled: true
+    # Optional per-provider override of features.upstream.response_header_timeout_seconds:
+    # response_header_timeout_seconds: 300
     default_limits:
       tokens_per_minute: 450_000
       requests_per_minute: 5_000

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,9 +8,17 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// DefaultResponseHeaderTimeoutSeconds is how long the proxy waits for the
+// first response header from an upstream LLM provider before returning 502.
+// Kept at 5 minutes so non-streaming Responses / thinking-model TTFT can
+// complete under Cloudflare's origin read timeout and the dedicated ALB
+// idle_timeout (both typically 300s when aligned).
+const DefaultResponseHeaderTimeoutSeconds = 300
 
 // formatNumber formats a number with commas for better readability
 func formatNumber(n int64) string {
@@ -71,6 +79,16 @@ type FeaturesConfig struct {
 	AdminDashboard   AdminDashboardConfig   `yaml:"admin_dashboard"`
 	History          HistoryConfig          `yaml:"history"`
 	ClientGzip       ClientGzipConfig       `yaml:"client_gzip"`
+	Upstream         UpstreamConfig         `yaml:"upstream"`
+}
+
+// UpstreamConfig configures outbound HTTP behaviour toward LLM providers.
+type UpstreamConfig struct {
+	// ResponseHeaderTimeoutSeconds is the default how long the proxy waits for
+	// the first response byte/header from any provider. Zero uses
+	// DefaultResponseHeaderTimeoutSeconds. Per-provider overrides live on
+	// ProviderConfig.ResponseHeaderTimeoutSeconds.
+	ResponseHeaderTimeoutSeconds int `yaml:"response_header_timeout_seconds"`
 }
 
 // ClientGzipConfig optionally gzip-compresses non-streaming responses to
@@ -761,6 +779,9 @@ type ProviderConfig struct {
 	// "task_sigv4" (bedrock-mantle + sidecar only) trusts the local network and
 	// authenticates upstream with the task role.
 	Auth string `yaml:"auth,omitempty"`
+	// ResponseHeaderTimeoutSeconds overrides features.upstream.response_header_timeout_seconds
+	// for this provider only. Zero inherits the global default.
+	ResponseHeaderTimeoutSeconds int `yaml:"response_header_timeout_seconds,omitempty"`
 }
 
 // ModelConfig represents configuration for a specific model
@@ -1164,7 +1185,45 @@ func (c *YAMLConfig) Validate() error {
 		return err
 	}
 
+	if err := c.validateUpstreamConfig(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (c *YAMLConfig) validateUpstreamConfig() error {
+	if c.Features.Upstream.ResponseHeaderTimeoutSeconds < 0 {
+		return fmt.Errorf("invalid upstream configuration: response_header_timeout_seconds cannot be negative")
+	}
+	for name, provider := range c.Providers {
+		if provider.ResponseHeaderTimeoutSeconds < 0 {
+			return fmt.Errorf("invalid providers.%s configuration: response_header_timeout_seconds cannot be negative", name)
+		}
+	}
+	return nil
+}
+
+// DefaultResponseHeaderTimeout returns the global upstream response-header
+// timeout, falling back to DefaultResponseHeaderTimeoutSeconds when unset.
+func (c *YAMLConfig) DefaultResponseHeaderTimeout() time.Duration {
+	sec := DefaultResponseHeaderTimeoutSeconds
+	if c != nil && c.Features.Upstream.ResponseHeaderTimeoutSeconds > 0 {
+		sec = c.Features.Upstream.ResponseHeaderTimeoutSeconds
+	}
+	return time.Duration(sec) * time.Second
+}
+
+// ResponseHeaderTimeoutFor returns the effective response-header timeout for
+// provider. A positive providers.<name>.response_header_timeout_seconds wins;
+// otherwise the global upstream default is used.
+func (c *YAMLConfig) ResponseHeaderTimeoutFor(provider string) time.Duration {
+	if c != nil {
+		if p, ok := c.Providers[provider]; ok && p.ResponseHeaderTimeoutSeconds > 0 {
+			return time.Duration(p.ResponseHeaderTimeoutSeconds) * time.Second
+		}
+	}
+	return c.DefaultResponseHeaderTimeout()
 }
 
 func (c *YAMLConfig) validateProviderAuth() error {

--- a/internal/config/upstream_timeout_test.go
+++ b/internal/config/upstream_timeout_test.go
@@ -1,86 +1,243 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
-func TestDefaultResponseHeaderTimeout(t *testing.T) {
+func TestUpstreamConfig_Unmarshal(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil config uses package default", func(t *testing.T) {
-		t.Parallel()
-		var cfg *YAMLConfig
-		if got := cfg.DefaultResponseHeaderTimeout(); got != DefaultResponseHeaderTimeoutSeconds*time.Second {
-			t.Fatalf("got %v, want %ds", got, DefaultResponseHeaderTimeoutSeconds)
-		}
-	})
+	raw := `
+enabled: true
+features:
+  cost_tracking:
+    enabled: false
+  upstream:
+    response_header_timeout_seconds: 300
+providers:
+  openai:
+    enabled: true
+  gemini:
+    enabled: true
+    response_header_timeout_seconds: 600
+  anthropic:
+    enabled: true
+    response_header_timeout_seconds: 0
+`
+	var cfg YAMLConfig
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &cfg))
+	require.Equal(t, 300, cfg.Features.Upstream.ResponseHeaderTimeoutSeconds)
+	require.Equal(t, 0, cfg.Providers["openai"].ResponseHeaderTimeoutSeconds)
+	require.Equal(t, 600, cfg.Providers["gemini"].ResponseHeaderTimeoutSeconds)
+	require.Equal(t, 0, cfg.Providers["anthropic"].ResponseHeaderTimeoutSeconds)
 
-	t.Run("zero upstream uses package default", func(t *testing.T) {
-		t.Parallel()
-		cfg := &YAMLConfig{}
-		if got := cfg.DefaultResponseHeaderTimeout(); got != 5*time.Minute {
-			t.Fatalf("got %v, want 5m", got)
-		}
-	})
-
-	t.Run("explicit upstream default", func(t *testing.T) {
-		t.Parallel()
-		cfg := &YAMLConfig{}
-		cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = 120
-		if got := cfg.DefaultResponseHeaderTimeout(); got != 2*time.Minute {
-			t.Fatalf("got %v, want 2m", got)
-		}
-	})
+	require.Equal(t, 5*time.Minute, cfg.DefaultResponseHeaderTimeout())
+	require.Equal(t, 5*time.Minute, cfg.ResponseHeaderTimeoutFor("openai"))
+	require.Equal(t, 10*time.Minute, cfg.ResponseHeaderTimeoutFor("gemini"))
+	require.Equal(t, 5*time.Minute, cfg.ResponseHeaderTimeoutFor("anthropic"))
 }
 
-func TestResponseHeaderTimeoutFor(t *testing.T) {
+func TestLoadYAMLConfig_UpstreamTimeouts(t *testing.T) {
 	t.Parallel()
 
-	cfg := &YAMLConfig{
-		Providers: map[string]ProviderConfig{
-			"openai": {Enabled: true},
-			"gemini": {Enabled: true, ResponseHeaderTimeoutSeconds: 600},
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream.yml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+enabled: true
+features:
+  cost_tracking:
+    enabled: false
+  upstream:
+    response_header_timeout_seconds: 180
+providers:
+  openai:
+    enabled: true
+  bedrock:
+    enabled: true
+    response_header_timeout_seconds: 420
+`), 0o644))
+
+	cfg, err := LoadYAMLConfig(path)
+	require.NoError(t, err)
+	require.Equal(t, 180, cfg.Features.Upstream.ResponseHeaderTimeoutSeconds)
+	require.Equal(t, 3*time.Minute, cfg.DefaultResponseHeaderTimeout())
+	require.Equal(t, 3*time.Minute, cfg.ResponseHeaderTimeoutFor("openai"))
+	require.Equal(t, 7*time.Minute, cfg.ResponseHeaderTimeoutFor("bedrock"))
+	require.Equal(t, 3*time.Minute, cfg.ResponseHeaderTimeoutFor("gemini"))
+}
+
+func TestLoadAndMergeConfigs_UpstreamTimeoutOverlay(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.yml")
+	overlay := filepath.Join(dir, "overlay.yml")
+	require.NoError(t, os.WriteFile(base, []byte(`
+enabled: true
+features:
+  cost_tracking:
+    enabled: false
+  upstream:
+    response_header_timeout_seconds: 300
+providers:
+  openai:
+    enabled: true
+  gemini:
+    enabled: true
+`), 0o644))
+	require.NoError(t, os.WriteFile(overlay, []byte(`
+features:
+  upstream:
+    response_header_timeout_seconds: 240
+providers:
+  gemini:
+    response_header_timeout_seconds: 480
+`), 0o644))
+
+	cfg, err := LoadAndMergeConfigs([]string{base, overlay})
+	require.NoError(t, err)
+	require.Equal(t, 240, cfg.Features.Upstream.ResponseHeaderTimeoutSeconds)
+	require.Equal(t, 4*time.Minute, cfg.DefaultResponseHeaderTimeout())
+	require.Equal(t, 4*time.Minute, cfg.ResponseHeaderTimeoutFor("openai"))
+	require.Equal(t, 8*time.Minute, cfg.ResponseHeaderTimeoutFor("gemini"))
+}
+
+func TestBaseYAML_UpstreamTimeoutDefault(t *testing.T) {
+	// Repo-root relative: tests run with package dir as cwd for `go test ./internal/config`.
+	cfg, err := LoadYAMLConfig(filepath.Join("..", "..", "configs", "base.yml"))
+	require.NoError(t, err)
+	require.Equal(t, 300, cfg.Features.Upstream.ResponseHeaderTimeoutSeconds)
+	require.Equal(t, 5*time.Minute, cfg.DefaultResponseHeaderTimeout())
+	for _, name := range []string{"openai", "anthropic", "gemini", "bedrock", "bedrock-mantle"} {
+		require.Equal(t, 5*time.Minute, cfg.ResponseHeaderTimeoutFor(name), name)
+	}
+}
+
+func TestResponseHeaderTimeoutFor_Table(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		cfg      *YAMLConfig
+		provider string
+		want     time.Duration
+	}{
+		{
+			name:     "nil config",
+			cfg:      nil,
+			provider: "openai",
+			want:     5 * time.Minute,
+		},
+		{
+			name:     "empty config",
+			cfg:      &YAMLConfig{},
+			provider: "openai",
+			want:     5 * time.Minute,
+		},
+		{
+			name: "global only",
+			cfg: &YAMLConfig{
+				Features: FeaturesConfig{
+					Upstream: UpstreamConfig{ResponseHeaderTimeoutSeconds: 90},
+				},
+			},
+			provider: "openai",
+			want:     90 * time.Second,
+		},
+		{
+			name: "provider zero inherits global",
+			cfg: &YAMLConfig{
+				Features: FeaturesConfig{
+					Upstream: UpstreamConfig{ResponseHeaderTimeoutSeconds: 120},
+				},
+				Providers: map[string]ProviderConfig{
+					"openai": {ResponseHeaderTimeoutSeconds: 0},
+				},
+			},
+			provider: "openai",
+			want:     2 * time.Minute,
+		},
+		{
+			name: "provider override beats global",
+			cfg: &YAMLConfig{
+				Features: FeaturesConfig{
+					Upstream: UpstreamConfig{ResponseHeaderTimeoutSeconds: 120},
+				},
+				Providers: map[string]ProviderConfig{
+					"openai": {ResponseHeaderTimeoutSeconds: 45},
+				},
+			},
+			provider: "openai",
+			want:     45 * time.Second,
+		},
+		{
+			name: "unknown provider inherits global",
+			cfg: &YAMLConfig{
+				Features: FeaturesConfig{
+					Upstream: UpstreamConfig{ResponseHeaderTimeoutSeconds: 150},
+				},
+				Providers: map[string]ProviderConfig{
+					"openai": {ResponseHeaderTimeoutSeconds: 600},
+				},
+			},
+			provider: "not-a-provider",
+			want:     150 * time.Second,
 		},
 	}
-	cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = 300
 
-	if got := cfg.ResponseHeaderTimeoutFor("openai"); got != 5*time.Minute {
-		t.Fatalf("openai: got %v, want 5m (global default)", got)
-	}
-	if got := cfg.ResponseHeaderTimeoutFor("gemini"); got != 10*time.Minute {
-		t.Fatalf("gemini: got %v, want 10m (provider override)", got)
-	}
-	if got := cfg.ResponseHeaderTimeoutFor("missing"); got != 5*time.Minute {
-		t.Fatalf("missing provider: got %v, want 5m", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.cfg.ResponseHeaderTimeoutFor(tc.provider); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
-func TestValidateUpstreamConfig(t *testing.T) {
+func TestValidateUpstreamConfig_ErrorMessages(t *testing.T) {
 	t.Parallel()
 
-	cfg := GetDefaultYAMLConfig()
-	cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = -1
-	if err := cfg.Validate(); err == nil {
-		t.Fatal("expected error for negative global timeout")
-	}
+	t.Run("negative global", func(t *testing.T) {
+		t.Parallel()
+		cfg := GetDefaultYAMLConfig()
+		cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = -1
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "response_header_timeout_seconds cannot be negative")
+	})
 
-	cfg = GetDefaultYAMLConfig()
-	cfg.Providers["openai"] = ProviderConfig{
-		Enabled:                      true,
-		ResponseHeaderTimeoutSeconds: -5,
-	}
-	if err := cfg.Validate(); err == nil {
-		t.Fatal("expected error for negative provider timeout")
-	}
+	t.Run("negative provider names provider", func(t *testing.T) {
+		t.Parallel()
+		cfg := GetDefaultYAMLConfig()
+		cfg.Providers["gemini"] = ProviderConfig{
+			Enabled:                      true,
+			ResponseHeaderTimeoutSeconds: -2,
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.True(t,
+			strings.Contains(err.Error(), "providers.gemini") &&
+				strings.Contains(err.Error(), "response_header_timeout_seconds cannot be negative"),
+			"got %v", err)
+	})
 
-	cfg = GetDefaultYAMLConfig()
-	cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = 300
-	cfg.Providers["openai"] = ProviderConfig{
-		Enabled:                      true,
-		ResponseHeaderTimeoutSeconds: 600,
-	}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("unexpected validate error: %v", err)
-	}
+	t.Run("zero values ok", func(t *testing.T) {
+		t.Parallel()
+		cfg := GetDefaultYAMLConfig()
+		cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = 0
+		cfg.Providers["openai"] = ProviderConfig{
+			Enabled:                      true,
+			ResponseHeaderTimeoutSeconds: 0,
+		}
+		require.NoError(t, cfg.validateUpstreamConfig())
+		require.Equal(t, 5*time.Minute, cfg.DefaultResponseHeaderTimeout())
+	})
 }

--- a/internal/config/upstream_timeout_test.go
+++ b/internal/config/upstream_timeout_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config uses package default", func(t *testing.T) {
+		t.Parallel()
+		var cfg *YAMLConfig
+		if got := cfg.DefaultResponseHeaderTimeout(); got != DefaultResponseHeaderTimeoutSeconds*time.Second {
+			t.Fatalf("got %v, want %ds", got, DefaultResponseHeaderTimeoutSeconds)
+		}
+	})
+
+	t.Run("zero upstream uses package default", func(t *testing.T) {
+		t.Parallel()
+		cfg := &YAMLConfig{}
+		if got := cfg.DefaultResponseHeaderTimeout(); got != 5*time.Minute {
+			t.Fatalf("got %v, want 5m", got)
+		}
+	})
+
+	t.Run("explicit upstream default", func(t *testing.T) {
+		t.Parallel()
+		cfg := &YAMLConfig{}
+		cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = 120
+		if got := cfg.DefaultResponseHeaderTimeout(); got != 2*time.Minute {
+			t.Fatalf("got %v, want 2m", got)
+		}
+	})
+}
+
+func TestResponseHeaderTimeoutFor(t *testing.T) {
+	t.Parallel()
+
+	cfg := &YAMLConfig{
+		Providers: map[string]ProviderConfig{
+			"openai": {Enabled: true},
+			"gemini": {Enabled: true, ResponseHeaderTimeoutSeconds: 600},
+		},
+	}
+	cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = 300
+
+	if got := cfg.ResponseHeaderTimeoutFor("openai"); got != 5*time.Minute {
+		t.Fatalf("openai: got %v, want 5m (global default)", got)
+	}
+	if got := cfg.ResponseHeaderTimeoutFor("gemini"); got != 10*time.Minute {
+		t.Fatalf("gemini: got %v, want 10m (provider override)", got)
+	}
+	if got := cfg.ResponseHeaderTimeoutFor("missing"); got != 5*time.Minute {
+		t.Fatalf("missing provider: got %v, want 5m", got)
+	}
+}
+
+func TestValidateUpstreamConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := GetDefaultYAMLConfig()
+	cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = -1
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for negative global timeout")
+	}
+
+	cfg = GetDefaultYAMLConfig()
+	cfg.Providers["openai"] = ProviderConfig{
+		Enabled:                      true,
+		ResponseHeaderTimeoutSeconds: -5,
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for negative provider timeout")
+	}
+
+	cfg = GetDefaultYAMLConfig()
+	cfg.Features.Upstream.ResponseHeaderTimeoutSeconds = 300
+	cfg.Providers["openai"] = ProviderConfig{
+		Enabled:                      true,
+		ResponseHeaderTimeoutSeconds: 600,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected validate error: %v", err)
+	}
+}

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -56,7 +56,7 @@ func NewAnthropicProxy(opts ...ProxyOptions) *AnthropicProxy {
 	proxy.Director = CreateGenericDirector(anthropicProxy, targetURL, originalDirector, opt.DisableGzip)
 
 	// Customize the transport for optimal streaming performance
-	proxy.Transport = newProxyTransport(opt.DisableGzip)
+	proxy.Transport = newProxyTransport(opt.DisableGzip, opt.ResponseHeaderTimeout)
 
 	// Add custom response modifier for streaming support
 	proxy.ModifyResponse = func(resp *http.Response) error {

--- a/internal/providers/bedrock.go
+++ b/internal/providers/bedrock.go
@@ -120,7 +120,7 @@ func NewBedrockProxy(opts ...ProxyOptions) *BedrockProxy {
 		}
 	}
 
-	proxy.Transport = newProxyTransport(opt.DisableGzip)
+	proxy.Transport = newProxyTransport(opt.DisableGzip, opt.ResponseHeaderTimeout)
 
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if bedrockProxy.isStreamingResponse(resp) {

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -170,7 +170,7 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 	}
 	proxy.Transport = &sigV4Transport{
 		credentials:   credentials,
-		inner:         newProxyTransport(opt.DisableGzip),
+		inner:         newProxyTransport(opt.DisableGzip, opt.ResponseHeaderTimeout),
 		region:        region,
 		regionForPath: mantle.regionForPath,
 		service:       bedrockMantleService,

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -59,11 +59,10 @@ func NewGeminiProxy(opts ...ProxyOptions) *GeminiProxy {
 	originalDirector := proxy.Director
 	proxy.Director = CreateGenericDirector(geminiProxy, targetURL, originalDirector, opt.DisableGzip)
 
-	// Customize the transport for optimal streaming performance.
-	// Gemini can be significantly slower to return response headers than other providers,
-	// so give it a dedicated transport with a longer ResponseHeaderTimeout to avoid
-	// premature 502s that trigger repeated retries in the client.
-	proxy.Transport = newGeminiProxyTransport(opt.DisableGzip)
+	// Customize the transport for optimal streaming performance. Gemini historically
+	// needed a longer ResponseHeaderTimeout than other providers; the shared default
+	// is now 5m and can be overridden via providers.gemini.response_header_timeout_seconds.
+	proxy.Transport = newProxyTransport(opt.DisableGzip, opt.ResponseHeaderTimeout)
 
 	// Add custom response modifier for streaming support
 	proxy.ModifyResponse = func(resp *http.Response) error {

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -58,7 +58,7 @@ func NewOpenAIProxy(opts ...ProxyOptions) *OpenAIProxy {
 	proxy.Director = CreateGenericDirector(openAIProxy, targetURL, originalDirector, opt.DisableGzip)
 
 	// Customize the transport for optimal streaming performance
-	proxy.Transport = newProxyTransport(opt.DisableGzip)
+	proxy.Transport = newProxyTransport(opt.DisableGzip, opt.ResponseHeaderTimeout)
 
 	// Add custom response modifier for streaming support
 	proxy.ModifyResponse = func(resp *http.Response) error {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -128,6 +128,11 @@ type ProxyOptions struct {
 	// visible in logs.  Defaults to false (gzip enabled).
 	DisableGzip bool
 
+	// ResponseHeaderTimeout is how long the outbound transport waits for the
+	// first response header from the upstream provider before failing with
+	// 502. Zero falls back to DefaultResponseHeaderTimeout (5 minutes).
+	ResponseHeaderTimeout time.Duration
+
 	// MantleModelProjects maps a Bedrock Mantle model id (or alias) to the
 	// Bedrock project id that should handle it. When a request's model matches,
 	// the Mantle proxy sets the OpenAI-Project header so Mantle resolves
@@ -149,6 +154,17 @@ type ProxyOptions struct {
 	// authenticates upstream with the task role. Standalone proxies leave this
 	// false so Mantle still requires a registered Bedrock-family proxy key.
 	MantleTaskSigV4Auth bool
+}
+
+// DefaultResponseHeaderTimeout is the fallback when ProxyOptions leaves
+// ResponseHeaderTimeout unset. Matches config.DefaultResponseHeaderTimeoutSeconds.
+const DefaultResponseHeaderTimeout = 5 * time.Minute
+
+func effectiveResponseHeaderTimeout(d time.Duration) time.Duration {
+	if d > 0 {
+		return d
+	}
+	return DefaultResponseHeaderTimeout
 }
 
 // ProviderManager manages multiple providers
@@ -290,8 +306,9 @@ func CreateGenericDirector(provider Provider, targetURL *url.URL, originalDirect
 // proxying LLM requests.  When disableGzip is true, DisableCompression is set
 // so Go's transport never auto-decompresses upstream gzip responses — useful
 // alongside Accept-Encoding stripping in CreateGenericDirector for debug builds.
-// Defaults to false (gzip allowed).
-func newProxyTransport(disableGzip bool) *http.Transport {
+// Defaults to false (gzip allowed). responseHeaderTimeout of zero uses
+// DefaultResponseHeaderTimeout (5 minutes).
+func newProxyTransport(disableGzip bool, responseHeaderTimeout time.Duration) *http.Transport {
 	// These settings are based on http.DefaultTransport, but customized for the proxy.
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -305,21 +322,12 @@ func newProxyTransport(disableGzip bool) *http.Transport {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		// A generous timeout for the response header, as some LLM providers
-		// may take a while to start streaming a response.
-		ResponseHeaderTimeout: 3 * time.Minute,
+		// (thinking models, non-streaming Responses) may take a while to start
+		// returning a response. Keep this <= Cloudflare origin read timeout
+		// and the dedicated ALB idle_timeout (typically 300s when aligned).
+		ResponseHeaderTimeout: effectiveResponseHeaderTimeout(responseHeaderTimeout),
 		DisableCompression:    disableGzip,
 	}
-}
-
-// newGeminiProxyTransport creates a transport specifically for Gemini requests.
-// Gemini models (especially larger ones) can take significantly longer to start
-// returning response headers than other providers, so we use a longer
-// ResponseHeaderTimeout to avoid premature 502s that the google-genai client
-// would then retry multiple times, leading to very long total request durations.
-func newGeminiProxyTransport(disableGzip bool) *http.Transport {
-	t := newProxyTransport(disableGzip)
-	t.ResponseHeaderTimeout = 5 * time.Minute
-	return t
 }
 
 // DecompressResponseIfNeeded checks if the response is gzip compressed and decompresses it.

--- a/internal/providers/transport_timeout_test.go
+++ b/internal/providers/transport_timeout_test.go
@@ -1,0 +1,68 @@
+package providers
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewProxyTransportResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	tr := newProxyTransport(false, 0)
+	if tr.ResponseHeaderTimeout != DefaultResponseHeaderTimeout {
+		t.Fatalf("zero timeout: got %v, want %v", tr.ResponseHeaderTimeout, DefaultResponseHeaderTimeout)
+	}
+
+	tr = newProxyTransport(false, 2*time.Minute)
+	if tr.ResponseHeaderTimeout != 2*time.Minute {
+		t.Fatalf("explicit timeout: got %v, want 2m", tr.ResponseHeaderTimeout)
+	}
+}
+
+func TestProviderConstructorsHonorResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	want := 7 * time.Minute
+	opt := ProxyOptions{ResponseHeaderTimeout: want}
+
+	cases := []struct {
+		name string
+		get  func() *http.Transport
+	}{
+		{"openai", func() *http.Transport {
+			return NewOpenAIProxy(opt).proxy.Transport.(*http.Transport)
+		}},
+		{"anthropic", func() *http.Transport {
+			return NewAnthropicProxy(opt).proxy.Transport.(*http.Transport)
+		}},
+		{"gemini", func() *http.Transport {
+			return NewGeminiProxy(opt).proxy.Transport.(*http.Transport)
+		}},
+		{"bedrock", func() *http.Transport {
+			return NewBedrockProxy(opt).proxy.Transport.(*http.Transport)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tr := tc.get()
+			if tr.ResponseHeaderTimeout != want {
+				t.Fatalf("got %v, want %v", tr.ResponseHeaderTimeout, want)
+			}
+		})
+	}
+}
+
+func TestProviderConstructorsDefaultResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	tr := NewOpenAIProxy().proxy.Transport.(*http.Transport)
+	if tr.ResponseHeaderTimeout != DefaultResponseHeaderTimeout {
+		t.Fatalf("got %v, want %v", tr.ResponseHeaderTimeout, DefaultResponseHeaderTimeout)
+	}
+	tr = NewGeminiProxy().proxy.Transport.(*http.Transport)
+	if tr.ResponseHeaderTimeout != DefaultResponseHeaderTimeout {
+		t.Fatalf("gemini default got %v, want %v", tr.ResponseHeaderTimeout, DefaultResponseHeaderTimeout)
+	}
+}

--- a/internal/providers/transport_timeout_test.go
+++ b/internal/providers/transport_timeout_test.go
@@ -4,20 +4,29 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/stretchr/testify/require"
 )
+
+func TestEffectiveResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, DefaultResponseHeaderTimeout, effectiveResponseHeaderTimeout(0))
+	require.Equal(t, DefaultResponseHeaderTimeout, effectiveResponseHeaderTimeout(-time.Second))
+	require.Equal(t, 90*time.Second, effectiveResponseHeaderTimeout(90*time.Second))
+}
 
 func TestNewProxyTransportResponseHeaderTimeout(t *testing.T) {
 	t.Parallel()
 
 	tr := newProxyTransport(false, 0)
-	if tr.ResponseHeaderTimeout != DefaultResponseHeaderTimeout {
-		t.Fatalf("zero timeout: got %v, want %v", tr.ResponseHeaderTimeout, DefaultResponseHeaderTimeout)
-	}
+	require.Equal(t, DefaultResponseHeaderTimeout, tr.ResponseHeaderTimeout)
+	require.False(t, tr.DisableCompression)
 
-	tr = newProxyTransport(false, 2*time.Minute)
-	if tr.ResponseHeaderTimeout != 2*time.Minute {
-		t.Fatalf("explicit timeout: got %v, want 2m", tr.ResponseHeaderTimeout)
-	}
+	tr = newProxyTransport(true, 2*time.Minute)
+	require.Equal(t, 2*time.Minute, tr.ResponseHeaderTimeout)
+	require.True(t, tr.DisableCompression)
 }
 
 func TestProviderConstructorsHonorResponseHeaderTimeout(t *testing.T) {
@@ -28,28 +37,46 @@ func TestProviderConstructorsHonorResponseHeaderTimeout(t *testing.T) {
 
 	cases := []struct {
 		name string
-		get  func() *http.Transport
+		get  func(t *testing.T) *http.Transport
 	}{
-		{"openai", func() *http.Transport {
-			return NewOpenAIProxy(opt).proxy.Transport.(*http.Transport)
+		{"openai", func(t *testing.T) *http.Transport {
+			tr, ok := NewOpenAIProxy(opt).proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
 		}},
-		{"anthropic", func() *http.Transport {
-			return NewAnthropicProxy(opt).proxy.Transport.(*http.Transport)
+		{"anthropic", func(t *testing.T) *http.Transport {
+			tr, ok := NewAnthropicProxy(opt).proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
 		}},
-		{"gemini", func() *http.Transport {
-			return NewGeminiProxy(opt).proxy.Transport.(*http.Transport)
+		{"gemini", func(t *testing.T) *http.Transport {
+			tr, ok := NewGeminiProxy(opt).proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
 		}},
-		{"bedrock", func() *http.Transport {
-			return NewBedrockProxy(opt).proxy.Transport.(*http.Transport)
+		{"bedrock", func(t *testing.T) *http.Transport {
+			tr, ok := NewBedrockProxy(opt).proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
+		}},
+		{"bedrock-mantle", func(t *testing.T) *http.Transport {
+			proxy := newBedrockMantleProxy(
+				"us-west-2",
+				credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+				opt,
+			)
+			signer, ok := proxy.proxy.Transport.(*sigV4Transport)
+			require.True(t, ok)
+			tr, ok := signer.inner.(*http.Transport)
+			require.True(t, ok)
+			return tr
 		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tr := tc.get()
-			if tr.ResponseHeaderTimeout != want {
-				t.Fatalf("got %v, want %v", tr.ResponseHeaderTimeout, want)
-			}
+			tr := tc.get(t)
+			require.Equal(t, want, tr.ResponseHeaderTimeout)
 		})
 	}
 }
@@ -57,12 +84,61 @@ func TestProviderConstructorsHonorResponseHeaderTimeout(t *testing.T) {
 func TestProviderConstructorsDefaultResponseHeaderTimeout(t *testing.T) {
 	t.Parallel()
 
-	tr := NewOpenAIProxy().proxy.Transport.(*http.Transport)
-	if tr.ResponseHeaderTimeout != DefaultResponseHeaderTimeout {
-		t.Fatalf("got %v, want %v", tr.ResponseHeaderTimeout, DefaultResponseHeaderTimeout)
+	cases := []struct {
+		name string
+		get  func(t *testing.T) *http.Transport
+	}{
+		{"openai", func(t *testing.T) *http.Transport {
+			tr, ok := NewOpenAIProxy().proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
+		}},
+		{"anthropic", func(t *testing.T) *http.Transport {
+			tr, ok := NewAnthropicProxy().proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
+		}},
+		{"gemini", func(t *testing.T) *http.Transport {
+			tr, ok := NewGeminiProxy().proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
+		}},
+		{"bedrock", func(t *testing.T) *http.Transport {
+			tr, ok := NewBedrockProxy().proxy.Transport.(*http.Transport)
+			require.True(t, ok)
+			return tr
+		}},
+		{"bedrock-mantle", func(t *testing.T) *http.Transport {
+			proxy := newBedrockMantleProxy(
+				"us-west-2",
+				credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "secret", "session"),
+				ProxyOptions{},
+			)
+			signer, ok := proxy.proxy.Transport.(*sigV4Transport)
+			require.True(t, ok)
+			tr, ok := signer.inner.(*http.Transport)
+			require.True(t, ok)
+			return tr
+		}},
 	}
-	tr = NewGeminiProxy().proxy.Transport.(*http.Transport)
-	if tr.ResponseHeaderTimeout != DefaultResponseHeaderTimeout {
-		t.Fatalf("gemini default got %v, want %v", tr.ResponseHeaderTimeout, DefaultResponseHeaderTimeout)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tr := tc.get(t)
+			require.Equal(t, DefaultResponseHeaderTimeout, tr.ResponseHeaderTimeout)
+		})
 	}
+}
+
+func TestProxyOptionsDisableGzipIndependentOfTimeout(t *testing.T) {
+	t.Parallel()
+
+	opt := ProxyOptions{
+		DisableGzip:           true,
+		ResponseHeaderTimeout: 90 * time.Second,
+	}
+	tr, ok := NewOpenAIProxy(opt).proxy.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.True(t, tr.DisableCompression)
+	require.Equal(t, 90*time.Second, tr.ResponseHeaderTimeout)
 }


### PR DESCRIPTION
## Summary
- Raise outbound `ResponseHeaderTimeout` from 3m to **5m** so non-streaming Responses / thinking-model TTFT can finish under Cloudflare + ALB (typically 300s when aligned).
- Add global default via `features.upstream.response_header_timeout_seconds` and per-provider overrides on `providers.<name>.response_header_timeout_seconds`.
- Wire all providers (OpenAI, Anthropic, Gemini, Bedrock, Mantle) through the shared transport; drop Gemini’s hardcoded special-case.

## Test plan
- [x] Unit tests for config resolve/validate/YAML load/merge + `configs/base.yml` default
- [x] Unit tests for all provider constructors (including Bedrock Mantle)
- [x] `go run ./cmd/config-validator/` — all profiles PASS
- [ ] CircleCI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable upstream response-header timeouts, with a five-minute default.
  - Added optional per-provider timeout overrides.
  - Added startup logging for the configured default timeout.

- **Bug Fixes**
  - Applied response-header timeout settings consistently across supported providers.
  - Added validation to reject negative timeout values while allowing defaults and overrides to inherit correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->