### PR TITLE
feat(cost): emit masked key_id on Datadog cost metrics

### DIFF
--- a/internal/cost/datadog.go
+++ b/internal/cost/datadog.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -173,10 +174,16 @@ func NewDatadogTransportFromConfig(transportConfig interface{}, logger *slog.Log
 	return dt.FromConfig(transportConfig, logger)
 }
 
+// dogstatsdKeyIDTagValue makes a masked key id safe for DogStatsD tag values.
+// Masked ids use a unicode ellipsis; Datadog tag grammar prefers ASCII.
+func dogstatsdKeyIDTagValue(keyID string) string {
+	return strings.ReplaceAll(keyID, "…", "...")
+}
+
 // WriteRecord writes a cost record to Datadog as metrics
 func (dt *DatadogTransport) WriteRecord(record *CostRecord) error {
 	// Create metric tags from the record
-	tags := make([]string, 0, len(dt.tags)+6)
+	tags := make([]string, 0, len(dt.tags)+7)
 	tags = append(tags, dt.tags...)
 	tags = append(
 		tags,
@@ -188,6 +195,10 @@ func (dt *DatadogTransport) WriteRecord(record *CostRecord) error {
 
 	if record.UserID != "" {
 		tags = append(tags, fmt.Sprintf("user_id:%s", record.UserID))
+	}
+
+	if record.KeyID != "" {
+		tags = append(tags, fmt.Sprintf("key_id:%s", dogstatsdKeyIDTagValue(record.KeyID)))
 	}
 
 	if record.FinishReason != "" {

--- a/internal/cost/tracker.go
+++ b/internal/cost/tracker.go
@@ -63,7 +63,9 @@ type CostRecord struct {
 	Timestamp time.Time `json:"timestamp"`
 	RequestID string    `json:"request_id,omitempty"`
 	UserID    string    `json:"user_id,omitempty"`
-	IPAddress string    `json:"ip_address,omitempty"`
+	// KeyID is the masked proxy API key id (never the raw secret).
+	KeyID     string `json:"key_id,omitempty"`
+	IPAddress string `json:"ip_address,omitempty"`
 
 	// Request details
 	Provider    string `json:"provider"`
@@ -555,6 +557,7 @@ func (ct *CostTracker) TrackRequest(metadata *providers.LLMResponseMetadata, use
 		Timestamp:    time.Now(),
 		RequestID:    metadata.RequestID,
 		UserID:       userID,
+		KeyID:        keyID,
 		IPAddress:    ipAddress,
 		Provider:     metadata.Provider,
 		Model:        metadata.Model,

--- a/internal/cost/tracker_test.go
+++ b/internal/cost/tracker_test.go
@@ -61,7 +61,7 @@ func TestCostTracker_TrackRequest_Sync(t *testing.T) {
 		OutputTokens: 50,
 	}
 
-	err := ct.TrackRequest(meta, "user1", "127.0.0.1", "/v1/chat", "")
+	err := ct.TrackRequest(meta, "user1", "127.0.0.1", "/v1/chat", "iw:0123456789ab…deadbeef")
 	assert.NoError(t, err)
 
 	records := mock.Records()
@@ -69,6 +69,7 @@ func TestCostTracker_TrackRequest_Sync(t *testing.T) {
 	assert.Equal(t, "openai", records[0].Provider)
 	assert.Equal(t, "gpt-4o", records[0].Model)
 	assert.Equal(t, "user1", records[0].UserID)
+	assert.Equal(t, "iw:0123456789ab…deadbeef", records[0].KeyID)
 	assert.Equal(t, 100, records[0].InputTokens)
 	assert.Equal(t, 50, records[0].OutputTokens)
 	// cost = 100 * 0.01/1000 + 50 * 0.02/1000 = 0.001 + 0.001 = 0.0001

--- a/internal/cost/transports_test.go
+++ b/internal/cost/transports_test.go
@@ -127,6 +127,7 @@ func TestDatadogTransport_NewAndWriteRecord_Defaults(t *testing.T) {
 		Endpoint:     "/v1/chat",
 		IsStreaming:  true,
 		UserID:       "user-1",
+		KeyID:        "iw:0123456789ab…deadbeef",
 		FinishReason: "stop",
 		InputTokens:  10,
 		OutputTokens: 20,
@@ -136,6 +137,9 @@ func TestDatadogTransport_NewAndWriteRecord_Defaults(t *testing.T) {
 		TotalCost:    0.003,
 	}
 	assert.NoError(t, tr.WriteRecord(rec))
+
+	assert.Equal(t, "iw:0123456789ab...deadbeef", dogstatsdKeyIDTagValue(rec.KeyID))
+	assert.Equal(t, "iw:short", dogstatsdKeyIDTagValue("iw:short"))
 
 	// also exercise zero defaults branch via empty cfg
 	tr2, err := NewDatadogTransport(DatadogTransportConfig{})


### PR DESCRIPTION
## Summary
- Persist the masked proxy API key id on cost records and tag DogStatsD metrics with `key_id` (ASCII-safe ellipsis).
- Unlocks by-key widgets on the [token](https://app.datadoghq.com/dashboard/eaq-fbd-pb5/llm-token-tracking-via-proxy) and [cost](https://app.datadoghq.com/dashboard/3v5-qer-zu6/llm-cost-tracking-via-proxy) dashboards (already added; charts populate after deploy).

## Test plan
- [x] `go test ./internal/cost/ -count=1`
- [ ] Confirm post-deploy that `llm.cost.total_cents` / `llm.tokens.total` expose a `key_id` tag
- [ ] Spot-check dashboard by-key widgets for non-empty series

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost tracking now includes a masked API key ID with recorded cost data.
  * Datadog metrics include the masked key ID as a sanitized metric tag when available.

* **Bug Fixes**
  * Improved metric tag formatting for masked key IDs containing special ellipsis characters.
  * Preserved expected formatting for both short and truncated key IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->