### PR TITLE
Capture the exact error behind silent 502 aborts (ctx state + body-read logging)

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1489,6 +1489,18 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 		)
 	}
 
+	// Body-read logging must be the LAST transport wrap (outermost) so its
+	// reader is the one ReverseProxy copies from — it then records the exact
+	// error ReverseProxy sees before panicking with http.ErrAbortHandler
+	// (which is otherwise silent for context.Canceled). Pure pass-through:
+	// no buffering, streaming unaffected.
+	for _, np := range namedProviders {
+		name := np.name
+		np.p.WrapTransport(func(inner http.RoundTripper) http.RoundTripper {
+			return providers.NewBodyReadLoggingTransport(inner, name)
+		})
+	}
+
 	// Add middleware (order matters for streaming)
 	// Abort logging must be outermost so it observes http.ErrAbortHandler
 	// panics raised anywhere below (ReverseProxy body-copy failures that

--- a/internal/middleware/abort_logging.go
+++ b/internal/middleware/abort_logging.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log/slog"
 	"net"
@@ -43,6 +44,12 @@ func AbortLoggingMiddleware() func(http.Handler) http.Handler {
 					return
 				}
 				if rec == http.ErrAbortHandler {
+					// ctx_err / ctx_cause disambiguate the two abort flavours:
+					// a non-empty ctx_err means the inbound request context was
+					// already canceled (net/http saw the client/ALB connection
+					// die), while an empty ctx_err with an abort means the
+					// failure was on the upstream side of the body copy.
+					ctx := r.Context()
 					slog.Error(
 						proxylog.UpstreamMsg("request aborted mid-response; client connection will be reset"),
 						slog.String("method", r.Method),
@@ -52,6 +59,8 @@ func AbortLoggingMiddleware() func(http.Handler) http.Handler {
 						slog.Int64("bytes_written", aw.bytesWritten),
 						slog.Bool("headers_sent", aw.wroteHeader),
 						slog.Duration("duration", time.Since(start)),
+						slog.String("ctx_err", errText(ctx.Err())),
+						slog.String("ctx_cause", errText(context.Cause(ctx))),
 					)
 				}
 				panic(rec)
@@ -126,3 +135,12 @@ func (w *abortTrackingWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 // Unwrap exposes the wrapped writer for http.ResponseController.
 func (w *abortTrackingWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+// errText renders an error for a slog attribute, with "" for nil so log
+// consumers can filter on attribute presence.
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/middleware/abort_logging_test.go
+++ b/internal/middleware/abort_logging_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,6 +76,53 @@ func TestAbortLoggingMiddleware_AbortBeforeHeaders(t *testing.T) {
 	if !strings.Contains(logOutput, "bytes_written=0") {
 		t.Errorf("expected bytes_written=0 in abort log, got: %s", logOutput)
 	}
+}
+
+// TestAbortLoggingMiddleware_LogsContextState verifies the abort line
+// carries the request-context error and cause, distinguishing "inbound
+// connection died (context canceled)" from "upstream body read failed with a
+// live client" (empty ctx_err).
+func TestAbortLoggingMiddleware_LogsContextState(t *testing.T) {
+	handler := AbortLoggingMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+
+	t.Run("live context logs empty ctx_err", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/gemini/v1beta/models/x:generateContent", nil)
+		rec := httptest.NewRecorder()
+
+		logOutput := captureSlogOutput(func() {
+			defer func() { _ = recover() }()
+			handler.ServeHTTP(rec, req)
+		})
+
+		if !strings.Contains(logOutput, "ctx_err=") {
+			t.Errorf("expected ctx_err attribute in abort log, got: %s", logOutput)
+		}
+		if strings.Contains(logOutput, "context canceled") {
+			t.Errorf("expected empty ctx_err for live context, got: %s", logOutput)
+		}
+	})
+
+	t.Run("canceled context logs cause", func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(errors.New("client hung up"))
+
+		req := httptest.NewRequest("POST", "/gemini/v1beta/models/x:generateContent", nil).WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		logOutput := captureSlogOutput(func() {
+			defer func() { _ = recover() }()
+			handler.ServeHTTP(rec, req)
+		})
+
+		if !strings.Contains(logOutput, "context canceled") {
+			t.Errorf("expected ctx_err=context canceled in abort log, got: %s", logOutput)
+		}
+		if !strings.Contains(logOutput, "client hung up") {
+			t.Errorf("expected ctx_cause with cancel cause in abort log, got: %s", logOutput)
+		}
+	})
 }
 
 // TestAbortLoggingMiddleware_OtherPanicsPassThrough verifies that non-abort

--- a/internal/providers/body_read_logging.go
+++ b/internal/providers/body_read_logging.go
@@ -1,0 +1,103 @@
+package providers
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/proxylog"
+)
+
+// NewBodyReadLoggingTransport wraps inner so the first error returned while
+// reading a response body is emitted as one structured log line.
+//
+// Rationale: when httputil.ReverseProxy hits a body-read error while copying
+// the upstream response to the client it panics with http.ErrAbortHandler,
+// and for context.Canceled it does so *silently* (net/http skips its
+// "ReverseProxy read error during body copy" log for canceled contexts). The
+// abort itself is visible via AbortLoggingMiddleware, but the underlying
+// error — who killed the stream, and whether the request context was already
+// canceled at that moment — is not. This transport captures exactly the error
+// the body consumer sees, without changing it.
+//
+// The wrapper is strictly pass-through: reads and Close are forwarded
+// unbuffered and errors are returned unmodified, so streaming (SSE flushing,
+// chunk boundaries) and connection reuse are unaffected. It should be
+// installed as the OUTERMOST transport wrapper so its body reader is the one
+// ReverseProxy actually reads from.
+func NewBodyReadLoggingTransport(inner http.RoundTripper, provider string) http.RoundTripper {
+	return &bodyReadLoggingTransport{inner: inner, provider: provider}
+}
+
+type bodyReadLoggingTransport struct {
+	inner    http.RoundTripper
+	provider string
+}
+
+func (t *bodyReadLoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if err != nil || resp == nil || resp.Body == nil {
+		return resp, err
+	}
+	resp.Body = &bodyReadLoggingReader{
+		inner:    resp.Body,
+		ctx:      req.Context(),
+		provider: t.provider,
+		method:   req.Method,
+		// Path only — Gemini carries the API key in the query string.
+		path:   req.URL.Path,
+		status: resp.StatusCode,
+		start:  time.Now(),
+	}
+	return resp, nil
+}
+
+// bodyReadLoggingReader forwards reads to the real response body and logs the
+// first non-EOF read error together with the request-context state at that
+// instant. Logging once keeps retry/drain paths from repeating the line.
+type bodyReadLoggingReader struct {
+	inner     io.ReadCloser
+	ctx       context.Context
+	provider  string
+	method    string
+	path      string
+	status    int
+	start     time.Time
+	bytesRead int64
+	logged    bool
+}
+
+func (b *bodyReadLoggingReader) Read(p []byte) (int, error) {
+	n, err := b.inner.Read(p)
+	b.bytesRead += int64(n)
+	if err != nil && err != io.EOF && !b.logged {
+		b.logged = true
+		slog.Error(
+			proxylog.UpstreamMsg("response body read error"),
+			slog.String("provider", b.provider),
+			slog.String("method", b.method),
+			slog.String("path", b.path),
+			slog.Int("status", b.status),
+			slog.String("error", err.Error()),
+			slog.String("ctx_err", readErrText(b.ctx.Err())),
+			slog.String("ctx_cause", readErrText(context.Cause(b.ctx))),
+			slog.Int64("bytes_read", b.bytesRead),
+			slog.Duration("since_headers", time.Since(b.start)),
+		)
+	}
+	return n, err
+}
+
+func (b *bodyReadLoggingReader) Close() error {
+	return b.inner.Close()
+}
+
+// readErrText renders an error for a slog attribute, with "" for nil.
+func readErrText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/providers/body_read_logging_test.go
+++ b/internal/providers/body_read_logging_test.go
@@ -1,0 +1,209 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func captureBodyReadSlog(fn func()) string {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+// erroringBody yields some payload bytes and then a terminal error.
+type erroringBody struct {
+	data   *bytes.Reader
+	err    error
+	closed bool
+}
+
+func (b *erroringBody) Read(p []byte) (int, error) {
+	if b.data.Len() > 0 {
+		return b.data.Read(p)
+	}
+	return 0, b.err
+}
+
+func (b *erroringBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type staticRoundTripper struct {
+	resp *http.Response
+	err  error
+}
+
+func (s *staticRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return s.resp, s.err
+}
+
+func newLoggingBodyResponse(t *testing.T, body io.ReadCloser) io.ReadCloser {
+	t.Helper()
+	inner := &staticRoundTripper{resp: &http.Response{StatusCode: http.StatusOK, Body: body}}
+	rt := NewBodyReadLoggingTransport(inner, "gemini")
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST", "https://upstream/v1beta/models/x:generateContent", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp.Body
+}
+
+// TestBodyReadLogging_PassThrough verifies data, EOF, and Close forward
+// unchanged and produce no log output.
+func TestBodyReadLogging_PassThrough(t *testing.T) {
+	body := &erroringBody{data: bytes.NewReader([]byte("hello world")), err: io.EOF}
+	wrapped := newLoggingBodyResponse(t, body)
+
+	var got []byte
+	logOutput := captureBodyReadSlog(func() {
+		var err error
+		got, err = io.ReadAll(wrapped)
+		if err != nil {
+			t.Fatalf("unexpected read error: %v", err)
+		}
+	})
+
+	if string(got) != "hello world" {
+		t.Errorf("expected pass-through body, got %q", got)
+	}
+	if logOutput != "" {
+		t.Errorf("expected no log output for clean EOF, got: %s", logOutput)
+	}
+	if err := wrapped.Close(); err != nil {
+		t.Fatalf("unexpected close error: %v", err)
+	}
+	if !body.closed {
+		t.Error("expected Close to forward to the inner body")
+	}
+}
+
+// TestBodyReadLogging_LogsFirstReadError verifies a non-EOF read error is
+// logged exactly once with the error text and context state, and that the
+// error itself is returned unchanged to the caller.
+func TestBodyReadLogging_LogsFirstReadError(t *testing.T) {
+	readErr := errors.New("stream reset by peer")
+	body := &erroringBody{data: bytes.NewReader([]byte("partial")), err: readErr}
+	wrapped := newLoggingBodyResponse(t, body)
+
+	var firstErr error
+	logOutput := captureBodyReadSlog(func() {
+		_, firstErr = io.ReadAll(wrapped)
+		// Second read after the error: must not log again.
+		buf := make([]byte, 8)
+		_, _ = wrapped.Read(buf)
+	})
+
+	if !errors.Is(firstErr, readErr) {
+		t.Fatalf("expected original error returned to caller, got %v", firstErr)
+	}
+	if count := strings.Count(logOutput, "response body read error"); count != 1 {
+		t.Errorf("expected exactly one read-error log line, got %d: %s", count, logOutput)
+	}
+	if !strings.Contains(logOutput, "stream reset by peer") {
+		t.Errorf("expected error text in log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "provider=gemini") {
+		t.Errorf("expected provider in log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "bytes_read=7") {
+		t.Errorf("expected bytes_read=7 in log, got: %s", logOutput)
+	}
+	if strings.Contains(logOutput, "context canceled") {
+		t.Errorf("expected empty ctx_err for live context, got: %s", logOutput)
+	}
+}
+
+// TestBodyReadLogging_CanceledContextCause verifies the log line captures the
+// request-context error and cancellation cause at the moment of the failed
+// read — the discriminator this instrumentation exists for.
+func TestBodyReadLogging_CanceledContextCause(t *testing.T) {
+	inner := &staticRoundTripper{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       &erroringBody{data: bytes.NewReader(nil), err: context.Canceled},
+	}}
+	rt := NewBodyReadLoggingTransport(inner, "gemini")
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://upstream/v1beta/models/x:generateContent", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel(errors.New("inbound connection lost"))
+
+	logOutput := captureBodyReadSlog(func() {
+		_, _ = io.ReadAll(resp.Body)
+	})
+
+	if !strings.Contains(logOutput, "ctx_err=\"context canceled\"") {
+		t.Errorf("expected ctx_err=context canceled in log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "inbound connection lost") {
+		t.Errorf("expected cancellation cause in log, got: %s", logOutput)
+	}
+}
+
+// TestBodyReadLogging_TransportErrorPassThrough verifies RoundTrip errors and
+// nil bodies flow through without wrapping.
+func TestBodyReadLogging_TransportErrorPassThrough(t *testing.T) {
+	rtErr := errors.New("dial failure")
+	rt := NewBodyReadLoggingTransport(&staticRoundTripper{err: rtErr}, "openai")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "https://upstream/v1/models", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, gotErr := rt.RoundTrip(req); !errors.Is(gotErr, rtErr) {
+		t.Fatalf("expected transport error passed through, got %v", gotErr)
+	}
+}
+
+// TestBodyReadLogging_QueryStringNotLogged verifies the log line uses only
+// the URL path — Gemini requests carry the API key in the query string.
+func TestBodyReadLogging_QueryStringNotLogged(t *testing.T) {
+	inner := &staticRoundTripper{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       &erroringBody{data: bytes.NewReader(nil), err: errors.New("boom")},
+	}}
+	rt := NewBodyReadLoggingTransport(inner, "gemini")
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		"https://upstream/v1beta/models/x:generateContent?key=sk-super-secret", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logOutput := captureBodyReadSlog(func() {
+		_, _ = io.ReadAll(resp.Body)
+	})
+
+	if strings.Contains(logOutput, "sk-super-secret") {
+		t.Errorf("API key must not appear in log output, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, ":generateContent") {
+		t.Errorf("expected path in log output, got: %s", logOutput)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #38. With ALB access logs now enabled, the intermittent 502s are confirmed to be the proxy resetting its own connection mid-response: the access log shows `elb_status_code=502`, `target_status_code=-` after ~20s of `target_processing_time` with the client (Cloudflare/n8n) still connected, and the proxy's abort log shows upstream returned a 200 with the body copy failing before the first byte was written.

The one missing datum is the underlying error. `httputil.ReverseProxy` panics with `http.ErrAbortHandler` on body-copy failures and — specifically for `context.Canceled` read errors — logs nothing (its "read error during body copy" line skips canceled contexts). This PR adds two strictly pass-through instrumentation points so the next 502 names its cause:

- **`AbortLoggingMiddleware`**: the abort line now includes `ctx_err` and `ctx_cause` for the inbound request context. A populated `ctx_err` means net/http saw the client/ALB connection die; an empty one means the failure was on the upstream side of the copy.
- **`NewBodyReadLoggingTransport`** (new, wrapped outermost around every provider transport after fake/circuit wrapping): forwards reads and `Close` unchanged and logs the first non-EOF response-body read error with the exact error text, request-context state at that instant, bytes read, and time since headers.

## Safety

- No behavior change: reads, errors, and `Close` pass through unmodified; no buffering, so SSE/streaming chunk boundaries and flushing are unaffected.
- Logs use the URL path only — Gemini API keys in query strings never reach the log line (covered by a test).
- The body logger fires at most once per response, so circuit drain/retry paths cannot spam it.

## Test plan

- [x] New unit tests: pass-through with clean EOF (no log), first-error logged exactly once with error text and provider, canceled-context cause captured, transport errors and nil bodies pass through, query string never logged.
- [x] New abort-middleware tests: `ctx_err` empty for live contexts, `ctx_err`/`ctx_cause` populated for canceled contexts.
- [x] `make ci` (gofmt -s / gofumpt / vet / lint-pii-logs / config validator / race-enabled unit tests) passes locally.
- [ ] After deploy: correlate the next `request aborted mid-response` line with its adjacent `response body read error` line to identify who kills the stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved diagnostics for interrupted provider responses, including request context errors, cancellation causes, response status, and bytes read.
  * Added safeguards to prevent sensitive query-string data from appearing in error logs.
  * Streaming behavior and response handling remain unchanged.

* **Bug Fixes**
  * Ensured response read errors are logged once with the exact error observed by the proxy.
  * Preserved transport and body-read errors without altering their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->