### PR TITLE
fix(ratelimit): attribute Adjust/Cancel to the reservation's window

### DIFF
--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"log"
@@ -51,7 +52,10 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 
 			scope := ratelimit.ScopeKeys{Provider: prov.GetName(), Model: model, APIKey: apiKey, UserID: userID}
 			reservationID := newReservationID()
-			res, err := limiter.CheckAndReserve(r.Context(), reservationID, scope, estTokens, time.Now())
+			// Reconciliation (Adjust/Cancel below) must attribute the delta to
+			// the window this reservation was made in, so keep the timestamp.
+			reservedAt := time.Now()
+			res, err := limiter.CheckAndReserve(r.Context(), reservationID, scope, estTokens, reservedAt)
 			if err != nil {
 				// Fail OPEN on limiter/backend (e.g. Redis) errors. A transient
 				// Redis blip must not turn into a wholesale 500 for every LLM
@@ -109,11 +113,17 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 			sw := &statusCapturingWriter{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(sw, r)
 
-			// Reconcile using input token metadata set by token parsing middleware headers if present
+			// Reconcile using input token metadata set by token parsing middleware headers if present.
+			// Detach from the request context: r.Context() is canceled the
+			// moment the client disconnects — which is exactly when the 5xx
+			// Cancel path below fires — and both limiter backends fail on a
+			// canceled context, leaving the reservation stuck in the window.
+			reconcileCtx, reconcileCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 2*time.Second)
+			defer reconcileCancel()
 			actualInput := headerToInt(w.Header().Get("X-LLM-Input-Tokens"))
 			if actualInput > 0 {
 				delta := actualInput - estTokens
-				if err := limiter.Adjust(r.Context(), reservationID, scope, delta, time.Now()); err != nil {
+				if err := limiter.Adjust(reconcileCtx, reservationID, scope, delta, reservedAt, time.Now()); err != nil {
 					proxylog.Proxy("ratelimit: adjust error: %v", err)
 				} else if delta != 0 {
 					log.Printf("ratelimit: adjust (input) provider=%s model=%s user=%s key_prefix=%s delta_input_tokens=%d",
@@ -128,7 +138,7 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 				// (client-caused) attempt that should count, and 2xx without an
 				// input-token header is a streaming/parsed success that the
 				// Adjust branch above (or estimation) already accounts for.
-				if err := limiter.Cancel(r.Context(), reservationID, scope, estTokens, time.Now()); err != nil {
+				if err := limiter.Cancel(reconcileCtx, reservationID, scope, estTokens, reservedAt, time.Now()); err != nil {
 					proxylog.Proxy("ratelimit: cancel error: %v", err)
 				} else {
 					log.Printf("ratelimit: cancel (upstream %d) provider=%s model=%s user=%s key_prefix=%s est_tokens=%d",

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -100,8 +101,9 @@ func TestRateLimitingRequestsPerMinute(t *testing.T) {
 	if got := rr2.Header().Get("X-RateLimit-Remaining"); got != "0" {
 		t.Fatalf("unexpected X-RateLimit-Remaining: %q", got)
 	}
-	if got := rr2.Header().Get("Retry-After"); got != "60" {
-		t.Fatalf("unexpected Retry-After: %q", got)
+	// Retry-After is the true seconds to the minute boundary (1..60).
+	if got, err := strconv.Atoi(rr2.Header().Get("Retry-After")); err != nil || got < 1 || got > 60 {
+		t.Fatalf("unexpected Retry-After: %q", rr2.Header().Get("Retry-After"))
 	}
 }
 
@@ -159,8 +161,9 @@ func TestRateLimitingTokensPerMinute(t *testing.T) {
 	if got := rr2.Header().Get("X-RateLimit-Remaining"); got != "0" {
 		t.Fatalf("unexpected X-RateLimit-Remaining: %q", got)
 	}
-	if got := rr2.Header().Get("Retry-After"); got != "60" {
-		t.Fatalf("unexpected Retry-After: %q", got)
+	// Retry-After is the true seconds to the minute boundary (1..60).
+	if got, err := strconv.Atoi(rr2.Header().Get("Retry-After")); err != nil || got < 1 || got > 60 {
+		t.Fatalf("unexpected Retry-After: %q", rr2.Header().Get("Retry-After"))
 	}
 }
 
@@ -288,11 +291,11 @@ func (erroringLimiter) CheckAndReserve(ctx context.Context, id string, scope rat
 	return ratelimit.ReservationResult{}, errors.New("simulated limiter outage")
 }
 
-func (erroringLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, now time.Time) error {
+func (erroringLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, reservedAt, now time.Time) error {
 	return errors.New("simulated adjust outage")
 }
 
-func (erroringLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, now time.Time) error {
+func (erroringLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, reservedAt, now time.Time) error {
 	return nil
 }
 
@@ -332,11 +335,11 @@ func (adjustErroringLimiter) CheckAndReserve(ctx context.Context, id string, sco
 	return ratelimit.ReservationResult{Allowed: true}, nil
 }
 
-func (adjustErroringLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, now time.Time) error {
+func (adjustErroringLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, reservedAt, now time.Time) error {
 	return errors.New("simulated adjust outage")
 }
 
-func (adjustErroringLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, now time.Time) error {
+func (adjustErroringLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, reservedAt, now time.Time) error {
 	return nil
 }
 
@@ -381,11 +384,11 @@ func (l *cancelRecordingLimiter) CheckAndReserve(ctx context.Context, id string,
 	return ratelimit.ReservationResult{Allowed: true, ReservationID: id}, nil
 }
 
-func (l *cancelRecordingLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, now time.Time) error {
+func (l *cancelRecordingLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, reservedAt, now time.Time) error {
 	return nil
 }
 
-func (l *cancelRecordingLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, now time.Time) error {
+func (l *cancelRecordingLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, reservedAt, now time.Time) error {
 	l.cancelCalled = true
 	l.cancelTokens = estTokens
 	return nil
@@ -415,6 +418,63 @@ func TestRateLimitingMiddleware_CancelsReservationOnUpstream5xx(t *testing.T) {
 	}
 	if !lim.cancelCalled {
 		t.Fatal("Cancel must be called to release the reservation on a 5xx upstream")
+	}
+}
+
+// ctxRecordingLimiter allows reservations and records the ctx.Err() observed
+// by Cancel, so tests can prove reconciliation runs on a context that
+// outlives the client connection.
+type ctxRecordingLimiter struct {
+	cancelCalled bool
+	cancelCtxErr error
+}
+
+func (l *ctxRecordingLimiter) CheckAndReserve(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, now time.Time) (ratelimit.ReservationResult, error) {
+	return ratelimit.ReservationResult{Allowed: true, ReservationID: id}, nil
+}
+
+func (l *ctxRecordingLimiter) Adjust(ctx context.Context, id string, scope ratelimit.ScopeKeys, delta int, reservedAt, now time.Time) error {
+	return nil
+}
+
+func (l *ctxRecordingLimiter) Cancel(ctx context.Context, id string, scope ratelimit.ScopeKeys, estTokens int, reservedAt, now time.Time) error {
+	l.cancelCalled = true
+	l.cancelCtxErr = ctx.Err()
+	return nil
+}
+
+// TestRateLimitingMiddleware_ReconcileSurvivesClientDisconnect asserts that
+// post-handler reconciliation (Adjust/Cancel) runs on a context detached from
+// the request. r.Context() is canceled the moment the client disconnects —
+// exactly when an upstream 5xx is most likely — and both limiter backends
+// refuse canceled contexts, which used to leave the reservation stuck in the
+// window until TTL expiry.
+func TestRateLimitingMiddleware_ReconcileSurvivesClientDisconnect(t *testing.T) {
+	cfg := makeCfg()
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(&fakeProvider{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lim := &ctxRecordingLimiter{}
+	chain := RateLimitingMiddleware(pm, cfg, lim, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate the client disconnecting mid-request.
+		cancel()
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+
+	req := httptest.NewRequest("POST", "/openai/v1/chat/completions", bytes.NewReader([]byte(`{"model":"gpt-4o","messages":[]}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	chain.ServeHTTP(rr, req)
+
+	if !lim.cancelCalled {
+		t.Fatal("Cancel must be called to release the reservation on a 5xx upstream")
+	}
+	if lim.cancelCtxErr != nil {
+		t.Fatalf("Cancel must receive a context that survives client disconnect; got ctx.Err() = %v", lim.cancelCtxErr)
 	}
 }
 

--- a/internal/ratelimit/memory.go
+++ b/internal/ratelimit/memory.go
@@ -357,6 +357,12 @@ func maxInt(a, b int) int {
 }
 
 func exceededMetric(c *counters, lim limits, addTokens int) string {
+	// Prefer requests over tokens when both are exceeded, matching exceeds()
+	// check order and redis.luaCheckAndReserve so X-RateLimit-* headers
+	// agree across backends.
+	if lim.reqPerWindow > 0 && c.Requests+1 > lim.reqPerWindow {
+		return "requests"
+	}
 	if lim.tokPerWindow > 0 && c.Tokens+addTokens > lim.tokPerWindow {
 		return "tokens"
 	}

--- a/internal/ratelimit/memory.go
+++ b/internal/ratelimit/memory.go
@@ -56,38 +56,36 @@ func (m *memoryLimiter) CheckAndReserve(ctx context.Context, id string, scope Sc
 		minC := m.getCounterLocked(m.minute, k)
 		minLim := m.limitFor(k, true)
 		if m.exceeds(minC, minLim, estTokens) {
-			remaining := 0
-			if minLim.tokPerWindow > 0 {
-				remaining = max0(minLim.tokPerWindow - (minC.Tokens + estTokens))
-			} else if minLim.reqPerWindow > 0 {
-				remaining = max0(minLim.reqPerWindow - (minC.Requests + 1))
-			}
+			// Derive Limit and Remaining from the metric that actually
+			// tripped, so the X-RateLimit-* headers are internally consistent
+			// (matches the Redis script's per-check computation).
 			metric := exceededMetric(minC, minLim, estTokens)
-			limitVal := 0
+			remaining, limitVal := 0, 0
 			if metric == "tokens" {
 				limitVal = minLim.tokPerWindow
+				remaining = max0(minLim.tokPerWindow - (minC.Tokens + estTokens))
 			} else {
 				limitVal = minLim.reqPerWindow
+				remaining = max0(minLim.reqPerWindow - (minC.Requests + 1))
 			}
 			details := &LimitDetails{ScopeKey: k, Metric: metric, Window: "minute", Limit: limitVal, Remaining: remaining}
-			return ReservationResult{Allowed: false, RetryAfterSeconds: 60, Reason: "minute limit exceeded", Details: details}, nil
+			// Retry-After is the true time to the window boundary, matching
+			// the Redis backend, not a flat 60 (a denial at second 55 can
+			// retry in 5s).
+			return ReservationResult{Allowed: false, RetryAfterSeconds: secToMinuteEnd(now), Reason: "minute limit exceeded", Details: details}, nil
 		}
 		// day window
 		dayC := m.getCounterLocked(m.day, k)
 		dayLim := m.limitFor(k, false)
 		if m.exceeds(dayC, dayLim, estTokens) {
-			remaining := 0
-			if dayLim.tokPerWindow > 0 {
-				remaining = max0(dayLim.tokPerWindow - (dayC.Tokens + estTokens))
-			} else if dayLim.reqPerWindow > 0 {
-				remaining = max0(dayLim.reqPerWindow - (dayC.Requests + 1))
-			}
 			metric := exceededMetric(dayC, dayLim, estTokens)
-			limitVal := 0
+			remaining, limitVal := 0, 0
 			if metric == "tokens" {
 				limitVal = dayLim.tokPerWindow
+				remaining = max0(dayLim.tokPerWindow - (dayC.Tokens + estTokens))
 			} else {
 				limitVal = dayLim.reqPerWindow
+				remaining = max0(dayLim.reqPerWindow - (dayC.Requests + 1))
 			}
 			details := &LimitDetails{ScopeKey: k, Metric: metric, Window: "day", Limit: limitVal, Remaining: remaining}
 			return ReservationResult{Allowed: false, RetryAfterSeconds: int(time.Until(m.dayTick.Add(24 * time.Hour)).Seconds()), Reason: "daily limit exceeded", Details: details}, nil
@@ -105,7 +103,7 @@ func (m *memoryLimiter) CheckAndReserve(ctx context.Context, id string, scope Sc
 	return ReservationResult{Allowed: true, ReservationID: id}, nil
 }
 
-func (m *memoryLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, tokenDelta int, now time.Time) error {
+func (m *memoryLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, tokenDelta int, reservedAt, now time.Time) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -113,10 +111,23 @@ func (m *memoryLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, 
 	defer m.mu.Unlock()
 
 	m.rotateWindowsLocked(now)
+	// Only touch windows the reservation was actually made in; if a window
+	// rotated between reserve and reconcile, the reservation vanished with it
+	// and applying the delta here would mutate other requests' counters.
+	sameMin := reservedAt.Truncate(time.Minute).Equal(m.minTick)
+	sameDay := reservedAt.Truncate(24 * time.Hour).Equal(m.dayTick)
 	keys := m.scopeKeys(scope)
 	for _, k := range keys {
-		m.getCounterLocked(m.minute, k).Tokens += tokenDelta
-		m.getCounterLocked(m.day, k).Tokens += tokenDelta
+		if sameMin {
+			c := m.getCounterLocked(m.minute, k)
+			// Clamp like the Redis script does: a large negative delta must
+			// not drive the counter negative and grant free capacity.
+			c.Tokens = max0(c.Tokens + tokenDelta)
+		}
+		if sameDay {
+			c := m.getCounterLocked(m.day, k)
+			c.Tokens = max0(c.Tokens + tokenDelta)
+		}
 	}
 	return nil
 }
@@ -124,7 +135,7 @@ func (m *memoryLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, 
 // Cancel undoes a prior reservation. estTokens MUST mirror what was passed
 // to CheckAndReserve for this reservation; otherwise the reserved tokens
 // remain in the window and silently under-credit the limit.
-func (m *memoryLimiter) Cancel(ctx context.Context, id string, scope ScopeKeys, estTokens int, now time.Time) error {
+func (m *memoryLimiter) Cancel(ctx context.Context, id string, scope ScopeKeys, estTokens int, reservedAt, now time.Time) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -132,14 +143,20 @@ func (m *memoryLimiter) Cancel(ctx context.Context, id string, scope ScopeKeys, 
 	defer m.mu.Unlock()
 
 	m.rotateWindowsLocked(now)
+	sameMin := reservedAt.Truncate(time.Minute).Equal(m.minTick)
+	sameDay := reservedAt.Truncate(24 * time.Hour).Equal(m.dayTick)
 	keys := m.scopeKeys(scope)
 	for _, k := range keys {
-		minC := m.getCounterLocked(m.minute, k)
-		minC.Requests = max0(minC.Requests - 1)
-		minC.Tokens = max0(minC.Tokens - estTokens)
-		dayC := m.getCounterLocked(m.day, k)
-		dayC.Requests = max0(dayC.Requests - 1)
-		dayC.Tokens = max0(dayC.Tokens - estTokens)
+		if sameMin {
+			minC := m.getCounterLocked(m.minute, k)
+			minC.Requests = max0(minC.Requests - 1)
+			minC.Tokens = max0(minC.Tokens - estTokens)
+		}
+		if sameDay {
+			dayC := m.getCounterLocked(m.day, k)
+			dayC.Requests = max0(dayC.Requests - 1)
+			dayC.Tokens = max0(dayC.Tokens - estTokens)
+		}
 	}
 	return nil
 }

--- a/internal/ratelimit/memory_test.go
+++ b/internal/ratelimit/memory_test.go
@@ -239,10 +239,57 @@ func TestMemoryLimiter_Adjust_AddsAndRefunds(t *testing.T) {
 	res, _ := lim.CheckAndReserve(context.Background(), "1", scope, 50, now)
 	require.True(t, res.Allowed)
 
-	require.NoError(t, lim.Adjust(context.Background(), "1", scope, -30, now))
+	require.NoError(t, lim.Adjust(context.Background(), "1", scope, -30, now, now))
 
 	res2, _ := lim.CheckAndReserve(context.Background(), "2", scope, 70, now)
 	assert.True(t, res2.Allowed)
+}
+
+// TestMemoryLimiter_CancelAfterMinuteRotationSkipsNewWindow guards the
+// window-attribution fix: a reservation made in minute window W1 whose 5xx
+// cancel arrives after the boundary must not erase other requests'
+// reservations in W2. The still-current day window IS released.
+func TestMemoryLimiter_CancelAfterMinuteRotationSkipsNewWindow(t *testing.T) {
+	cfg := baseCfg()
+	lim := NewMemoryLimiter(cfg)
+	scope := ScopeKeys{UserID: "u-rotate"}
+	t0 := time.Date(2026, 7, 24, 12, 0, 50, 0, time.UTC)
+
+	resA, _ := lim.CheckAndReserve(context.Background(), "A", scope, 40, t0)
+	require.True(t, resA.Allowed)
+
+	t1 := t0.Add(15 * time.Second) // next minute window
+	resB, _ := lim.CheckAndReserve(context.Background(), "B", scope, 40, t1)
+	require.True(t, resB.Allowed)
+
+	require.NoError(t, lim.Cancel(context.Background(), "A", scope, 40, t0, t1))
+
+	snap := lim.(Snapshotter).Snapshot(t1)
+	minC := snap.Minute.Counters["user:u-rotate"]
+	assert.Equal(t, 1, minC.Requests, "B's minute request must survive A's late cancel")
+	assert.Equal(t, 40, minC.Tokens, "B's minute tokens must survive A's late cancel")
+	dayC := snap.Day.Counters["user:u-rotate"]
+	assert.Equal(t, 1, dayC.Requests, "A's day reservation should be released")
+	assert.Equal(t, 40, dayC.Tokens)
+}
+
+// TestMemoryLimiter_AdjustClampsAtZero guards the negative-clamp fix: an
+// over-refund (actual usage far below the estimate) must clamp the counter at
+// zero — mirroring the Redis script — instead of going negative and granting
+// free headroom beyond the configured TPM.
+func TestMemoryLimiter_AdjustClampsAtZero(t *testing.T) {
+	cfg := baseCfg()
+	lim := NewMemoryLimiter(cfg)
+	scope := ScopeKeys{UserID: "u-clamp"}
+	now := time.Now()
+
+	res, _ := lim.CheckAndReserve(context.Background(), "1", scope, 50, now)
+	require.True(t, res.Allowed)
+
+	require.NoError(t, lim.Adjust(context.Background(), "1", scope, -1900, now, now))
+	snap := lim.(Snapshotter).Snapshot(now)
+	assert.Equal(t, 0, snap.Minute.Counters["user:u-clamp"].Tokens)
+	assert.Equal(t, 0, snap.Day.Counters["user:u-clamp"].Tokens)
 }
 
 func TestMemoryLimiter_Cancel_FreesRequestSlot(t *testing.T) {
@@ -259,7 +306,7 @@ func TestMemoryLimiter_Cancel_FreesRequestSlot(t *testing.T) {
 	res3, _ := lim.CheckAndReserve(context.Background(), "3", scope, 1, now)
 	require.False(t, res3.Allowed)
 
-	require.NoError(t, lim.Cancel(context.Background(), "1", scope, 1, now))
+	require.NoError(t, lim.Cancel(context.Background(), "1", scope, 1, now, now))
 
 	res4, _ := lim.CheckAndReserve(context.Background(), "4", scope, 1, now)
 	assert.True(t, res4.Allowed)

--- a/internal/ratelimit/memory_test.go
+++ b/internal/ratelimit/memory_test.go
@@ -57,6 +57,26 @@ func TestMemoryLimiterTokensPerMinute(t *testing.T) {
 	}
 }
 
+func TestMemoryLimiterBothLimitsExceededPrefersRequestsMetric(t *testing.T) {
+	// When a denial trips both RPM and TPM, report "requests" so headers
+	// match redis.luaCheckAndReserve (requests checked first).
+	cfg := baseCfg()
+	cfg.Features.RateLimiting.Limits.RequestsPerMinute = 1
+	cfg.Features.RateLimiting.Limits.TokensPerMinute = 10
+	lim := NewMemoryLimiter(cfg)
+	scope := ScopeKeys{Provider: "openai", Model: "gpt-4o", UserID: "u-both"}
+	now := time.Now()
+
+	if res, _ := lim.CheckAndReserve(context.Background(), "1", scope, 10, now); !res.Allowed {
+		t.Fatalf("first should be allowed")
+	}
+	res, err := lim.CheckAndReserve(context.Background(), "2", scope, 10, now)
+	require.NoError(t, err)
+	require.False(t, res.Allowed)
+	require.NotNil(t, res.Details)
+	assert.Equal(t, "requests", res.Details.Metric)
+}
+
 func TestMemoryLimiterDailyWindow(t *testing.T) {
 	cfg := baseCfg()
 	cfg.Features.RateLimiting.Limits.RequestsPerMinute = 1000

--- a/internal/ratelimit/redis.go
+++ b/internal/ratelimit/redis.go
@@ -258,20 +258,29 @@ end
 return {1}
 `)
 
+// applyMin/applyDay (ARGV 5/6) gate each window: the caller sets them to 0
+// when that window rotated since the reservation was made, in which case the
+// counters now belong to other requests and must not be touched.
 var luaAdjust = redis.NewScript(`
 local delta = tonumber(ARGV[1])
 local ttlMin = tonumber(ARGV[2])
 local ttlDay = tonumber(ARGV[3])
 local pairsCount = tonumber(ARGV[4])
+local applyMin = tonumber(ARGV[5]) == 1
+local applyDay = tonumber(ARGV[6]) == 1
 for i = 0, pairsCount - 1 do
   local kMin = KEYS[2*i + 1]
   local kDay = KEYS[2*i + 2]
-  local newMin = redis.call('HINCRBY', kMin, 'tok', delta)
-  if tonumber(newMin) < 0 then redis.call('HSET', kMin, 'tok', 0) end
-  redis.call('EXPIRE', kMin, ttlMin)
-  local newDay = redis.call('HINCRBY', kDay, 'tok', delta)
-  if tonumber(newDay) < 0 then redis.call('HSET', kDay, 'tok', 0) end
-  redis.call('EXPIRE', kDay, ttlDay)
+  if applyMin then
+    local newMin = redis.call('HINCRBY', kMin, 'tok', delta)
+    if tonumber(newMin) < 0 then redis.call('HSET', kMin, 'tok', 0) end
+    redis.call('EXPIRE', kMin, ttlMin)
+  end
+  if applyDay then
+    local newDay = redis.call('HINCRBY', kDay, 'tok', delta)
+    if tonumber(newDay) < 0 then redis.call('HSET', kDay, 'tok', 0) end
+    redis.call('EXPIRE', kDay, ttlDay)
+  end
 end
 return {1}
 `)
@@ -284,19 +293,25 @@ local estTokens = tonumber(ARGV[1])
 local ttlMin = tonumber(ARGV[2])
 local ttlDay = tonumber(ARGV[3])
 local pairsCount = tonumber(ARGV[4])
+local applyMin = tonumber(ARGV[5]) == 1
+local applyDay = tonumber(ARGV[6]) == 1
 for i = 0, pairsCount - 1 do
   local kMin = KEYS[2*i + 1]
   local kDay = KEYS[2*i + 2]
-  local newMinReq = redis.call('HINCRBY', kMin, 'req', -1)
-  if tonumber(newMinReq) < 0 then redis.call('HSET', kMin, 'req', 0) end
-  local newMinTok = redis.call('HINCRBY', kMin, 'tok', -estTokens)
-  if tonumber(newMinTok) < 0 then redis.call('HSET', kMin, 'tok', 0) end
-  redis.call('EXPIRE', kMin, ttlMin)
-  local newDayReq = redis.call('HINCRBY', kDay, 'req', -1)
-  if tonumber(newDayReq) < 0 then redis.call('HSET', kDay, 'req', 0) end
-  local newDayTok = redis.call('HINCRBY', kDay, 'tok', -estTokens)
-  if tonumber(newDayTok) < 0 then redis.call('HSET', kDay, 'tok', 0) end
-  redis.call('EXPIRE', kDay, ttlDay)
+  if applyMin then
+    local newMinReq = redis.call('HINCRBY', kMin, 'req', -1)
+    if tonumber(newMinReq) < 0 then redis.call('HSET', kMin, 'req', 0) end
+    local newMinTok = redis.call('HINCRBY', kMin, 'tok', -estTokens)
+    if tonumber(newMinTok) < 0 then redis.call('HSET', kMin, 'tok', 0) end
+    redis.call('EXPIRE', kMin, ttlMin)
+  end
+  if applyDay then
+    local newDayReq = redis.call('HINCRBY', kDay, 'req', -1)
+    if tonumber(newDayReq) < 0 then redis.call('HSET', kDay, 'req', 0) end
+    local newDayTok = redis.call('HINCRBY', kDay, 'tok', -estTokens)
+    if tonumber(newDayTok) < 0 then redis.call('HSET', kDay, 'tok', 0) end
+    redis.call('EXPIRE', kDay, ttlDay)
+  end
 end
 return {1}
 `)
@@ -406,10 +421,28 @@ func (r *redisLimiter) CheckAndReserve(ctx context.Context, id string, scope Sco
 	return ReservationResult{Allowed: false, RetryAfterSeconds: retry, Reason: reason, Details: details}, nil
 }
 
-func (r *redisLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, tokenDelta int, now time.Time) error {
+// windowFlags reports which windows are still the ones the reservation was
+// made in. The Redis key names are not window-stamped (identity comes from
+// TTL expiry), so a reconcile that crosses a boundary would otherwise land on
+// the next window's counters and erase other requests' reservations.
+func windowFlags(reservedAt, now time.Time) (applyMin, applyDay int) {
+	if reservedAt.Truncate(time.Minute).Equal(now.Truncate(time.Minute)) {
+		applyMin = 1
+	}
+	if reservedAt.Truncate(24 * time.Hour).Equal(now.Truncate(24 * time.Hour)) {
+		applyDay = 1
+	}
+	return applyMin, applyDay
+}
+
+func (r *redisLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, tokenDelta int, reservedAt, now time.Time) error {
 	_ = id
 	scopeKeys := r.scopeKeys(scope)
 	if len(scopeKeys) == 0 {
+		return nil
+	}
+	applyMin, applyDay := windowFlags(reservedAt, now)
+	if applyMin == 0 && applyDay == 0 {
 		return nil
 	}
 	keys := make([]string, 0, len(scopeKeys)*2)
@@ -417,15 +450,19 @@ func (r *redisLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, t
 		keys = append(keys, minuteKey(sk))
 		keys = append(keys, dayKey(sk))
 	}
-	argv := []interface{}{tokenDelta, secToMinuteEnd(now), secToDayEnd(now), len(scopeKeys)}
+	argv := []interface{}{tokenDelta, secToMinuteEnd(now), secToDayEnd(now), len(scopeKeys), applyMin, applyDay}
 	_, err := luaAdjust.Run(ctx, r.rdb, keys, argv...).Result()
 	return err
 }
 
-func (r *redisLimiter) Cancel(ctx context.Context, id string, scope ScopeKeys, estTokens int, now time.Time) error {
+func (r *redisLimiter) Cancel(ctx context.Context, id string, scope ScopeKeys, estTokens int, reservedAt, now time.Time) error {
 	_ = id
 	scopeKeys := r.scopeKeys(scope)
 	if len(scopeKeys) == 0 {
+		return nil
+	}
+	applyMin, applyDay := windowFlags(reservedAt, now)
+	if applyMin == 0 && applyDay == 0 {
 		return nil
 	}
 	keys := make([]string, 0, len(scopeKeys)*2)
@@ -433,7 +470,7 @@ func (r *redisLimiter) Cancel(ctx context.Context, id string, scope ScopeKeys, e
 		keys = append(keys, minuteKey(sk))
 		keys = append(keys, dayKey(sk))
 	}
-	argv := []interface{}{estTokens, secToMinuteEnd(now), secToDayEnd(now), len(scopeKeys)}
+	argv := []interface{}{estTokens, secToMinuteEnd(now), secToDayEnd(now), len(scopeKeys), applyMin, applyDay}
 	_, err := luaCancel.Run(ctx, r.rdb, keys, argv...).Result()
 	return err
 }

--- a/internal/ratelimit/redis_test.go
+++ b/internal/ratelimit/redis_test.go
@@ -57,6 +57,41 @@ func TestRedisLimiterTokensPerMinute(t *testing.T) {
 	}
 }
 
+// TestRedisLimiterCancelAfterMinuteRotationSkipsNewWindow guards the
+// window-attribution fix: request A reserves in minute window W1, the key
+// expires at the boundary, request B reserves in W2, and A's late 5xx cancel
+// must not drain B's counters. The day window is still current, so A's day
+// reservation is released.
+func TestRedisLimiterCancelAfterMinuteRotationSkipsNewWindow(t *testing.T) {
+	cfg := baseCfg()
+	lim, mr := newRedisLimiterForTest(t, cfg)
+
+	scope := ScopeKeys{UserID: "u-rotate"}
+	t0 := time.Date(2026, 7, 24, 12, 0, 50, 0, time.UTC)
+
+	resA, _ := lim.CheckAndReserve(context.Background(), "A", scope, 40, t0)
+	require.True(t, resA.Allowed)
+
+	// Cross the minute boundary: the W1 minute key (TTL 10s) expires.
+	mr.FastForward(15 * time.Second)
+	t1 := t0.Add(15 * time.Second)
+
+	resB, _ := lim.CheckAndReserve(context.Background(), "B", scope, 40, t1)
+	require.True(t, resB.Allowed)
+
+	require.NoError(t, lim.Cancel(context.Background(), "A", scope, 40, t0, t1))
+
+	// B's 40 minute tokens must still be counted: a further 70-token reserve
+	// exceeds TPM=100 only if B's reservation survived the cancel.
+	probe, _ := lim.CheckAndReserve(context.Background(), "probe", scope, 70, t1)
+	assert.False(t, probe.Allowed, "B's minute reservation must survive A's late cancel")
+
+	// The day window was still current, so A's day tokens were released:
+	// B's 40 remain (A's 40 + B's 40 - A's cancel).
+	dayTok := mr.HGet("rl:day:user:u-rotate", "tok")
+	assert.Equal(t, "40", dayTok, "day window should hold only B's tokens after A's cancel")
+}
+
 func TestRedisLimiterAdjust(t *testing.T) {
 	cfg := baseCfg()
 	lim, _ := newRedisLimiterForTest(t, cfg)
@@ -71,7 +106,7 @@ func TestRedisLimiterAdjust(t *testing.T) {
 	}
 
 	// Adjust to refund 30 tokens
-	err := lim.Adjust(context.Background(), "1", scope, -30, now)
+	err := lim.Adjust(context.Background(), "1", scope, -30, now, now)
 	if err != nil {
 		t.Fatalf("Adjust: %v", err)
 	}
@@ -101,7 +136,7 @@ func TestRedisLimiterCancel(t *testing.T) {
 	}
 
 	// Cancel one request
-	err := lim.Cancel(context.Background(), "1", scope, 10, now)
+	err := lim.Cancel(context.Background(), "1", scope, 10, now, now)
 	if err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}

--- a/internal/ratelimit/types.go
+++ b/internal/ratelimit/types.go
@@ -77,7 +77,15 @@ type RateLimiter interface {
 
 	// Adjust reconciles a prior reservation by applying the token delta
 	// (actual-estimated) across the same scope. Negative deltas credit back.
-	Adjust(ctx context.Context, id string, scope ScopeKeys, tokenDelta int, now time.Time) error
+	//
+	// reservedAt MUST be the time the reservation was made (the `now` passed
+	// to CheckAndReserve). LLM responses routinely take longer than a minute,
+	// so the reconcile often lands in a later window than the reservation;
+	// applying the delta to the current window would then debit/credit other
+	// requests' counters instead of this reservation's. Implementations skip
+	// any window (minute/day) that has rotated since reservedAt — the
+	// reservation expired with that window and there is nothing to reconcile.
+	Adjust(ctx context.Context, id string, scope ScopeKeys, tokenDelta int, reservedAt, now time.Time) error
 
 	// Cancel releases the effects of a prior reservation entirely (e.g., upstream
 	// error). estTokens MUST be the same value passed to CheckAndReserve for this
@@ -85,7 +93,11 @@ type RateLimiter interface {
 	// silently left the reserved tokens in place, causing under-credit when an
 	// upstream error happened after reservation. Callers that genuinely don't
 	// know the est tokens can pass 0; counters will only decrement the request.
-	Cancel(ctx context.Context, id string, scope ScopeKeys, estTokens int, now time.Time) error
+	//
+	// reservedAt has the same window-attribution semantics as in Adjust: a
+	// cancel that arrives after the reservation's window rotated is a no-op
+	// for that window rather than erasing other requests' reservations.
+	Cancel(ctx context.Context, id string, scope ScopeKeys, estTokens int, reservedAt, now time.Time) error
 }
 
 // PerKeyOverrideFunc resolves dynamic per-key rate-limit overrides at request


### PR DESCRIPTION
## Summary
- Neither limiter backend recorded which window a reservation was made in, so post-response reconciliation always hit the *current* minute window. With LLM latencies routinely crossing minute boundaries, a cancel after an upstream 5xx landed on the next window and erased **other** requests' reservations — worst during outages, exactly when the limiter matters most. `Adjust`/`Cancel` now take the reservation timestamp and skip any window (minute/day) that rotated since the reserve, in both the memory and Redis backends.
- The memory `Adjust` now clamps at zero like the Redis Lua script; a large refund used to drive counters negative and grant free capacity beyond the TPM limit.
- Reconciliation runs on a context detached from the request (with a 2s budget), so a client disconnect mid-response no longer strands the reserved tokens in the window.
- Denial `X-RateLimit-Limit`/`Remaining` headers are now derived from the metric that actually tripped (requests vs tokens could previously disagree), and the memory backend's `Retry-After` reports true seconds to the window boundary instead of a flat 60, matching Redis.

Regression tests cover cancel-after-rotation on both backends and the negative clamp.

## Test plan
- [x] `go test -race ./internal/ratelimit/... ./internal/middleware/...` passes on this branch in isolation
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit accounting for token/request reservations when adjustments or cancellations occur after minute/day window rotation.
  * Prevented late cancellations from impacting newer requests’ current-window limits.
  * Ensured rate-limit reconciliation reliably completes even if a client disconnects mid-request.
  * Updated retry timing to better match the actual rate-limit window boundary.
  * Clamped token counters to avoid negative remaining values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->