### PR TITLE
fix(server): log silent request aborts and outlive ALB idle timeout

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1490,6 +1490,10 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	}
 
 	// Add middleware (order matters for streaming)
+	// Abort logging must be outermost so it observes http.ErrAbortHandler
+	// panics raised anywhere below (ReverseProxy body-copy failures that
+	// otherwise reset the connection with zero log output).
+	r.Use(middleware.AbortLoggingMiddleware())
 	r.Use(middleware.MetaURLRewritingMiddleware(globalProviderManager)) // URL rewriting must happen first
 
 	if yamlConfig.Features.ClientGzip.Enabled {
@@ -1871,13 +1875,20 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	// stalls. WriteTimeout is intentionally generous to accommodate long SSE
 	// streams; per-request deadlines are still enforced by upstream provider
 	// transports and per-handler context.WithTimeout helpers.
+	//
+	// IdleTimeout must be strictly GREATER than the ALB idle timeout (300s).
+	// When they are equal, the server closes idle keep-alive connections at
+	// the same moment the ALB reuses them, and the resulting RST surfaces to
+	// clients as intermittent ALB-generated 502s (HTTPCode_ELB_502_Count with
+	// zero target 5xx). Per AWS guidance the target's keep-alive idle timeout
+	// must outlive the load balancer's so the ALB always closes first.
 	server := &http.Server{
 		Addr:              "0.0.0.0:" + port,
 		Handler:           r,
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       60 * time.Second,
 		WriteTimeout:      0, // streaming: rely on per-handler ctx deadlines
-		IdleTimeout:       300 * time.Second,
+		IdleTimeout:       400 * time.Second,
 	}
 
 	// Set up graceful shutdown

--- a/internal/middleware/abort_logging.go
+++ b/internal/middleware/abort_logging.go
@@ -1,0 +1,113 @@
+package middleware
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/proxylog"
+)
+
+// AbortLoggingMiddleware makes silent request aborts visible.
+//
+// When httputil.ReverseProxy fails to copy the upstream response body to the
+// client (upstream stream reset after headers, client connection already
+// gone, ...), it panics with http.ErrAbortHandler. net/http deliberately
+// suppresses that panic — no stack trace, no log line — and resets the client
+// connection. Behind an ALB that reset surfaces to callers as an
+// ALB-generated 502 (HTTPCode_ELB_502_Count) with nothing in our logs: the
+// request has a "Started request" line but no TTFB / token-usage /
+// "Completed request" lines.
+//
+// This middleware recovers http.ErrAbortHandler, emits one structured log
+// line with enough context to correlate against ALB 502s (method, path,
+// status, bytes written, headers-sent flag, duration), and re-panics so
+// net/http's connection-teardown semantics are preserved. All other panic
+// values are re-panicked untouched — net/http already logs those with a
+// stack trace.
+//
+// It must be registered as the OUTERMOST middleware so it observes aborts
+// raised anywhere in the chain, including the provider ReverseProxy handlers.
+func AbortLoggingMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			aw := &abortTrackingWriter{ResponseWriter: w}
+
+			defer func() {
+				rec := recover()
+				if rec == nil {
+					return
+				}
+				if rec == http.ErrAbortHandler {
+					slog.Error(
+						proxylog.UpstreamMsg("request aborted mid-response; client connection will be reset"),
+						slog.String("method", r.Method),
+						slog.String("path", r.URL.Path),
+						slog.String("remote_addr", r.RemoteAddr),
+						slog.Int("status", aw.status),
+						slog.Int64("bytes_written", aw.bytesWritten),
+						slog.Bool("headers_sent", aw.wroteHeader),
+						slog.Duration("duration", time.Since(start)),
+					)
+				}
+				panic(rec)
+			}()
+
+			next.ServeHTTP(aw, r)
+		})
+	}
+}
+
+// abortTrackingWriter records the status code and number of body bytes
+// written so the abort log line can say how far the response got before the
+// connection died (headers_sent=false + bytes_written=0 means the client saw
+// the ALB's 502; a non-zero byte count means a truncated body). It forwards
+// http.Flusher and http.Hijacker and exposes Unwrap so wrapping never
+// degrades streaming or other writer capabilities (same contract as
+// statusCapturingWriter and responseCapture).
+type abortTrackingWriter struct {
+	http.ResponseWriter
+	status       int
+	bytesWritten int64
+	wroteHeader  bool
+}
+
+func (w *abortTrackingWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *abortTrackingWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		// Mirror net/http: the first Write implies a 200 if WriteHeader was
+		// never called.
+		w.status = http.StatusOK
+		w.wroteHeader = true
+	}
+	n, err := w.ResponseWriter.Write(b)
+	w.bytesWritten += int64(n)
+	return n, err
+}
+
+func (w *abortTrackingWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *abortTrackingWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not support hijacking")
+}
+
+// Unwrap exposes the wrapped writer for http.ResponseController.
+func (w *abortTrackingWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }

--- a/internal/middleware/abort_logging.go
+++ b/internal/middleware/abort_logging.go
@@ -77,6 +77,14 @@ type abortTrackingWriter struct {
 }
 
 func (w *abortTrackingWriter) WriteHeader(code int) {
+	// 1xx informational responses (100 Continue, 103 Early Hints — which
+	// ReverseProxy forwards via WriteHeader) are non-terminal: net/http lets
+	// the handler call WriteHeader again with the final status, so don't
+	// latch tracking state on them.
+	if code >= 100 && code < 200 {
+		w.ResponseWriter.WriteHeader(code)
+		return
+	}
 	if !w.wroteHeader {
 		w.status = code
 		w.wroteHeader = true
@@ -97,6 +105,13 @@ func (w *abortTrackingWriter) Write(b []byte) (int, error) {
 }
 
 func (w *abortTrackingWriter) Flush() {
+	// Flush commits an implicit 200 in net/http when WriteHeader hasn't been
+	// called yet; mirror that so abort logs never claim headers_sent=false
+	// after headers already reached the client.
+	if !w.wroteHeader {
+		w.status = http.StatusOK
+		w.wroteHeader = true
+	}
 	if f, ok := w.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}

--- a/internal/middleware/abort_logging_test.go
+++ b/internal/middleware/abort_logging_test.go
@@ -142,3 +142,37 @@ func TestAbortTrackingWriter_ForwardsFlush(t *testing.T) {
 		t.Error("expected Flush to be forwarded to the underlying writer")
 	}
 }
+
+// TestAbortTrackingWriter_InformationalHeadersNonTerminal verifies that 1xx
+// responses (e.g. 103 Early Hints, which ReverseProxy forwards) do not latch
+// the tracked status — the later final WriteHeader wins.
+func TestAbortTrackingWriter_InformationalHeadersNonTerminal(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &abortTrackingWriter{ResponseWriter: rec}
+
+	w.WriteHeader(http.StatusEarlyHints)
+	if w.wroteHeader {
+		t.Error("1xx must not mark headers as terminally written")
+	}
+	w.WriteHeader(http.StatusAccepted)
+	if w.status != http.StatusAccepted || !w.wroteHeader {
+		t.Errorf("expected final status 202 tracked, got status=%d wroteHeader=%v", w.status, w.wroteHeader)
+	}
+}
+
+// TestAbortTrackingWriter_FlushCommitsImplicit200 verifies a flush-only
+// response is tracked as headers committed with the implicit 200 that
+// net/http sends, so abort logs never report headers_sent=false after the
+// client already received headers.
+func TestAbortTrackingWriter_FlushCommitsImplicit200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &abortTrackingWriter{ResponseWriter: rec}
+
+	w.Flush()
+	if !w.wroteHeader || w.status != http.StatusOK {
+		t.Errorf("expected flush to commit implicit 200, got status=%d wroteHeader=%v", w.status, w.wroteHeader)
+	}
+	if !rec.Flushed {
+		t.Error("expected Flush to be forwarded to the underlying writer")
+	}
+}

--- a/internal/middleware/abort_logging_test.go
+++ b/internal/middleware/abort_logging_test.go
@@ -1,0 +1,144 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestAbortLoggingMiddleware_LogsErrAbortHandler verifies that an
+// http.ErrAbortHandler panic (the ReverseProxy body-copy failure signal) is
+// logged with request context and then re-panicked so net/http still resets
+// the connection.
+func TestAbortLoggingMiddleware_LogsErrAbortHandler(t *testing.T) {
+	handler := AbortLoggingMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("partial bo"))
+		panic(http.ErrAbortHandler)
+	}))
+
+	req := httptest.NewRequest("POST", "/openai/v1/responses", nil)
+	req.RemoteAddr = "172.31.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	var recovered any
+	logOutput := captureSlogOutput(func() {
+		defer func() { recovered = recover() }()
+		handler.ServeHTTP(rec, req)
+	})
+
+	if recovered != http.ErrAbortHandler {
+		t.Fatalf("expected http.ErrAbortHandler to be re-panicked, got %v", recovered)
+	}
+	if !strings.Contains(logOutput, "request aborted mid-response") {
+		t.Errorf("expected abort log line, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "/openai/v1/responses") {
+		t.Errorf("expected path in abort log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "bytes_written=10") {
+		t.Errorf("expected bytes_written=10 in abort log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "status=200") {
+		t.Errorf("expected status=200 in abort log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "headers_sent=true") {
+		t.Errorf("expected headers_sent=true in abort log, got: %s", logOutput)
+	}
+}
+
+// TestAbortLoggingMiddleware_AbortBeforeHeaders covers the observed
+// production shape: upstream returned headers to the transport but the body
+// copy failed before the first client write, so nothing was sent.
+func TestAbortLoggingMiddleware_AbortBeforeHeaders(t *testing.T) {
+	handler := AbortLoggingMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+
+	req := httptest.NewRequest("POST", "/openai/v1/responses", nil)
+	rec := httptest.NewRecorder()
+
+	var recovered any
+	logOutput := captureSlogOutput(func() {
+		defer func() { recovered = recover() }()
+		handler.ServeHTTP(rec, req)
+	})
+
+	if recovered != http.ErrAbortHandler {
+		t.Fatalf("expected http.ErrAbortHandler to be re-panicked, got %v", recovered)
+	}
+	if !strings.Contains(logOutput, "headers_sent=false") {
+		t.Errorf("expected headers_sent=false in abort log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "bytes_written=0") {
+		t.Errorf("expected bytes_written=0 in abort log, got: %s", logOutput)
+	}
+}
+
+// TestAbortLoggingMiddleware_OtherPanicsPassThrough verifies that non-abort
+// panics re-panic without the abort log line (net/http logs those itself,
+// with a stack trace).
+func TestAbortLoggingMiddleware_OtherPanicsPassThrough(t *testing.T) {
+	handler := AbortLoggingMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+
+	var recovered any
+	logOutput := captureSlogOutput(func() {
+		defer func() { recovered = recover() }()
+		handler.ServeHTTP(rec, req)
+	})
+
+	if recovered != "boom" {
+		t.Fatalf("expected original panic value to propagate, got %v", recovered)
+	}
+	if strings.Contains(logOutput, "request aborted mid-response") {
+		t.Errorf("abort log line should not fire for non-abort panics, got: %s", logOutput)
+	}
+}
+
+// TestAbortLoggingMiddleware_NormalRequestUntouched verifies the middleware
+// is transparent for successful requests.
+func TestAbortLoggingMiddleware_NormalRequestUntouched(t *testing.T) {
+	handler := AbortLoggingMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+
+	logOutput := captureSlogOutput(func() {
+		handler.ServeHTTP(rec, req)
+	})
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", rec.Code)
+	}
+	if rec.Body.String() != "ok" {
+		t.Errorf("expected body 'ok', got %q", rec.Body.String())
+	}
+	if strings.Contains(logOutput, "request aborted mid-response") {
+		t.Errorf("abort log line should not fire for normal requests, got: %s", logOutput)
+	}
+}
+
+// TestAbortTrackingWriter_ForwardsFlush verifies the wrapper keeps SSE
+// streaming working by forwarding Flush to the underlying writer.
+func TestAbortTrackingWriter_ForwardsFlush(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &abortTrackingWriter{ResponseWriter: rec}
+
+	if _, ok := interface{}(w).(http.Flusher); !ok {
+		t.Fatal("abortTrackingWriter must implement http.Flusher")
+	}
+	w.Write([]byte("chunk"))
+	w.Flush()
+	if !rec.Flushed {
+		t.Error("expected Flush to be forwarded to the underlying writer")
+	}
+}

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -99,7 +99,7 @@ func NewAnthropicProxy(opts ...ProxyOptions) *AnthropicProxy {
 				proxylog.Proxy("anthropic cannot send error response, headers already sent")
 			}
 		} else {
-			proxylog.UpstreamHTTPError(w, fmt.Sprintf("anthropic transport: %v", err), http.StatusBadGateway)
+			proxylog.WriteUpstreamJSONError(w, http.StatusBadGateway, fmt.Sprintf("anthropic transport: %v", err))
 		}
 	}
 

--- a/internal/providers/bedrock.go
+++ b/internal/providers/bedrock.go
@@ -144,7 +144,7 @@ func NewBedrockProxy(opts ...ProxyOptions) *BedrockProxy {
 			}
 			return
 		}
-		proxylog.UpstreamHTTPError(w, fmt.Sprintf("bedrock transport: %v", err), http.StatusBadGateway)
+		proxylog.WriteUpstreamJSONError(w, http.StatusBadGateway, fmt.Sprintf("bedrock transport: %v", err))
 	}
 
 	return bedrockProxy

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -197,7 +197,7 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 			}
 			return
 		}
-		proxylog.UpstreamHTTPError(w, fmt.Sprintf("bedrock-mantle transport: %v", err), http.StatusBadGateway)
+		proxylog.WriteUpstreamJSONError(w, http.StatusBadGateway, fmt.Sprintf("bedrock-mantle transport: %v", err))
 	}
 	return mantle
 }

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -105,7 +105,7 @@ func NewGeminiProxy(opts ...ProxyOptions) *GeminiProxy {
 				proxylog.Proxy("gemini cannot send error response, headers already sent")
 			}
 		} else {
-			proxylog.UpstreamHTTPError(w, fmt.Sprintf("gemini transport: %v", err), http.StatusBadGateway)
+			proxylog.WriteUpstreamJSONError(w, http.StatusBadGateway, fmt.Sprintf("gemini transport: %v", err))
 		}
 	}
 

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -101,7 +101,7 @@ func NewOpenAIProxy(opts ...ProxyOptions) *OpenAIProxy {
 				proxylog.Proxy("openai cannot send error response, headers already sent")
 			}
 		} else {
-			proxylog.UpstreamHTTPError(w, fmt.Sprintf("openai transport: %v", err), http.StatusBadGateway)
+			proxylog.WriteUpstreamJSONError(w, http.StatusBadGateway, fmt.Sprintf("openai transport: %v", err))
 		}
 	}
 

--- a/internal/providers/proxy_construction_test.go
+++ b/internal/providers/proxy_construction_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -128,8 +129,22 @@ func TestOpenAIProxy_ErrorHandler_Streaming(t *testing.T) {
 func TestOpenAIProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	rr := runErrorHandler(t, NewOpenAIProxy(), "/openai/v1/chat/completions", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
-	assert.Contains(t, rr.Body.String(), "openai transport")
+	assertJSONTransportError(t, rr, "openai transport")
+}
+
+// assertJSONTransportError verifies the non-streaming ErrorHandler body is
+// the {"error":"[UPSTREAM] <provider> transport: ..."} JSON shape (so API
+// clients like n8n can surface a readable message) rather than plain text.
+func assertJSONTransportError(t *testing.T, rr *httptest.ResponseRecorder, wantFragment string) {
+	t.Helper()
+	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+	assert.Contains(t, rr.Header().Get("X-Llm-Proxy-Error-Source"), "upstream")
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Contains(t, body.Error, "[UPSTREAM]")
+	assert.Contains(t, body.Error, wantFragment)
 }
 
 func TestAnthropicProxy_ErrorHandler_Streaming(t *testing.T) {
@@ -141,8 +156,7 @@ func TestAnthropicProxy_ErrorHandler_Streaming(t *testing.T) {
 func TestAnthropicProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	rr := runErrorHandler(t, NewAnthropicProxy(), "/anthropic/v1/messages", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
-	assert.Contains(t, rr.Body.String(), "anthropic transport")
+	assertJSONTransportError(t, rr, "anthropic transport")
 }
 
 func TestGeminiProxy_ErrorHandler_Streaming(t *testing.T) {
@@ -154,8 +168,7 @@ func TestGeminiProxy_ErrorHandler_Streaming(t *testing.T) {
 func TestGeminiProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	rr := runErrorHandler(t, NewGeminiProxy(), "/gemini/v1/models/gemini-pro:generateContent", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
-	assert.Contains(t, rr.Body.String(), "gemini transport")
+	assertJSONTransportError(t, rr, "gemini transport")
 }
 
 func TestBedrockProxy_ErrorHandler_Streaming(t *testing.T) {
@@ -169,8 +182,7 @@ func TestBedrockProxy_ErrorHandler_Streaming(t *testing.T) {
 func TestBedrockProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	rr := runErrorHandler(t, NewBedrockProxy(), "/bedrock/model/anthropic.claude-3-sonnet/converse", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
-	assert.Contains(t, rr.Body.String(), "bedrock transport")
+	assertJSONTransportError(t, rr, "bedrock transport")
 }
 
 func TestBedrockMantleProxy_ErrorHandler_Streaming(t *testing.T) {
@@ -193,8 +205,7 @@ func TestBedrockMantleProxy_ErrorHandler_NonStreaming(t *testing.T) {
 	)
 	rr := runErrorHandler(t, mantle, "/bedrock-mantle/anthropic/v1/messages", "")
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "[UPSTREAM]")
-	assert.Contains(t, rr.Body.String(), "bedrock-mantle transport")
+	assertJSONTransportError(t, rr, "bedrock-mantle transport")
 }
 
 func TestProvider_ModifyResponse_SSEHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to the n8n 502 investigation. The Jul 21 failure was **not a timeout**: OpenAI returned 200 in 19.2s, but the response body copy aborted and `net/http` reset the connection with zero log output — the ALB turned that reset into a client-facing 502 (`HTTPCode_ELB_502_Count` spiked that exact minute; target 5xx stayed zero). ELB 502s run 30–170/hour around the clock, so this is chronic, not incidental.

- **`AbortLoggingMiddleware`** (registered outermost): recovers `http.ErrAbortHandler` — the panic value `httputil.ReverseProxy` uses when the body copy fails — logs one structured line (method, path, status, bytes written, headers-sent flag, duration), and re-panics so the connection teardown semantics are unchanged. Non-abort panics pass through untouched (net/http already logs those with a stack). Today these aborts are completely invisible: "Started request" with no TTFB / token-usage / "Completed request" lines.
- **`IdleTimeout` 300s → 400s** on the HTTP server. It was exactly equal to the ALB's `idle_timeout` (300s), which races our keep-alive close against the ALB's connection reuse and produces intermittent ALB 502s. AWS guidance requires the target's keep-alive idle timeout to exceed the load balancer's so the ALB always closes first.
- **JSON bodies for proxy-generated transport 502s**: the non-streaming `ErrorHandler` paths now return `{"error":"[UPSTREAM] <provider> transport: ..."}` with `Content-Type: application/json` instead of plain text, so API clients (n8n, SDKs) can parse the failure reason and distinguish our 502s from the ALB's fixed HTML page. Streaming branches keep their SSE error format; the `X-Llm-Proxy-Error-Source: upstream` header is unchanged.

## Test plan

- [x] New unit tests: abort logged with context and re-panicked; abort-before-headers shape (the production signature); non-abort panics pass through without the abort line; normal requests untouched; `Flush` forwarding preserved for SSE.
- [x] Non-streaming ErrorHandler tests for all five providers now assert the JSON body shape and content type.
- [x] `make test` (race-enabled unit suite, uncached) green locally; `go vet`, `gofmt -s`, `gofumpt` clean.
- [ ] After deploy: watch for `request aborted mid-response` lines and correlate with `HTTPCode_ELB_502_Count`; expect the idle-race share of 502s to drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility for requests aborted mid-response by emitting a single structured error log with request details and response progress metrics.
  * Reduced intermittent 502 failures by increasing the server idle timeout to better align with load balancer behavior.
  * Standardized non-streaming upstream error responses to return JSON payloads (instead of generic text) across supported providers.
* **Reliability**
  * Preserved existing connection teardown behavior for aborted responses.
* **Tests**
  * Added coverage for abort-logging behavior and updated provider tests to validate JSON error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->