### PR TITLE
fix: cost tracking foranthropic/gemini OpenAI-compatibility endpoints + CI cost-tracking integration tests

### DIFF
--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -347,16 +347,25 @@ func (a *AnthropicProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRes
 	}
 
 	// The OpenAI-compatibility endpoint streams OpenAI-style
-	// chat.completion.chunk events, not Anthropic message_* events.
-	data, err := io.ReadAll(decompressedReader)
-	if err != nil {
+	// chat.completion.chunk events, not Anthropic message_* events. Peek at
+	// the head to classify the stream; only compat streams are then read in
+	// full (the OpenAI parser needs the final usage chunk), so the native
+	// path keeps decompressing incrementally instead of materializing the
+	// whole decompressed body.
+	buffered := bufio.NewReaderSize(decompressedReader, compatStreamSniffLen)
+	head, err := buffered.Peek(compatStreamSniffLen)
+	if err != nil && err != io.EOF && len(head) == 0 {
 		return nil, fmt.Errorf("failed to read streaming response: %w", err)
 	}
-	if looksLikeOpenAIChatStream(data) {
+	if looksLikeOpenAIChatStream(head) {
+		data, err := io.ReadAll(buffered)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read streaming response: %w", err)
+		}
 		return parseOpenAICompatMetadata(data, true, "anthropic")
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner := bufio.NewScanner(buffered)
 	// Allow lines up to 2 MB — large tool call / thinking deltas can be wide.
 	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
 

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -119,7 +119,9 @@ func (a *AnthropicProxy) IsStreamingRequest(req *http.Request) bool {
 		return true
 	}
 
-	if req.Method == "POST" && strings.Contains(req.URL.Path, "/messages") {
+	// /messages is the native endpoint; /chat/completions is the
+	// OpenAI-compatibility endpoint (same "stream": true body contract).
+	if req.Method == "POST" && (strings.Contains(req.URL.Path, "/messages") || isChatCompletionsPath(req.URL.Path)) {
 		return a.checkStreamingInBody(req)
 	}
 
@@ -304,6 +306,14 @@ func (a *AnthropicProxy) parseNonStreamingResponse(responseBody io.Reader) (*LLM
 	log.Printf("🔍 Debug: Response body preview: %s",
 		redact.LogPreview(context.Background(), string(bodyBytes), 100))
 
+	// Anthropic's OpenAI-compatibility endpoint (/v1/chat/completions)
+	// returns OpenAI-shaped JSON ("choices" + usage.prompt_tokens). Parsing
+	// it as native Anthropic silently yields zero token counts, which
+	// disables cost tracking and cost-limit enforcement for that traffic.
+	if looksLikeOpenAIChatJSON(bodyBytes) {
+		return parseOpenAICompatMetadata(bodyBytes, false, "anthropic")
+	}
+
 	var response AnthropicResponse
 	if err := json.Unmarshal(bodyBytes, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse Anthropic response: %w", err)
@@ -336,7 +346,17 @@ func (a *AnthropicProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRes
 		defer gzipReader.Close()
 	}
 
-	scanner := bufio.NewScanner(decompressedReader)
+	// The OpenAI-compatibility endpoint streams OpenAI-style
+	// chat.completion.chunk events, not Anthropic message_* events.
+	data, err := io.ReadAll(decompressedReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read streaming response: %w", err)
+	}
+	if looksLikeOpenAIChatStream(data) {
+		return parseOpenAICompatMetadata(data, true, "anthropic")
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	// Allow lines up to 2 MB — large tool call / thinking deltas can be wide.
 	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
 

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -650,11 +650,7 @@ func (b *BedrockMantleProxy) ParseResponseMetadata(responseBody io.Reader, isStr
 		Choices json.RawMessage `json:"choices"`
 	}
 	if json.Unmarshal(body, &responseType) == nil && responseType.Choices != nil {
-		metadata, err := (&OpenAIProxy{}).ParseResponseMetadata(bytes.NewReader(body), false)
-		if metadata != nil {
-			metadata.Provider = bedrockMantleName
-		}
-		return metadata, err
+		return parseOpenAIFormatMetadata(bytes.NewReader(body), false, bedrockMantleName)
 	}
 	return parseMantleMetadata(body, false)
 }

--- a/internal/providers/cost_tracking_integration_test.go
+++ b/internal/providers/cost_tracking_integration_test.go
@@ -1,0 +1,409 @@
+// Cost-tracking end-to-end integration tests.
+//
+// These run in CI as part of `make test-integration` (name pattern
+// Test(OpenAI|Anthropic|Gemini)Integration) whenever the provider API keys
+// are present. Unlike the per-provider passthrough tests, they exercise the
+// SAME pipeline production uses to bill a request:
+//
+//	created sk-iw key (DynamoDB store) → APIKeyValidationMiddleware →
+//	provider reverse proxy → TokenParsingMiddleware → cost callback →
+//	CostTracker transports + per-key admin spend stats
+//
+// and then assert that a cost record with non-zero tokens AND non-zero USD
+// was actually written and attributed to the created key. This is the
+// regression net for the Opik outage, where Anthropic's OpenAI-compatibility
+// endpoint (/v1/chat/completions) parsed to zero tokens and silently
+// produced no cost records — while PII stats kept counting.
+//
+// The file lives in package providers_test (external) so it can import the
+// middleware package without an import cycle.
+package providers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/cost"
+	"github.com/Instawork/llm-proxy/internal/coststats"
+	"github.com/Instawork/llm-proxy/internal/middleware"
+	"github.com/Instawork/llm-proxy/internal/providers"
+	"github.com/Instawork/llm-proxy/internal/testhelpers/dynamodbfake"
+)
+
+// recordSink is an in-memory cost.Transport capturing every written record.
+type recordSink struct {
+	mu      sync.Mutex
+	records []cost.CostRecord
+}
+
+func (s *recordSink) WriteRecord(record *cost.CostRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = append(s.records, *record)
+	return nil
+}
+
+func (s *recordSink) snapshot() []cost.CostRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]cost.CostRecord, len(s.records))
+	copy(out, s.records)
+	return out
+}
+
+type costTrackingEnv struct {
+	server *httptest.Server
+	store  *apikeys.Store
+	sink   *recordSink
+	stats  *coststats.Recorder
+}
+
+// newCostTrackingEnv assembles the production cost-tracking pipeline against
+// real upstream providers: key store backed by the shared DynamoDB fake,
+// pricing loaded from the real configs/base.yml, and the exact middleware
+// order used in cmd/llm-proxy/main.go runServer.
+func newCostTrackingEnv(t *testing.T) *costTrackingEnv {
+	t.Helper()
+
+	fake := dynamodbfake.New(t)
+	dynamodbfake.UseFakeDynamo(t, fake.URL())
+	store, err := apikeys.NewStore(apikeys.StoreConfig{
+		TableName:       "cost-tracking-integration-keys",
+		Region:          "us-west-2",
+		AutoCreateTable: true,
+	})
+	require.NoError(t, err)
+
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(providers.NewOpenAIProxy())
+	pm.RegisterProvider(providers.NewAnthropicProxy())
+	pm.RegisterProvider(providers.NewGeminiProxy())
+
+	sink := &recordSink{}
+	tracker := cost.NewCostTracker(sink)
+	stats := coststats.NewRecorder()
+	tracker.SetStatsRecorder(stats)
+	loadPricingFromBaseConfig(t, tracker)
+
+	// Mirrors the costTrackingCallback in cmd/llm-proxy/main.go, including
+	// the TotalTokens > 0 gate: if response parsing regresses to zero
+	// tokens (the Opik failure mode), no record is written and the test
+	// fails — exactly the signal we want.
+	costCallback := func(r *http.Request, metadata *providers.LLMResponseMetadata) {
+		if metadata.TotalTokens > 0 {
+			provider := middleware.GetProviderFromRequest(pm, r)
+			userID := middleware.ExtractUserIDFromRequest(r, provider)
+			ipAddress := middleware.ExtractIPAddressFromRequest(r)
+			keyID := ""
+			if keyRecord, ok := apikeys.FromContext(r.Context()); ok && keyRecord != nil {
+				keyID = middleware.MaskKeyID(keyRecord.PK)
+			}
+			if err := tracker.TrackRequest(metadata, userID, ipAddress, r.URL.Path, keyID); err != nil {
+				t.Logf("cost tracking failed: %v", err)
+			}
+		}
+	}
+
+	r := mux.NewRouter()
+	r.Use(middleware.APIKeyValidationMiddleware(pm, store, false, false))
+	r.Use(middleware.TokenParsingMiddleware(pm, costCallback))
+	for name, provider := range pm.GetAllProviders() {
+		r.PathPrefix("/" + name + "/").Handler(provider.Proxy())
+	}
+
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &costTrackingEnv{server: server, store: store, sink: sink, stats: stats}
+}
+
+// loadPricingFromBaseConfig mirrors initializeCostTracker in
+// cmd/llm-proxy/main.go so the assertion "TotalCost > 0" also verifies that
+// the models used by these tests still have pricing configured.
+func loadPricingFromBaseConfig(t *testing.T, tracker *cost.CostTracker) {
+	t.Helper()
+	yamlConfig, err := config.LoadYAMLConfig(filepath.Join("..", "..", "configs", "base.yml"))
+	require.NoError(t, err)
+
+	total := 0
+	for providerName, providerConfig := range yamlConfig.Providers {
+		for modelName, modelConfig := range providerConfig.Models {
+			if !modelConfig.Enabled || modelConfig.Pricing == nil {
+				continue
+			}
+			modelPricing, ok := modelConfig.Pricing.(*config.ModelPricing)
+			if !ok {
+				continue
+			}
+			var trackerPricing cost.ModelPricing
+			for _, tier := range modelPricing.Tiers {
+				trackerPricing.Tiers = append(trackerPricing.Tiers, cost.PricingTier{
+					Threshold: tier.Threshold,
+					Input:     tier.Input,
+					Output:    tier.Output,
+				})
+			}
+			tracker.SetPricingForModel(providerName, modelName, &trackerPricing)
+			total++
+			for _, alias := range modelConfig.Aliases {
+				tracker.SetPricingForModel(providerName, alias, &trackerPricing)
+			}
+		}
+	}
+	require.Greater(t, total, 0, "no pricing loaded from configs/base.yml — wrong working directory?")
+}
+
+func (env *costTrackingEnv) createKey(t *testing.T, provider, upstreamKey string) *apikeys.APIKey {
+	t.Helper()
+	created, err := env.store.CreateKey(
+		context.Background(), provider, upstreamKey, "cost-tracking integration test", 0, nil, nil,
+	)
+	require.NoError(t, err)
+	return created
+}
+
+// doJSON posts body to path with the given headers and requires HTTP 200,
+// returning the response body for debugging context on failures.
+func (env *costTrackingEnv) doJSON(t *testing.T, path string, headers map[string]string, body map[string]interface{}) []byte {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, env.server.URL+path, bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// Upstream quota blip (shared CI provider keys) — not a cost-tracking
+		// regression. Match the wider integration suite's convention of
+		// skipping on missing prerequisites rather than failing the build.
+		t.Skipf("upstream rate limited (429): %s", string(respBody))
+	}
+	require.Equal(t, http.StatusOK, resp.StatusCode, "upstream error: %s", string(respBody))
+	return respBody
+}
+
+// requireCostTracked waits for a new cost record (past baseline) for the
+// given provider and asserts the full billing contract: non-zero tokens,
+// non-zero USD, and per-key spend attribution in the admin stats recorder.
+func (env *costTrackingEnv) requireCostTracked(t *testing.T, baseline int, wantProvider, maskedKey string) cost.CostRecord {
+	t.Helper()
+
+	var got cost.CostRecord
+	require.Eventually(t, func() bool {
+		records := env.sink.snapshot()
+		if len(records) <= baseline {
+			return false
+		}
+		for _, record := range records[baseline:] {
+			if record.Provider == wantProvider {
+				got = record
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond,
+		"no cost record written for provider %s — token parsing likely returned zero tokens", wantProvider)
+
+	assert.Greater(t, got.InputTokens, 0, "input tokens missing from cost record")
+	assert.Greater(t, got.OutputTokens, 0, "output tokens missing from cost record")
+	assert.Greater(t, got.TotalCost, 0.0,
+		"cost record has zero USD — no pricing matched model %q for provider %s", got.Model, wantProvider)
+
+	keySpend := env.stats.KeySpendUSD(context.Background(), maskedKey)
+	assert.Greater(t, keySpend, 0.0, "admin spend stats missing attribution for key %s", maskedKey)
+
+	return got
+}
+
+func (env *costTrackingEnv) recordCount() int {
+	return len(env.sink.snapshot())
+}
+
+// ----------------------------------------------------------------------------
+// OpenAI (native /chat/completions — the baseline that always worked)
+// ----------------------------------------------------------------------------
+
+func TestOpenAIIntegration_CostTracking_CreatedKey(t *testing.T) {
+	upstreamKey := os.Getenv("OPENAI_API_KEY")
+	if upstreamKey == "" {
+		t.Skip("OPENAI_API_KEY environment variable is not set")
+	}
+
+	env := newCostTrackingEnv(t)
+	created := env.createKey(t, "openai", upstreamKey)
+	masked := middleware.MaskKeyID(created.PK)
+
+	baseline := env.recordCount()
+	env.doJSON(t, "/openai/v1/chat/completions",
+		map[string]string{"Authorization": "Bearer " + created.PK},
+		map[string]interface{}{
+			"model":      "gpt-4o-mini",
+			"max_tokens": 32,
+			"messages":   []map[string]string{{"role": "user", "content": "Say hi in one word."}},
+		})
+
+	record := env.requireCostTracked(t, baseline, "openai", masked)
+	assert.Contains(t, record.Model, "gpt-4o-mini")
+}
+
+// ----------------------------------------------------------------------------
+// Anthropic: native /v1/messages and the OpenAI-compatibility endpoint
+// /v1/chat/completions (the Opik regression).
+// ----------------------------------------------------------------------------
+
+func TestAnthropicIntegration_CostTracking_CreatedKey(t *testing.T) {
+	upstreamKey := os.Getenv("ANTHROPIC_API_KEY")
+	if upstreamKey == "" {
+		t.Skip("ANTHROPIC_API_KEY environment variable is not set")
+	}
+
+	env := newCostTrackingEnv(t)
+	created := env.createKey(t, "anthropic", upstreamKey)
+	masked := middleware.MaskKeyID(created.PK)
+
+	baseline := env.recordCount()
+	env.doJSON(t, "/anthropic/v1/messages",
+		map[string]string{"x-api-key": created.PK, "anthropic-version": "2023-06-01"},
+		map[string]interface{}{
+			"model":      "claude-haiku-4-5",
+			"max_tokens": 32,
+			"messages":   []map[string]string{{"role": "user", "content": "Say hi in one word."}},
+		})
+
+	record := env.requireCostTracked(t, baseline, "anthropic", masked)
+	assert.Contains(t, record.Model, "claude-haiku-4-5")
+}
+
+func TestAnthropicIntegration_CostTracking_CreatedKey_OpenAICompat(t *testing.T) {
+	upstreamKey := os.Getenv("ANTHROPIC_API_KEY")
+	if upstreamKey == "" {
+		t.Skip("ANTHROPIC_API_KEY environment variable is not set")
+	}
+
+	env := newCostTrackingEnv(t)
+	created := env.createKey(t, "anthropic", upstreamKey)
+	masked := middleware.MaskKeyID(created.PK)
+	headers := map[string]string{"Authorization": "Bearer " + created.PK}
+
+	t.Run("NonStreaming", func(t *testing.T) {
+		baseline := env.recordCount()
+		env.doJSON(t, "/anthropic/v1/chat/completions", headers,
+			map[string]interface{}{
+				"model":      "claude-haiku-4-5",
+				"max_tokens": 32,
+				"messages":   []map[string]string{{"role": "user", "content": "Say hi in one word."}},
+			})
+
+		record := env.requireCostTracked(t, baseline, "anthropic", masked)
+		assert.Contains(t, record.Model, "claude-haiku-4-5")
+	})
+
+	t.Run("Streaming", func(t *testing.T) {
+		baseline := env.recordCount()
+		env.doJSON(t, "/anthropic/v1/chat/completions", headers,
+			map[string]interface{}{
+				"model":          "claude-haiku-4-5",
+				"max_tokens":     32,
+				"stream":         true,
+				"stream_options": map[string]bool{"include_usage": true},
+				"messages":       []map[string]string{{"role": "user", "content": "Say hi in one word."}},
+			})
+
+		record := env.requireCostTracked(t, baseline, "anthropic", masked)
+		assert.True(t, record.IsStreaming, "streaming request should produce a streaming cost record")
+	})
+}
+
+// ----------------------------------------------------------------------------
+// Gemini: native :generateContent and the OpenAI-compatibility endpoint
+// /v1beta/openai/chat/completions.
+// ----------------------------------------------------------------------------
+
+func TestGeminiIntegration_CostTracking_CreatedKey(t *testing.T) {
+	upstreamKey := os.Getenv("GEMINI_API_KEY")
+	if upstreamKey == "" {
+		t.Skip("GEMINI_API_KEY environment variable is not set")
+	}
+
+	env := newCostTrackingEnv(t)
+	created := env.createKey(t, "gemini", upstreamKey)
+	masked := middleware.MaskKeyID(created.PK)
+
+	baseline := env.recordCount()
+	env.doJSON(t, "/gemini/v1beta/models/gemini-2.5-flash:generateContent",
+		map[string]string{"x-goog-api-key": created.PK},
+		map[string]interface{}{
+			"contents": []map[string]interface{}{
+				{"parts": []map[string]string{{"text": "Say hi in one word."}}},
+			},
+			"generationConfig": map[string]interface{}{"maxOutputTokens": 32},
+		})
+
+	record := env.requireCostTracked(t, baseline, "gemini", masked)
+	assert.Contains(t, record.Model, "gemini-2.5-flash")
+}
+
+func TestGeminiIntegration_CostTracking_CreatedKey_OpenAICompat(t *testing.T) {
+	upstreamKey := os.Getenv("GEMINI_API_KEY")
+	if upstreamKey == "" {
+		t.Skip("GEMINI_API_KEY environment variable is not set")
+	}
+
+	env := newCostTrackingEnv(t)
+	created := env.createKey(t, "gemini", upstreamKey)
+	masked := middleware.MaskKeyID(created.PK)
+	headers := map[string]string{"Authorization": "Bearer " + created.PK}
+
+	t.Run("NonStreaming", func(t *testing.T) {
+		baseline := env.recordCount()
+		env.doJSON(t, "/gemini/v1beta/openai/chat/completions", headers,
+			map[string]interface{}{
+				"model":      "gemini-2.5-flash",
+				"max_tokens": 32,
+				"messages":   []map[string]string{{"role": "user", "content": "Say hi in one word."}},
+			})
+
+		record := env.requireCostTracked(t, baseline, "gemini", masked)
+		assert.Contains(t, record.Model, "gemini-2.5-flash")
+	})
+
+	t.Run("Streaming", func(t *testing.T) {
+		baseline := env.recordCount()
+		env.doJSON(t, "/gemini/v1beta/openai/chat/completions", headers,
+			map[string]interface{}{
+				"model":          "gemini-2.5-flash",
+				"max_tokens":     32,
+				"stream":         true,
+				"stream_options": map[string]bool{"include_usage": true},
+				"messages":       []map[string]string{{"role": "user", "content": "Say hi in one word."}},
+			})
+
+		record := env.requireCostTracked(t, baseline, "gemini", masked)
+		assert.True(t, record.IsStreaming, "streaming request should produce a streaming cost record")
+	})
+}

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -130,6 +130,14 @@ func (g *GeminiProxy) IsStreamingRequest(req *http.Request) bool {
 		return true
 	}
 
+	// The OpenAI-compatibility endpoint signals streaming via "stream": true
+	// in the JSON body, like OpenAI proper. Scoped to /chat/completions so
+	// native Gemini requests (including large media uploads) are never
+	// body-inspected.
+	if req.Method == "POST" && isChatCompletionsPath(req.URL.Path) {
+		return requestBodyHasStreamTrue(req, "gemini")
+	}
+
 	// For Gemini generateContent endpoints, rely on explicit streaming indicators
 	// via the URL path (streamGenerateContent) rather than inspecting the body.
 	if req.Method == "POST" && (strings.Contains(req.URL.Path, ":generateContent") ||
@@ -248,6 +256,14 @@ func (g *GeminiProxy) parseNonStreamingResponse(responseBody io.Reader) (*LLMRes
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	// Gemini's OpenAI-compatibility endpoint (/v1beta/openai/chat/completions)
+	// returns OpenAI-shaped JSON ("choices" + usage.prompt_tokens). Parsing
+	// it as native Gemini silently yields zero token counts, which disables
+	// cost tracking and cost-limit enforcement for that traffic.
+	if looksLikeOpenAIChatJSON(bodyBytes) {
+		return parseOpenAICompatMetadata(bodyBytes, false, "gemini")
+	}
+
 	var response GeminiResponse
 	if err := json.Unmarshal(bodyBytes, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse Gemini response: %w", err)
@@ -292,7 +308,17 @@ func (g *GeminiProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespon
 		defer gzipReader.Close()
 	}
 
-	scanner := bufio.NewScanner(decompressedReader)
+	// The OpenAI-compatibility endpoint streams OpenAI-style
+	// chat.completion.chunk events, not Gemini candidate chunks.
+	data, err := io.ReadAll(decompressedReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read streaming response: %w", err)
+	}
+	if looksLikeOpenAIChatStream(data) {
+		return parseOpenAICompatMetadata(data, true, "gemini")
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	// Allow lines up to 2 MB — large Gemini SSE JSON chunks (e.g. with grounded
 	// citations or long thinking traces) can exceed the default 64 KB.
 	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -309,16 +309,25 @@ func (g *GeminiProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespon
 	}
 
 	// The OpenAI-compatibility endpoint streams OpenAI-style
-	// chat.completion.chunk events, not Gemini candidate chunks.
-	data, err := io.ReadAll(decompressedReader)
-	if err != nil {
+	// chat.completion.chunk events, not Gemini candidate chunks. Peek at the
+	// head to classify the stream; only compat streams are then read in full
+	// (the OpenAI parser needs the final usage chunk), so the native path
+	// keeps decompressing incrementally instead of materializing the whole
+	// decompressed body.
+	buffered := bufio.NewReaderSize(decompressedReader, compatStreamSniffLen)
+	head, err := buffered.Peek(compatStreamSniffLen)
+	if err != nil && err != io.EOF && len(head) == 0 {
 		return nil, fmt.Errorf("failed to read streaming response: %w", err)
 	}
-	if looksLikeOpenAIChatStream(data) {
+	if looksLikeOpenAIChatStream(head) {
+		data, err := io.ReadAll(buffered)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read streaming response: %w", err)
+		}
 		return parseOpenAICompatMetadata(data, true, "gemini")
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner := bufio.NewScanner(buffered)
 	// Allow lines up to 2 MB — large Gemini SSE JSON chunks (e.g. with grounded
 	// citations or long thinking traces) can exceed the default 64 KB.
 	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -328,34 +328,50 @@ type OpenAIResponsesEvent struct {
 	Status    string                 `json:"status,omitempty"`
 }
 
-// ParseResponseMetadata extracts tokens and model information from OpenAI responses
+// ParseResponseMetadata extracts tokens and model information from OpenAI responses.
 func (o *OpenAIProxy) ParseResponseMetadata(responseBody io.Reader, isStreaming bool) (*LLMResponseMetadata, error) {
-	// Create a buffer to read the response body
+	return parseOpenAIFormatMetadata(responseBody, isStreaming, "openai")
+}
+
+// parseOpenAIFormatMetadata parses an OpenAI Chat Completions or Responses API
+// body (streaming or non-streaming) and attributes the result to provider.
+//
+// This is the shared entry point for OpenAI-shaped responses. OpenAIProxy
+// uses it for native traffic; Anthropic/Gemini/Bedrock Mantle OpenAI-
+// compatibility endpoints call it when they detect a choices-based body so
+// they do not depend on constructing a concrete OpenAIProxy.
+func parseOpenAIFormatMetadata(responseBody io.Reader, isStreaming bool, provider string) (*LLMResponseMetadata, error) {
 	bodyBytes, err := io.ReadAll(responseBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// For streaming responses, use unified parsing
-	if isStreaming {
-		reader := bytes.NewReader(bodyBytes)
-		return o.parseUnifiedStreamingResponse(reader)
-	}
+	// The chat/completions and Responses parsers are methods on OpenAIProxy
+	// for historical grouping; they are stateless and do not use receiver
+	// fields. Route through a zero-value receiver so the format knowledge
+	// stays in one place.
+	parser := &OpenAIProxy{}
 
-	// For non-streaming, check the structure
-	// Responses API has "output" field while Chat Completions has "choices"
-	var checkResponse map[string]interface{}
-	if err := json.Unmarshal(bodyBytes, &checkResponse); err == nil {
-		if _, hasOutput := checkResponse["output"]; hasOutput {
-			// This is a Responses API response
-			reader := bytes.NewReader(bodyBytes)
-			return o.parseResponsesNonStreamingResponse(reader)
+	var metadata *LLMResponseMetadata
+	if isStreaming {
+		metadata, err = parser.parseUnifiedStreamingResponse(bytes.NewReader(bodyBytes))
+	} else {
+		// Responses API has "output"; Chat Completions has "choices".
+		var checkResponse map[string]interface{}
+		if json.Unmarshal(bodyBytes, &checkResponse) == nil {
+			if _, hasOutput := checkResponse["output"]; hasOutput {
+				metadata, err = parser.parseResponsesNonStreamingResponse(bytes.NewReader(bodyBytes))
+			} else {
+				metadata, err = parser.parseNonStreamingResponse(bytes.NewReader(bodyBytes))
+			}
+		} else {
+			metadata, err = parser.parseNonStreamingResponse(bytes.NewReader(bodyBytes))
 		}
 	}
-
-	// Traditional Chat Completions API response
-	reader := bytes.NewReader(bodyBytes)
-	return o.parseNonStreamingResponse(reader)
+	if metadata != nil {
+		metadata.Provider = provider
+	}
+	return metadata, err
 }
 
 // parseNonStreamingResponse handles standard OpenAI JSON responses

--- a/internal/providers/openai_compat.go
+++ b/internal/providers/openai_compat.go
@@ -32,11 +32,20 @@ func looksLikeOpenAIChatJSON(body []byte) bool {
 	return json.Unmarshal(body, &shape) == nil && shape.Choices != nil
 }
 
+// compatStreamSniffLen is how many leading bytes of an SSE stream
+// looksLikeOpenAIChatStream needs. The very first data line of an
+// OpenAI-compat stream is a small role/content delta carrying the "object"
+// discriminator, so a bufio.Reader Peek of this size classifies the stream
+// without materializing the full decompressed body.
+const compatStreamSniffLen = 16 * 1024
+
 // looksLikeOpenAIChatStream reports whether SSE bytes carry OpenAI-style
 // chat.completion chunks. It inspects the first few data lines for a
 // top-level "object" beginning with "chat.completion". Native Anthropic
 // streams carry "type" events (message_start, ...) and native Gemini streams
-// carry "candidates", neither of which sets "object".
+// carry "candidates", neither of which sets "object". A trailing partial
+// line (from a truncated Peek window) simply fails to unmarshal and is
+// skipped.
 func looksLikeOpenAIChatStream(data []byte) bool {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)

--- a/internal/providers/openai_compat.go
+++ b/internal/providers/openai_compat.go
@@ -1,0 +1,131 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Instawork/llm-proxy/internal/proxylog"
+)
+
+// This file holds the shared OpenAI-compatibility detection used by the
+// Anthropic and Gemini providers. Both vendors expose an OpenAI-style
+// /chat/completions endpoint (Anthropic: /v1/chat/completions, Gemini:
+// /v1beta/openai/chat/completions) whose responses are OpenAI-shaped
+// ("choices" + usage.prompt_tokens) rather than the vendor's native format.
+// Without delegation the native parsers unmarshal those bodies into zero
+// token counts, which silently disables cost tracking, admin spend stats,
+// and per-key cost-limit enforcement for that traffic (this is exactly what
+// happened with Opik traffic on the Anthropic compat endpoint).
+
+// looksLikeOpenAIChatJSON reports whether a (decompressed) non-streaming JSON
+// body is OpenAI-shaped: a top-level "choices" array. Native Anthropic bodies
+// use "content" and native Gemini bodies use "candidates", so this cannot
+// misfire on vendor-native responses.
+func looksLikeOpenAIChatJSON(body []byte) bool {
+	var shape struct {
+		Choices json.RawMessage `json:"choices"`
+	}
+	return json.Unmarshal(body, &shape) == nil && shape.Choices != nil
+}
+
+// looksLikeOpenAIChatStream reports whether SSE bytes carry OpenAI-style
+// chat.completion chunks. It inspects the first few data lines for a
+// top-level "object" beginning with "chat.completion". Native Anthropic
+// streams carry "type" events (message_start, ...) and native Gemini streams
+// carry "candidates", neither of which sets "object".
+func looksLikeOpenAIChatStream(data []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	seen := 0
+	for scanner.Scan() && seen < 5 {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		jsonData := strings.TrimPrefix(line, "data: ")
+		if strings.TrimSpace(jsonData) == "[DONE]" {
+			break
+		}
+		seen++
+		var shape struct {
+			Object string `json:"object"`
+		}
+		if json.Unmarshal([]byte(jsonData), &shape) != nil {
+			continue
+		}
+		if strings.HasPrefix(shape.Object, "chat.completion") {
+			return true
+		}
+	}
+	return false
+}
+
+// parseOpenAICompatMetadata delegates an OpenAI-shaped body to the OpenAI
+// parser and re-tags the resulting metadata with the owning provider's name
+// so cost records, pricing lookups, and stats stay attributed to the vendor
+// that actually served the request.
+func parseOpenAICompatMetadata(body []byte, isStreaming bool, provider string) (*LLMResponseMetadata, error) {
+	metadata, err := (&OpenAIProxy{}).ParseResponseMetadata(bytes.NewReader(body), isStreaming)
+	if metadata != nil {
+		metadata.Provider = provider
+	}
+	return metadata, err
+}
+
+// isChatCompletionsPath reports whether the request path targets an
+// OpenAI-compatibility /chat/completions endpoint.
+func isChatCompletionsPath(path string) bool {
+	return strings.Contains(path, "/chat/completions")
+}
+
+// requestBodyHasStreamTrue reads (and restores) the request body and reports
+// whether it contains "stream": true. Used by providers whose native
+// streaming detection is path-based but whose OpenAI-compatibility endpoint
+// signals streaming in the JSON body, like OpenAI proper.
+func requestBodyHasStreamTrue(req *http.Request, providerName string) bool {
+	if req.Body == nil {
+		return false
+	}
+
+	var bodyBytes []byte
+	var err error
+
+	if req.GetBody != nil {
+		bodyReader, err := req.GetBody()
+		if err != nil {
+			proxylog.Proxy("%s streaming check: error getting cached request body: %v", providerName, err)
+			return false
+		}
+		defer bodyReader.Close()
+		bodyBytes, err = io.ReadAll(bodyReader)
+		if err != nil {
+			proxylog.Proxy("%s streaming check: error reading cached request body: %v", providerName, err)
+			return false
+		}
+	} else {
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			proxylog.Proxy("%s streaming check: error reading request body: %v", providerName, err)
+			return false
+		}
+		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewBuffer(bodyBytes)), nil
+		}
+	}
+
+	var requestData map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &requestData); err != nil {
+		return false
+	}
+	if streamValue, exists := requestData["stream"]; exists {
+		if streamBool, ok := streamValue.(bool); ok {
+			return streamBool
+		}
+	}
+	return false
+}

--- a/internal/providers/openai_compat.go
+++ b/internal/providers/openai_compat.go
@@ -11,15 +11,17 @@ import (
 	"github.com/Instawork/llm-proxy/internal/proxylog"
 )
 
-// This file holds the shared OpenAI-compatibility detection used by the
-// Anthropic and Gemini providers. Both vendors expose an OpenAI-style
-// /chat/completions endpoint (Anthropic: /v1/chat/completions, Gemini:
-// /v1beta/openai/chat/completions) whose responses are OpenAI-shaped
-// ("choices" + usage.prompt_tokens) rather than the vendor's native format.
-// Without delegation the native parsers unmarshal those bodies into zero
-// token counts, which silently disables cost tracking, admin spend stats,
-// and per-key cost-limit enforcement for that traffic (this is exactly what
-// happened with Opik traffic on the Anthropic compat endpoint).
+// This file holds OpenAI-compatibility detection used by Anthropic and Gemini.
+// Both vendors expose an OpenAI-style /chat/completions endpoint (Anthropic:
+// /v1/chat/completions, Gemini: /v1beta/openai/chat/completions) whose
+// responses are OpenAI-shaped ("choices" + usage.prompt_tokens) rather than
+// the vendor's native format. When detected, parsing goes through
+// parseOpenAIFormatMetadata (the shared OpenAI-format parser), attributed to
+// the owning provider. Without that, the native parsers unmarshal those
+// bodies into zero token counts, which silently disables cost tracking,
+// admin spend stats, and per-key cost-limit enforcement for that traffic
+// (this is exactly what happened with Opik traffic on the Anthropic compat
+// endpoint).
 
 // looksLikeOpenAIChatJSON reports whether a (decompressed) non-streaming JSON
 // body is OpenAI-shaped: a top-level "choices" array. Native Anthropic bodies
@@ -73,16 +75,12 @@ func looksLikeOpenAIChatStream(data []byte) bool {
 	return false
 }
 
-// parseOpenAICompatMetadata delegates an OpenAI-shaped body to the OpenAI
-// parser and re-tags the resulting metadata with the owning provider's name
-// so cost records, pricing lookups, and stats stay attributed to the vendor
-// that actually served the request.
+// parseOpenAICompatMetadata parses an OpenAI-shaped body via the shared
+// OpenAI-format parser and attributes the result to the owning provider so
+// cost records, pricing lookups, and stats stay on the vendor that actually
+// served the request.
 func parseOpenAICompatMetadata(body []byte, isStreaming bool, provider string) (*LLMResponseMetadata, error) {
-	metadata, err := (&OpenAIProxy{}).ParseResponseMetadata(bytes.NewReader(body), isStreaming)
-	if metadata != nil {
-		metadata.Provider = provider
-	}
-	return metadata, err
+	return parseOpenAIFormatMetadata(bytes.NewReader(body), isStreaming, provider)
 }
 
 // isChatCompletionsPath reports whether the request path targets an

--- a/internal/providers/openai_compat_test.go
+++ b/internal/providers/openai_compat_test.go
@@ -1,0 +1,123 @@
+package providers
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openAICompatBody is a real-world-shaped response from a vendor's
+// OpenAI-compatibility /chat/completions endpoint (this is what Anthropic
+// returns for /v1/chat/completions and Gemini for
+// /v1beta/openai/chat/completions). Regression fixture for the Opik
+// cost-tracking outage: the native parsers used to unmarshal this into zero
+// token counts, which silently disabled cost tracking for that traffic.
+const openAICompatBody = `{
+	"id": "msg_011CdHFhDAE7TNRPBZLxENES",
+	"object": "chat.completion",
+	"created": 1784730000,
+	"model": "claude-haiku-4-5-20251001",
+	"choices": [
+		{
+			"index": 0,
+			"message": {"role": "assistant", "content": "Hello!"},
+			"finish_reason": "stop"
+		}
+	],
+	"usage": {"prompt_tokens": 120, "completion_tokens": 34, "total_tokens": 154}
+}`
+
+const openAICompatStreamBody = `data: {"id":"msg_01","object":"chat.completion.chunk","created":1784730000,"model":"claude-haiku-4-5-20251001","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"msg_01","object":"chat.completion.chunk","created":1784730000,"model":"claude-haiku-4-5-20251001","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":120,"completion_tokens":34,"total_tokens":154}}
+
+data: [DONE]
+`
+
+func assertCompatMetadata(t *testing.T, metadata *LLMResponseMetadata, provider string, isStreaming bool) {
+	t.Helper()
+	require.NotNil(t, metadata)
+	assert.Equal(t, provider, metadata.Provider)
+	assert.Equal(t, "claude-haiku-4-5-20251001", metadata.Model)
+	assert.Equal(t, 120, metadata.InputTokens)
+	assert.Equal(t, 34, metadata.OutputTokens)
+	assert.Equal(t, 154, metadata.TotalTokens)
+	assert.Equal(t, isStreaming, metadata.IsStreaming)
+}
+
+func TestAnthropic_ParseResponseMetadata_OpenAICompatNonStreaming(t *testing.T) {
+	metadata, err := NewAnthropicProxy().ParseResponseMetadata(strings.NewReader(openAICompatBody), false)
+	require.NoError(t, err)
+	assertCompatMetadata(t, metadata, "anthropic", false)
+}
+
+func TestAnthropic_ParseResponseMetadata_OpenAICompatStreaming(t *testing.T) {
+	metadata, err := NewAnthropicProxy().ParseResponseMetadata(strings.NewReader(openAICompatStreamBody), true)
+	require.NoError(t, err)
+	assertCompatMetadata(t, metadata, "anthropic", true)
+}
+
+func TestGemini_ParseResponseMetadata_OpenAICompatNonStreaming(t *testing.T) {
+	metadata, err := NewGeminiProxy().ParseResponseMetadata(strings.NewReader(openAICompatBody), false)
+	require.NoError(t, err)
+	assertCompatMetadata(t, metadata, "gemini", false)
+}
+
+func TestGemini_ParseResponseMetadata_OpenAICompatStreaming(t *testing.T) {
+	metadata, err := NewGeminiProxy().ParseResponseMetadata(strings.NewReader(openAICompatStreamBody), true)
+	require.NoError(t, err)
+	assertCompatMetadata(t, metadata, "gemini", true)
+}
+
+// Native-format bodies must keep flowing through the native parsers: the
+// compat detection keys on "choices", which never appears in native
+// Anthropic ("content") or Gemini ("candidates") responses.
+func TestOpenAICompatDetection_DoesNotMisfireOnNativeBodies(t *testing.T) {
+	anthropicNative := `{"id":"msg_1","type":"message","model":"claude-haiku-4-5","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`
+	metadata, err := NewAnthropicProxy().ParseResponseMetadata(strings.NewReader(anthropicNative), false)
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic", metadata.Provider)
+	assert.Equal(t, 15, metadata.TotalTokens)
+
+	geminiNative := `{"candidates":[{"content":{"parts":[{"text":"hi"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15},"modelVersion":"gemini-2.5-flash"}`
+	metadata, err = NewGeminiProxy().ParseResponseMetadata(strings.NewReader(geminiNative), false)
+	require.NoError(t, err)
+	assert.Equal(t, "gemini", metadata.Provider)
+	assert.Equal(t, 15, metadata.TotalTokens)
+
+	anthropicNativeStream := "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-haiku-4-5\",\"usage\":{\"input_tokens\":10,\"output_tokens\":1}}}\n\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n" +
+		"data: {\"type\":\"message_stop\"}\n\n"
+	metadata, err = NewAnthropicProxy().ParseResponseMetadata(strings.NewReader(anthropicNativeStream), true)
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic", metadata.Provider)
+	assert.Equal(t, 16, metadata.TotalTokens)
+}
+
+// The OpenAI-compatibility endpoints signal streaming via "stream": true in
+// the body, not via the URL path, so IsStreamingRequest must body-sniff
+// /chat/completions for Anthropic and Gemini (OpenAI SDK clients do not
+// reliably send Accept: text/event-stream).
+func TestIsStreamingRequest_OpenAICompatEndpoints(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider Provider
+		path     string
+	}{
+		{"anthropic", NewAnthropicProxy(), "/anthropic/v1/chat/completions"},
+		{"gemini", NewGeminiProxy(), "/gemini/v1beta/openai/chat/completions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			streaming, _ := http.NewRequest("POST", tc.path, bytes.NewBufferString(`{"model":"m","stream":true}`))
+			assert.True(t, tc.provider.IsStreamingRequest(streaming))
+
+			nonStreaming, _ := http.NewRequest("POST", tc.path, bytes.NewBufferString(`{"model":"m"}`))
+			assert.False(t, tc.provider.IsStreamingRequest(nonStreaming))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug (production impact):** Anthropic's `/v1/chat/completions` and Gemini's `/v1beta/openai/chat/completions` return OpenAI-shaped JSON (`choices` + `usage.prompt_tokens`), but the native parsers unmarshalled those bodies into zero token counts. The `TotalTokens > 0` gate in the cost callback then never fired, so requests on these endpoints produced **no cost records, no admin spend stats, and no cost-limit enforcement** — while request-side PII stats kept counting. This is exactly how the Opik key (`sk-iw-12368b…c2bc77fc`) accumulated heavy Anthropic usage with a permanently empty cost tab.
- **Fix:** detect OpenAI-shaped bodies and SSE streams (`internal/providers/openai_compat.go`) and delegate them to the OpenAI parser, re-tagged with the owning provider — the same delegation pattern Bedrock Mantle already uses. Detection keys on the top-level `choices` field / `"object":"chat.completion…"` chunks, which never appear in native Anthropic (`content`) or Gemini (`candidates`) responses, so native paths are unaffected.
- **Streaming detection:** both providers' `IsStreamingRequest` now body-sniff `"stream": true` on `/chat/completions` paths (OpenAI SDK clients don't reliably send `Accept: text/event-stream`). For Gemini this is scoped to the compat path so native requests — including large media uploads — are never body-inspected.
- **Real cost-tracking integration tests via created keys:** `internal/providers/cost_tracking_integration_test.go` builds the production billing pipeline (sk-iw key created in the DynamoDB-fake-backed store → `APIKeyValidationMiddleware` → reverse proxy to the real upstream → `TokenParsingMiddleware` → the same cost callback as `main.go`) and asserts a cost record with **non-zero tokens and non-zero USD** is written and attributed to the masked created key. Pricing is loaded from the real `configs/base.yml`, so the tests also catch pricing-config drift for the tested models. Test names match the existing `Test(OpenAI|Anthropic|Gemini)Integration` pattern, so they run in the existing `integration-tests` CircleCI job (LLMs context) with no CI config changes; they skip when provider keys are absent and skip on upstream 429s.
- Parser-level unit tests (`openai_compat_test.go`) cover compat bodies through both providers (streaming + non-streaming), negative tests proving native formats still take the native parsers, and streaming detection for both compat endpoints.

## Test plan

- [x] `go test ./...` — full unit suite passes
- [x] `go vet ./...`, `gofumpt -l .` clean
- [x] Live run of all five new integration tests against real upstreams (OpenAI native; Anthropic native + compat non-streaming/streaming; Gemini native + compat non-streaming/streaming) — all pass with cost records, non-zero USD, and per-key attribution
- [ ] After deploy: confirm the Opik key's spend appears in the admin cost tab and per-key rollups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage and cost tracking for Anthropic and Gemini requests using OpenAI-compatible chat completions.
  * Streaming and non-streaming responses now correctly report input, output, and total token counts.
  * Preserved accurate provider attribution when processing compatible response formats.
* **Tests**
  * Added integration coverage for native and OpenAI-compatible endpoints, including streaming requests and API key spend tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->