### PR TITLE
fix(providers): repair token parsing gaps across all four transports

### DIFF
--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -282,14 +282,16 @@ func parseAnthropicNonStreamingResponse(responseBody io.Reader) (*LLMResponseMet
 	}
 
 	metadata := &LLMResponseMetadata{
-		Model:        response.Model,
-		InputTokens:  response.Usage.InputTokens,
-		OutputTokens: response.Usage.OutputTokens,
-		TotalTokens:  response.Usage.InputTokens + response.Usage.OutputTokens,
-		Provider:     "anthropic",
-		RequestID:    response.ID,
-		IsStreaming:  false,
-		FinishReason: response.StopReason,
+		Model:                    response.Model,
+		InputTokens:              response.Usage.InputTokens,
+		OutputTokens:             response.Usage.OutputTokens,
+		TotalTokens:              response.Usage.InputTokens + response.Usage.OutputTokens,
+		CacheReadInputTokens:     response.Usage.CacheReadInputTokens,
+		CacheCreationInputTokens: response.Usage.CacheCreationInputTokens,
+		Provider:                 "anthropic",
+		RequestID:                response.ID,
+		IsStreaming:              false,
+		FinishReason:             response.StopReason,
 	}
 
 	return metadata, nil
@@ -397,8 +399,13 @@ func parseAnthropicStreamingResponse(responseBody io.Reader) (*LLMResponseMetada
 			if streamResponse.Delta != nil && streamResponse.Delta.StopReason != "" {
 				finishReason = streamResponse.Delta.StopReason
 			}
+			// Anthropic documents message_delta usage as CUMULATIVE ("the
+			// cumulative number of output tokens which were used"), so take
+			// the latest value. Adding it would double-count the
+			// message_start seed on every stream and double/triple-count
+			// output when multiple message_delta events arrive.
 			if streamResponse.Usage != nil && streamResponse.Usage.OutputTokens > 0 {
-				outputTokens += streamResponse.Usage.OutputTokens
+				outputTokens = streamResponse.Usage.OutputTokens
 			}
 
 		case "message_stop":
@@ -601,21 +608,21 @@ func (a *AnthropicProxy) ExtractRequestModelAndMessages(req *http.Request) (stri
 // ValidateAPIKey validates and potentially replaces the API key in the request
 func (a *AnthropicProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore) error {
 	// Get the API key from the x-api-key header (Anthropic uses this header).
-	apiKey := req.Header.Get("x-api-key")
-	if apiKey == "" {
+	presentedCredential := req.Header.Get("x-api-key")
+	if presentedCredential == "" {
 		// Some clients (e.g. OpenAI-compatible SDKs) send credentials as
 		// "Authorization: Bearer <key>" instead. Translate that onto
 		// x-api-key — the header Anthropic's API actually expects — so the
 		// rest of this function, and the upstream request, only ever deal
 		// with x-api-key.
 		const bearerPrefix = "Bearer "
-		if authHeader := req.Header.Get("Authorization"); strings.HasPrefix(authHeader, bearerPrefix) {
-			apiKey = strings.TrimPrefix(authHeader, bearerPrefix)
-			req.Header.Set("x-api-key", apiKey)
+		if bearerCredential, ok := strings.CutPrefix(req.Header.Get("Authorization"), bearerPrefix); ok {
+			presentedCredential = bearerCredential
+			req.Header.Set("x-api-key", presentedCredential)
 			req.Header.Del("Authorization")
 		}
 	}
-	if apiKey == "" {
+	if presentedCredential == "" {
 		// No API key provided, let the provider handle the error
 		return nil
 	}
@@ -623,7 +630,7 @@ func (a *AnthropicProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore)
 	// Validate and potentially replace the key. Use the request context so
 	// client cancellation / handler-level deadlines propagate into the
 	// DynamoDB validation lookup.
-	actualKey, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), apiKey)
+	providerCredential, provider, err := keyStore.ValidateAndGetActualKey(req.Context(), presentedCredential)
 	if err != nil {
 		return fmt.Errorf("API key validation failed: %w", err)
 	}
@@ -634,8 +641,8 @@ func (a *AnthropicProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore)
 	}
 
 	// Replace the key in the request header if it was translated
-	if actualKey != apiKey {
-		req.Header.Set("x-api-key", actualKey)
+	if providerCredential != presentedCredential {
+		req.Header.Set("x-api-key", providerCredential)
 		log.Printf("🔑 Anthropic: Translated API key from iw: format")
 	}
 

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -614,12 +614,14 @@ func (a *AnthropicProxy) ValidateAPIKey(req *http.Request, keyStore APIKeyStore)
 		// "Authorization: Bearer <key>" instead. Translate that onto
 		// x-api-key — the header Anthropic's API actually expects — so the
 		// rest of this function, and the upstream request, only ever deal
-		// with x-api-key.
-		const bearerPrefix = "Bearer "
-		if bearerCredential, ok := strings.CutPrefix(req.Header.Get("Authorization"), bearerPrefix); ok {
-			presentedCredential = bearerCredential
-			req.Header.Set("x-api-key", presentedCredential)
-			req.Header.Del("Authorization")
+		// with x-api-key. Scheme matching is case-insensitive per RFC 7235.
+		if authHeader := req.Header.Get("Authorization"); authHeader != "" {
+			scheme, credential, ok := strings.Cut(authHeader, " ")
+			if ok && strings.EqualFold(scheme, "Bearer") && credential != "" {
+				presentedCredential = credential
+				req.Header.Set("x-api-key", presentedCredential)
+				req.Header.Del("Authorization")
+			}
 		}
 	}
 	if presentedCredential == "" {

--- a/internal/providers/anthropic_test.go
+++ b/internal/providers/anthropic_test.go
@@ -123,17 +123,18 @@ data: {"type": "message_stop"}
 		t.Errorf("Expected request ID 'msg_01AVJ15FX8ZGY7sLCo4ajfPW', got %s", metadata.RequestID)
 	}
 
-	// Check token counts - should be 25 input + (1 + 15) output = 41 total
+	// Check token counts - message_delta usage is CUMULATIVE per Anthropic's
+	// docs, so the final value (15) already includes the message_start seed.
 	if metadata.InputTokens != 25 {
 		t.Errorf("Expected 25 input tokens, got %d", metadata.InputTokens)
 	}
 
-	if metadata.OutputTokens != 16 { // 1 from message_start + 15 from message_delta
-		t.Errorf("Expected 16 output tokens, got %d", metadata.OutputTokens)
+	if metadata.OutputTokens != 15 { // cumulative total from the last message_delta
+		t.Errorf("Expected 15 output tokens, got %d", metadata.OutputTokens)
 	}
 
-	if metadata.TotalTokens != 41 { // 25 + 16
-		t.Errorf("Expected 41 total tokens, got %d", metadata.TotalTokens)
+	if metadata.TotalTokens != 40 { // 25 + 15
+		t.Errorf("Expected 40 total tokens, got %d", metadata.TotalTokens)
 	}
 
 	if metadata.FinishReason != "end_turn" {
@@ -149,6 +150,37 @@ data: {"type": "message_stop"}
 }
 
 // TestAnthropicGzipDecompression tests the gzip decompression functionality
+// TestAnthropicNonStreamingCacheTokens guards the prompt-caching fields:
+// the non-streaming parser used to drop cache_read_input_tokens /
+// cache_creation_input_tokens, so cached prompt tokens (which Anthropic
+// excludes from input_tokens) vanished entirely from cost accounting while
+// the streaming path recorded them.
+func TestAnthropicNonStreamingCacheTokens(t *testing.T) {
+	response := `{
+		"id": "msg_cache",
+		"type": "message",
+		"role": "assistant",
+		"content": [{"type": "text", "text": "hi"}],
+		"model": "claude-3-5-sonnet-20241022",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 12, "output_tokens": 30, "cache_read_input_tokens": 2048, "cache_creation_input_tokens": 512}
+	}`
+
+	metadata, err := parseAnthropicNonStreamingResponse(strings.NewReader(response))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if metadata.CacheReadInputTokens != 2048 {
+		t.Errorf("Expected 2048 cache read tokens, got %d", metadata.CacheReadInputTokens)
+	}
+	if metadata.CacheCreationInputTokens != 512 {
+		t.Errorf("Expected 512 cache creation tokens, got %d", metadata.CacheCreationInputTokens)
+	}
+	if metadata.FinishReason != "end_turn" {
+		t.Errorf("Expected end_turn, got %s", metadata.FinishReason)
+	}
+}
+
 func TestAnthropicGzipDecompression(t *testing.T) {
 	// Create a sample JSON response
 	originalResponse := `{

--- a/internal/providers/api_key_validation_test.go
+++ b/internal/providers/api_key_validation_test.go
@@ -84,6 +84,17 @@ func TestAnthropic_ValidateAPIKey_TranslatesBearerAuthorizationHeader(t *testing
 	assert.Empty(t, req.Header.Get("Authorization"))
 	assert.Equal(t, "iw:fake", store.lastInput)
 
+	// Scheme matching is case-insensitive (RFC 7235).
+	for _, scheme := range []string{"bearer", "BEARER", "BeArEr"} {
+		req, _ = http.NewRequest("POST", "/anthropic/v1/messages", nil)
+		req.Header.Set("Authorization", scheme+" iw:mixed")
+		mixedStore := &stubKeyStore{actual: "real-anthropic", provider: "anthropic"}
+		require.NoError(t, ap.ValidateAPIKey(req, mixedStore), "scheme=%s", scheme)
+		assert.Equal(t, "iw:mixed", mixedStore.lastInput, "scheme=%s", scheme)
+		assert.Equal(t, "real-anthropic", req.Header.Get("x-api-key"), "scheme=%s", scheme)
+		assert.Empty(t, req.Header.Get("Authorization"), "scheme=%s", scheme)
+	}
+
 	// x-api-key takes precedence over Authorization when both are present.
 	req, _ = http.NewRequest("POST", "/anthropic/v1/messages", nil)
 	req.Header.Set("x-api-key", "iw:direct")

--- a/internal/providers/bedrock.go
+++ b/internal/providers/bedrock.go
@@ -106,10 +106,14 @@ func NewBedrockProxy(opts ...ProxyOptions) *BedrockProxy {
 		req.Host = targetURL.Host
 		// Optional: strip Accept-Encoding so upstream returns plain bytes —
 		// matches the debug-mode contract of CreateGenericDirector.
-		// IMPORTANT: this header is NOT part of the SigV4 canonical request
-		// by default (the AWS signer signs `host` only when no x-amz-* is
-		// set), so mutating it does not break the signature.
-		if opt.DisableGzip {
+		// boto3 adds Accept-Encoding after signing so deleting it is safe
+		// there, but some signers (AWS SDK for Java v2, aws-crt-based
+		// custom signers) include every present header in SignedHeaders;
+		// deleting a signed header changes the canonical request AWS
+		// reconstructs and every request fails with
+		// InvalidSignatureException. Only strip when the client did not
+		// sign it.
+		if opt.DisableGzip && !sigV4HeaderSigned(req.Header.Get("Authorization"), "accept-encoding") {
 			req.Header.Del("Accept-Encoding")
 		}
 		isStreaming := bedrockProxy.IsStreamingRequest(req)
@@ -246,6 +250,36 @@ func (b *BedrockProxy) parseNonStreamingResponse(responseBody io.Reader) (*LLMRe
 	if err := json.Unmarshal(body, &r); err != nil {
 		return nil, fmt.Errorf("failed to parse bedrock response: %w", err)
 	}
+	if r.Usage.InputTokens == 0 && r.Usage.OutputTokens == 0 {
+		// InvokeModel (`/model/{id}/invoke`) returns the model-NATIVE body,
+		// not the Converse shape. Anthropic models report snake_case usage
+		// (Go's JSON matching is case-insensitive but not
+		// underscore-insensitive, so input_tokens never matches inputTokens)
+		// — without this fallback the whole InvokeModel API family silently
+		// recorded zero tokens.
+		var native struct {
+			StopReason string `json:"stop_reason"`
+			Usage      struct {
+				InputTokens              int `json:"input_tokens"`
+				OutputTokens             int `json:"output_tokens"`
+				CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+				CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			} `json:"usage"`
+		}
+		if json.Unmarshal(body, &native) == nil &&
+			(native.Usage.InputTokens > 0 || native.Usage.OutputTokens > 0) {
+			return &LLMResponseMetadata{
+				InputTokens:              native.Usage.InputTokens,
+				OutputTokens:             native.Usage.OutputTokens,
+				TotalTokens:              native.Usage.InputTokens + native.Usage.OutputTokens,
+				CacheReadInputTokens:     native.Usage.CacheReadInputTokens,
+				CacheCreationInputTokens: native.Usage.CacheCreationInputTokens,
+				Provider:                 "bedrock",
+				IsStreaming:              false,
+				FinishReason:             native.StopReason,
+			}, nil
+		}
+	}
 	total := r.Usage.TotalTokens
 	if total == 0 {
 		total = r.Usage.InputTokens + r.Usage.OutputTokens
@@ -293,7 +327,12 @@ func (b *BedrockProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespo
 	for {
 		msg, decErr := decoder.Decode(decompressed, payloadBuf)
 		if decErr != nil {
-			if errors.Is(decErr, io.EOF) {
+			// ErrUnexpectedEOF is a stream cut MID-frame (the typical shape
+			// when a client disconnects during body copy). Treat it like a
+			// clean EOF so the partial-metadata fallback below still returns
+			// whatever was decoded (e.g. the finish reason) instead of
+			// discarding everything.
+			if errors.Is(decErr, io.EOF) || errors.Is(decErr, io.ErrUnexpectedEOF) {
 				break
 			}
 			return nil, fmt.Errorf("decode eventstream: %w", decErr)
@@ -344,7 +383,18 @@ func (b *BedrockProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespo
 				metadata.CacheCreationInputTokens = meta.Usage.CacheCreationInputTokens
 				sawUsage = true
 			}
+		case "chunk":
+			// InvokeModelWithResponseStream frames: the payload is
+			// {"bytes":"<base64 model-native JSON>"} (Converse streams never
+			// emit this event type). Without handling it, the InvokeModel
+			// streaming family silently recorded zero tokens.
+			if b.parseInvokeChunk(msg.Payload, metadata) {
+				sawUsage = true
+			}
 		}
+	}
+	if sawUsage && metadata.TotalTokens == 0 {
+		metadata.TotalTokens = metadata.InputTokens + metadata.OutputTokens
 	}
 
 	if !sawData {
@@ -358,6 +408,106 @@ func (b *BedrockProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespo
 		return metadata, nil
 	}
 	return metadata, nil
+}
+
+// parseInvokeChunk decodes one InvokeModelWithResponseStream `chunk` frame
+// and folds any usage/finish-reason information into metadata. It returns
+// true when it found authoritative token counts.
+//
+// Two sources of truth, in increasing authority:
+//   - Anthropic-native stream events (message_start seeds input/cache
+//     tokens; message_delta carries the CUMULATIVE output count and the
+//     stop reason);
+//   - the `amazon-bedrock-invocationMetrics` block Bedrock appends to the
+//     final chunk for EVERY model family, which we prefer since it is
+//     model-agnostic.
+func (b *BedrockProxy) parseInvokeChunk(payload []byte, metadata *LLMResponseMetadata) bool {
+	var wrapper struct {
+		Bytes []byte `json:"bytes"` // encoding/json base64-decodes into []byte
+	}
+	if json.Unmarshal(payload, &wrapper) != nil || len(wrapper.Bytes) == 0 {
+		return false
+	}
+
+	var inner struct {
+		Type    string `json:"type"`
+		Message *struct {
+			Usage struct {
+				InputTokens              int `json:"input_tokens"`
+				OutputTokens             int `json:"output_tokens"`
+				CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+				CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			} `json:"usage"`
+		} `json:"message"`
+		Delta *struct {
+			StopReason string `json:"stop_reason"`
+		} `json:"delta"`
+		Usage *struct {
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+		InvocationMetrics *struct {
+			InputTokenCount  int `json:"inputTokenCount"`
+			OutputTokenCount int `json:"outputTokenCount"`
+		} `json:"amazon-bedrock-invocationMetrics"`
+	}
+	if json.Unmarshal(wrapper.Bytes, &inner) != nil {
+		return false
+	}
+
+	sawUsage := false
+	switch inner.Type {
+	case "message_start":
+		if inner.Message != nil {
+			u := inner.Message.Usage
+			if u.InputTokens > 0 {
+				metadata.InputTokens = u.InputTokens
+			}
+			if u.OutputTokens > 0 {
+				metadata.OutputTokens = u.OutputTokens
+			}
+			metadata.CacheReadInputTokens = u.CacheReadInputTokens
+			metadata.CacheCreationInputTokens = u.CacheCreationInputTokens
+			sawUsage = u.InputTokens > 0 || u.OutputTokens > 0
+		}
+	case "message_delta":
+		if inner.Delta != nil && inner.Delta.StopReason != "" {
+			metadata.FinishReason = inner.Delta.StopReason
+		}
+		if inner.Usage != nil && inner.Usage.OutputTokens > 0 {
+			metadata.OutputTokens = inner.Usage.OutputTokens
+			sawUsage = true
+		}
+	}
+	if m := inner.InvocationMetrics; m != nil && (m.InputTokenCount > 0 || m.OutputTokenCount > 0) {
+		metadata.InputTokens = m.InputTokenCount
+		metadata.OutputTokens = m.OutputTokenCount
+		metadata.TotalTokens = m.InputTokenCount + m.OutputTokenCount
+		sawUsage = true
+	}
+	return sawUsage
+}
+
+// sigV4HeaderSigned reports whether name appears in the SignedHeaders list of
+// an AWS SigV4 Authorization header value ("AWS4-HMAC-SHA256
+// Credential=..., SignedHeaders=a;b;c, Signature=..."). SignedHeaders
+// entries are lowercase per the SigV4 spec, but compare case-insensitively
+// to be safe.
+func sigV4HeaderSigned(authorization, name string) bool {
+	const marker = "SignedHeaders="
+	idx := strings.Index(authorization, marker)
+	if idx < 0 {
+		return false
+	}
+	list := authorization[idx+len(marker):]
+	if end := strings.IndexAny(list, ", "); end >= 0 {
+		list = list[:end]
+	}
+	for _, h := range strings.Split(list, ";") {
+		if strings.EqualFold(h, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // eventstreamHeaderString returns the string value of a given header name,

--- a/internal/providers/bedrock.go
+++ b/internal/providers/bedrock.go
@@ -479,9 +479,16 @@ func (b *BedrockProxy) parseInvokeChunk(payload []byte, metadata *LLMResponseMet
 		}
 	}
 	if m := inner.InvocationMetrics; m != nil && (m.InputTokenCount > 0 || m.OutputTokenCount > 0) {
-		metadata.InputTokens = m.InputTokenCount
-		metadata.OutputTokens = m.OutputTokenCount
-		metadata.TotalTokens = m.InputTokenCount + m.OutputTokenCount
+		// Overwrite each field independently. Bedrock may emit a metrics
+		// block with only one side populated; blindly assigning both would
+		// zero out a previously-correct count from message_start/delta.
+		if m.InputTokenCount > 0 {
+			metadata.InputTokens = m.InputTokenCount
+		}
+		if m.OutputTokenCount > 0 {
+			metadata.OutputTokens = m.OutputTokenCount
+		}
+		metadata.TotalTokens = metadata.InputTokens + metadata.OutputTokens
 		sawUsage = true
 	}
 	return sawUsage

--- a/internal/providers/bedrock_mantle.go
+++ b/internal/providers/bedrock_mantle.go
@@ -159,9 +159,9 @@ func newBedrockMantleProxy(region string, credentials aws.CredentialsProvider, o
 		req.Header.Del("X-Amz-Date")
 		req.Header.Del("X-Amz-Content-Sha256")
 		req.Header.Del("X-Amz-Security-Token")
-		// Drop CDN/client hop headers before SigV4. Cloudflare (in front of
-		// llm.instawork.com) and OpenAI SDKs inject headers that must not be
-		// forwarded or signed — otherwise Mantle returns 401 InvalidSignature.
+		// Drop CDN/client hop headers before SigV4. Reverse proxies and OpenAI
+		// SDKs inject headers that must not be forwarded or signed — otherwise
+		// Mantle returns 401 InvalidSignature.
 		stripMantleClientHopHeaders(req)
 		if opt.DisableGzip {
 			req.Header.Del("Accept-Encoding")
@@ -721,12 +721,17 @@ func parseMantleOpenAIStream(responseBody io.Reader) (*LLMResponseMetadata, erro
 
 func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, error) {
 	var envelope struct {
-		Model    string       `json:"model"`
-		ID       string       `json:"id"`
-		Status   string       `json:"status"`
-		Type     string       `json:"type"`
-		Usage    *mantleUsage `json:"usage"`
-		Response *struct {
+		Model  string `json:"model"`
+		ID     string `json:"id"`
+		Status string `json:"status"`
+		// StopReason is the Anthropic-native finish field ("stop_reason");
+		// non-streaming /anthropic/v1/messages bodies land here (they have
+		// no "choices" so they take this generic path, not the Anthropic
+		// stream parser).
+		StopReason string       `json:"stop_reason"`
+		Type       string       `json:"type"`
+		Usage      *mantleUsage `json:"usage"`
+		Response   *struct {
 			Model  string       `json:"model"`
 			ID     string       `json:"id"`
 			Status string       `json:"status"`
@@ -762,22 +767,37 @@ func parseMantleMetadata(body []byte, streaming bool) (*LLMResponseMetadata, err
 	if total == 0 {
 		total = input + output
 	}
+	finish := envelope.Status
+	if finish == "" {
+		finish = envelope.StopReason
+	}
+	cacheRead := usage.InputTokensDetails.CachedTokens
+	if cacheRead == 0 {
+		cacheRead = usage.CacheReadInputTokens
+	}
 	return &LLMResponseMetadata{
 		Model: envelope.Model, RequestID: envelope.ID, Provider: bedrockMantleName,
 		InputTokens: input, OutputTokens: output, TotalTokens: total,
-		FinishReason: envelope.Status, IsStreaming: streaming,
-		CacheReadInputTokens: usage.InputTokensDetails.CachedTokens,
-		ThoughtTokens:        usage.OutputTokensDetails.ReasoningTokens,
+		FinishReason: finish, IsStreaming: streaming,
+		CacheReadInputTokens:     cacheRead,
+		CacheCreationInputTokens: usage.CacheCreationInputTokens,
+		ThoughtTokens:            usage.OutputTokensDetails.ReasoningTokens,
 	}, nil
 }
 
 type mantleUsage struct {
-	InputTokens        int `json:"input_tokens"`
-	OutputTokens       int `json:"output_tokens"`
-	TotalTokens        int `json:"total_tokens"`
-	PromptTokens       int `json:"prompt_tokens"`
-	CompletionTokens   int `json:"completion_tokens"`
-	InputTokensDetails struct {
+	InputTokens      int `json:"input_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	// Anthropic-native prompt-caching fields (non-streaming
+	// /anthropic/v1/messages responses take this parser, and Anthropic
+	// excludes cache reads from input_tokens — dropping these hid the
+	// cached prompt portion from cost accounting entirely).
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	InputTokensDetails       struct {
 		CachedTokens int `json:"cached_tokens"`
 	} `json:"input_tokens_details"`
 	OutputTokensDetails struct {

--- a/internal/providers/bedrock_mantle_test.go
+++ b/internal/providers/bedrock_mantle_test.go
@@ -411,7 +411,7 @@ func TestBedrockMantle_StripsCloudflareAndClientHopHeadersBeforeSigning(t *testi
 	req.Header.Set("Authorization", "Bearer sk-iw-mantle")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	// Headers Cloudflare / OpenAI SDKs inject in front of llm.instawork.com.
+	// Headers CDN proxies and OpenAI SDKs may inject before the request arrives.
 	req.Header.Set("CDN-Loop", "cloudflare; loops=1")
 	req.Header.Set("CF-Connecting-IP", "73.143.211.71")
 	req.Header.Set("CF-IPCountry", "US")
@@ -585,6 +585,29 @@ data: [DONE]
 	}
 }
 
+// TestBedrockMantle_ParseAnthropicNonStreamingUsage guards the non-streaming
+// Anthropic path through parseMantleMetadata: cache token fields and
+// stop_reason used to be dropped (the generic envelope only knew OpenAI
+// shapes), making the books inconsistent with the streaming path.
+func TestBedrockMantle_ParseAnthropicNonStreamingUsage(t *testing.T) {
+	body := `{"id":"msg_ns","type":"message","model":"anthropic.claude-haiku-4-5",` +
+		`"stop_reason":"end_turn","content":[{"type":"text","text":"hi"}],` +
+		`"usage":{"input_tokens":40,"output_tokens":9,"cache_read_input_tokens":1024,"cache_creation_input_tokens":256}}`
+	metadata, err := mustNewBedrockMantleProxy(t).ParseResponseMetadata(strings.NewReader(body), false)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata: %v", err)
+	}
+	if metadata.InputTokens != 40 || metadata.OutputTokens != 9 || metadata.TotalTokens != 49 {
+		t.Fatalf("unexpected usage: %+v", metadata)
+	}
+	if metadata.CacheReadInputTokens != 1024 || metadata.CacheCreationInputTokens != 256 {
+		t.Fatalf("cache tokens dropped: %+v", metadata)
+	}
+	if metadata.FinishReason != "end_turn" {
+		t.Fatalf("finish reason dropped: %+v", metadata)
+	}
+}
+
 func TestBedrockMantle_ParseAnthropicStreamingUsage(t *testing.T) {
 	stream := `event: message_start
 data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"anthropic.claude-haiku-4-5","stop_reason":null,"usage":{"input_tokens":25,"output_tokens":1,"cache_read_input_tokens":5,"cache_creation_input_tokens":2}}}
@@ -603,7 +626,9 @@ data: {"type":"message_stop"}
 	if metadata.Provider != bedrockMantleName || metadata.Model != "anthropic.claude-haiku-4-5" {
 		t.Fatalf("unexpected metadata: %+v", metadata)
 	}
-	if metadata.InputTokens != 25 || metadata.OutputTokens != 16 || metadata.TotalTokens != 41 {
+	// message_delta usage is cumulative per Anthropic's docs, so the final
+	// output count is the last delta's value (15), not message_start + delta.
+	if metadata.InputTokens != 25 || metadata.OutputTokens != 15 || metadata.TotalTokens != 40 {
 		t.Fatalf("unexpected token aggregation: %+v", metadata)
 	}
 	if metadata.CacheReadInputTokens != 5 || metadata.CacheCreationInputTokens != 2 {

--- a/internal/providers/bedrock_test.go
+++ b/internal/providers/bedrock_test.go
@@ -387,6 +387,99 @@ func TestBedrock_ParseStreamingResponse(t *testing.T) {
 	}
 }
 
+// TestBedrock_ParseNonStreaming_InvokeAnthropicNative guards the InvokeModel
+// fallback: /model/{id}/invoke returns the model-NATIVE body whose snake_case
+// usage never matched the camelCase Converse struct, so the whole InvokeModel
+// family silently recorded zero tokens.
+func TestBedrock_ParseNonStreaming_InvokeAnthropicNative(t *testing.T) {
+	b := NewBedrockProxy()
+	body := `{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5",` +
+		`"stop_reason":"end_turn","content":[{"type":"text","text":"hi"}],` +
+		`"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}`
+	md, err := b.ParseResponseMetadata(strings.NewReader(body), false)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata invoke: %v", err)
+	}
+	if md.InputTokens != 100 || md.OutputTokens != 50 || md.TotalTokens != 150 {
+		t.Errorf("invoke usage: in=%d out=%d total=%d", md.InputTokens, md.OutputTokens, md.TotalTokens)
+	}
+	if md.CacheReadInputTokens != 10 || md.CacheCreationInputTokens != 5 {
+		t.Errorf("invoke cache: read=%d write=%d", md.CacheReadInputTokens, md.CacheCreationInputTokens)
+	}
+	if md.FinishReason != "end_turn" {
+		t.Errorf("invoke finish: %q", md.FinishReason)
+	}
+}
+
+// encodeBedrockInvokeChunk wraps model-native JSON the way
+// InvokeModelWithResponseStream does: an eventstream frame with
+// :event-type "chunk" whose payload is {"bytes":"<base64 native JSON>"}.
+func encodeBedrockInvokeChunk(t *testing.T, w io.Writer, native any) {
+	t.Helper()
+	nativeJSON, err := json.Marshal(native)
+	if err != nil {
+		t.Fatalf("marshal native chunk: %v", err)
+	}
+	encodeBedrockEvent(t, w, "chunk", map[string]any{"bytes": nativeJSON})
+}
+
+// TestBedrock_ParseStreamingResponse_InvokeChunks guards streaming
+// InvokeModel parsing: `chunk` frames carry base64 model-native JSON that the
+// Converse-only switch used to drain without recording any tokens.
+func TestBedrock_ParseStreamingResponse_InvokeChunks(t *testing.T) {
+	b := NewBedrockProxy()
+	var buf bytes.Buffer
+	encodeBedrockInvokeChunk(t, &buf, map[string]any{
+		"type":    "message_start",
+		"message": map[string]any{"id": "msg_1", "usage": map[string]int{"input_tokens": 25, "output_tokens": 1, "cache_read_input_tokens": 8}},
+	})
+	encodeBedrockInvokeChunk(t, &buf, map[string]any{
+		"type":  "content_block_delta",
+		"delta": map[string]string{"type": "text_delta", "text": "hello"},
+	})
+	encodeBedrockInvokeChunk(t, &buf, map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]string{"stop_reason": "end_turn"},
+		"usage": map[string]int{"output_tokens": 17},
+		"amazon-bedrock-invocationMetrics": map[string]int{
+			"inputTokenCount": 25, "outputTokenCount": 17, "invocationLatency": 900, "firstByteLatency": 60,
+		},
+	})
+
+	md, err := b.ParseResponseMetadata(&buf, true)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata invoke stream: %v", err)
+	}
+	if md.InputTokens != 25 || md.OutputTokens != 17 || md.TotalTokens != 42 {
+		t.Errorf("invoke stream usage: in=%d out=%d total=%d", md.InputTokens, md.OutputTokens, md.TotalTokens)
+	}
+	if md.CacheReadInputTokens != 8 {
+		t.Errorf("invoke stream cache_read: %d", md.CacheReadInputTokens)
+	}
+	if md.FinishReason != "end_turn" {
+		t.Errorf("invoke stream finish: %q", md.FinishReason)
+	}
+}
+
+func TestSigV4HeaderSigned(t *testing.T) {
+	auth := "AWS4-HMAC-SHA256 Credential=AKIA/20260724/us-east-1/bedrock/aws4_request, " +
+		"SignedHeaders=accept-encoding;content-type;host;x-amz-date, Signature=abc123"
+	if !sigV4HeaderSigned(auth, "accept-encoding") {
+		t.Error("accept-encoding should be detected as signed")
+	}
+	if sigV4HeaderSigned(auth, "accept") {
+		t.Error("accept is not in SignedHeaders (must not prefix-match accept-encoding)")
+	}
+	botoAuth := "AWS4-HMAC-SHA256 Credential=AKIA/20260724/us-east-1/bedrock/aws4_request, " +
+		"SignedHeaders=content-type;host;x-amz-date, Signature=abc123"
+	if sigV4HeaderSigned(botoAuth, "accept-encoding") {
+		t.Error("accept-encoding not signed by boto3-style clients")
+	}
+	if sigV4HeaderSigned("", "accept-encoding") {
+		t.Error("empty Authorization must report unsigned")
+	}
+}
+
 func TestBedrock_ParseStreamingResponse_TruncatedBeforeMetadata(t *testing.T) {
 	b := NewBedrockProxy()
 	var buf bytes.Buffer

--- a/internal/providers/bedrock_test.go
+++ b/internal/providers/bedrock_test.go
@@ -461,6 +461,41 @@ func TestBedrock_ParseStreamingResponse_InvokeChunks(t *testing.T) {
 	}
 }
 
+// TestBedrock_ParseInvokeChunk_PartialInvocationMetricsPreservesPriorCounts
+// guards against zeroing a previously-correct token when Bedrock emits
+// amazon-bedrock-invocationMetrics with only one side populated.
+func TestBedrock_ParseInvokeChunk_PartialInvocationMetricsPreservesPriorCounts(t *testing.T) {
+	b := NewBedrockProxy()
+	var buf bytes.Buffer
+	encodeBedrockInvokeChunk(t, &buf, map[string]any{
+		"type":    "message_start",
+		"message": map[string]any{"id": "msg_1", "usage": map[string]int{"input_tokens": 40, "output_tokens": 1}},
+	})
+	encodeBedrockInvokeChunk(t, &buf, map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]string{"stop_reason": "end_turn"},
+		"usage": map[string]int{"output_tokens": 12},
+		// Only output side present — must not wipe the input count from message_start.
+		"amazon-bedrock-invocationMetrics": map[string]int{
+			"outputTokenCount": 12,
+		},
+	})
+
+	md, err := b.ParseResponseMetadata(&buf, true)
+	if err != nil {
+		t.Fatalf("ParseResponseMetadata: %v", err)
+	}
+	if md.InputTokens != 40 {
+		t.Errorf("input tokens wiped by partial InvocationMetrics: got %d want 40", md.InputTokens)
+	}
+	if md.OutputTokens != 12 {
+		t.Errorf("output tokens: got %d want 12", md.OutputTokens)
+	}
+	if md.TotalTokens != 52 {
+		t.Errorf("total tokens: got %d want 52", md.TotalTokens)
+	}
+}
+
 func TestSigV4HeaderSigned(t *testing.T) {
 	auth := "AWS4-HMAC-SHA256 Credential=AKIA/20260724/us-east-1/bedrock/aws4_request, " +
 		"SignedHeaders=accept-encoding;content-type;host;x-amz-date, Signature=abc123"

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -327,6 +327,18 @@ func (g *GeminiProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespon
 		return parseOpenAICompatMetadata(data, true, "gemini")
 	}
 
+	// :streamGenerateContent WITHOUT alt=sse returns a plain JSON array of
+	// GenerateContentResponse objects, not SSE "data:" lines. The line
+	// scanner below would find no data and report an error, silently losing
+	// the request's tokens, so detect the array shape and parse it directly.
+	if isJSONArrayHead(head) {
+		data, err := io.ReadAll(buffered)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read streaming response: %w", err)
+		}
+		return parseGeminiJSONArrayStream(data)
+	}
+
 	scanner := bufio.NewScanner(buffered)
 	// Allow lines up to 2 MB — large Gemini SSE JSON chunks (e.g. with grounded
 	// citations or long thinking traces) can exceed the default 64 KB.
@@ -419,6 +431,64 @@ func (g *GeminiProxy) parseStreamingResponse(responseBody io.Reader) (*LLMRespon
 	}
 
 	return nil, fmt.Errorf("no usage information found in streaming response")
+}
+
+// isJSONArrayHead reports whether the peeked stream head starts a JSON array
+// (ignoring leading whitespace).
+func isJSONArrayHead(head []byte) bool {
+	for _, b := range head {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// parseGeminiJSONArrayStream handles the :streamGenerateContent response
+// shape used when the client does not pass alt=sse: a JSON array of
+// GenerateContentResponse chunks, the last of which carries usageMetadata.
+func parseGeminiJSONArrayStream(data []byte) (*LLMResponseMetadata, error) {
+	var chunks []GeminiStreamResponse
+	if err := json.Unmarshal(data, &chunks); err != nil {
+		return nil, fmt.Errorf("failed to parse gemini JSON-array stream: %w", err)
+	}
+	if len(chunks) == 0 {
+		return nil, fmt.Errorf("no usage information found in streaming response")
+	}
+	var model, finishReason string
+	var metadata *LLMResponseMetadata
+	for _, chunk := range chunks {
+		if model == "" && chunk.ModelVersion != "" {
+			model = strings.TrimPrefix(chunk.ModelVersion, "models/")
+		}
+		if len(chunk.Candidates) > 0 && chunk.Candidates[0].FinishReason != "" {
+			finishReason = chunk.Candidates[0].FinishReason
+		}
+		if chunk.UsageMetadata != nil {
+			metadata = &LLMResponseMetadata{
+				InputTokens:   chunk.UsageMetadata.PromptTokenCount,
+				OutputTokens:  chunk.UsageMetadata.CandidatesTokenCount,
+				TotalTokens:   chunk.UsageMetadata.TotalTokenCount,
+				ThoughtTokens: chunk.UsageMetadata.ThoughtsTokenCount,
+				Provider:      "gemini",
+				IsStreaming:   true,
+			}
+		}
+	}
+	if model == "" {
+		model = "gemini"
+	}
+	if metadata == nil {
+		return &LLMResponseMetadata{Model: model, Provider: "gemini", IsStreaming: true, FinishReason: finishReason}, nil
+	}
+	metadata.Model = model
+	metadata.FinishReason = finishReason
+	return metadata, nil
 }
 
 // UserIDFromRequest extracts user ID from Gemini request body

--- a/internal/providers/gemini_test.go
+++ b/internal/providers/gemini_test.go
@@ -106,6 +106,30 @@ func TestGemini_ModelNameStripping(t *testing.T) {
 	}`
 
 	geminiProvider := NewGeminiProxy()
+
+	// :streamGenerateContent WITHOUT alt=sse: a plain JSON array of chunks
+	// (no "data:" lines). Regression: this shape used to yield "no usage
+	// information found" and record zero tokens.
+	t.Run("json array stream without alt=sse", func(t *testing.T) {
+		arrayStream := `[
+			{"candidates":[{"content":{"parts":[{"text":"Hel"}]},"index":0}],"modelVersion":"models/gemini-2.0-flash"},
+			{"candidates":[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":11,"totalTokenCount":18},"modelVersion":"models/gemini-2.0-flash"}
+		]`
+		md, err := geminiProvider.ParseResponseMetadata(strings.NewReader(arrayStream), true)
+		if err != nil {
+			t.Fatalf("parse JSON-array stream: %v", err)
+		}
+		if md.InputTokens != 7 || md.OutputTokens != 11 || md.TotalTokens != 18 {
+			t.Errorf("array stream usage: in=%d out=%d total=%d", md.InputTokens, md.OutputTokens, md.TotalTokens)
+		}
+		if md.Model != "gemini-2.0-flash" {
+			t.Errorf("array stream model: %q", md.Model)
+		}
+		if md.FinishReason != "STOP" {
+			t.Errorf("array stream finish: %q", md.FinishReason)
+		}
+	})
+
 	metadata, err := geminiProvider.ParseResponseMetadata(strings.NewReader(nonStreamingResponse), false)
 	if err != nil {
 		t.Fatalf("Failed to parse non-streaming response: %v", err)

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -296,8 +296,24 @@ func parseOpenAIFormatMetadata(responseBody io.Reader, isStreaming bool, provide
 		metadata, err = parseOpenAIUnifiedStreamingResponse(bytes.NewReader(bodyBytes))
 	} else {
 		// Responses API has "output"; Chat Completions has "choices".
+		// The shape check must run on DECOMPRESSED bytes: clients that send
+		// Accept-Encoding: gzip themselves (the stock OpenAI SDKs do) leave
+		// raw gzip in the capture buffer, and probing that with
+		// json.Unmarshal fails — which used to mis-route Responses API
+		// bodies to the Chat Completions parser and silently record zero
+		// tokens. The downstream parsers decompress independently, so we
+		// only use the decompressed copy for the probe.
+		checkBytes := bodyBytes
+		if dr, derr := DecompressResponseIfNeeded(bytes.NewReader(bodyBytes)); derr == nil {
+			if decompressed, rerr := io.ReadAll(dr); rerr == nil {
+				checkBytes = decompressed
+			}
+			if gz, ok := dr.(*gzip.Reader); ok {
+				_ = gz.Close()
+			}
+		}
 		var checkResponse map[string]interface{}
-		if json.Unmarshal(bodyBytes, &checkResponse) == nil {
+		if json.Unmarshal(checkBytes, &checkResponse) == nil {
 			if _, hasOutput := checkResponse["output"]; hasOutput {
 				metadata, err = parseOpenAIResponsesNonStreamingResponse(bytes.NewReader(bodyBytes))
 			} else {
@@ -488,8 +504,14 @@ func parseOpenAIResponsesStreamingChunk(jsonData string, model, requestID, finis
 	// Check the type field to understand what kind of chunk this is
 	typeField, hasType := chunkData["type"].(string)
 	if hasType {
-		// Handle different types of Responses API streaming chunks
-		if typeField == "response.created" || typeField == "response.done" {
+		// Handle different types of Responses API streaming chunks.
+		// Usage is carried ONLY by the terminal events — the real API emits
+		// "response.completed" (or "response.incomplete"/"response.failed");
+		// earlier echoes of the response object have usage: null.
+		// "response.done" does not exist in the API but is kept for
+		// compatibility with older fixtures.
+		switch typeField {
+		case "response.created", "response.completed", "response.incomplete", "response.failed", "response.done":
 			// These events may contain usage information
 			log.Printf("🔄 OpenAI Responses API: Found %s event", typeField)
 			// Routed through redact.LogPreview: the chunk carries model
@@ -585,10 +607,12 @@ func parseOpenAIResponsesStreamingChunk(jsonData string, model, requestID, finis
 					}
 				}
 			}
-		} else if strings.HasPrefix(typeField, "response.") {
-			// This is a delta chunk (e.g., "response.output_text.delta")
-			// Skip these for metadata extraction as they don't contain usage info
-			return nil, model, requestID, finishReason, thoughtTokens
+		default:
+			if strings.HasPrefix(typeField, "response.") {
+				// This is a delta chunk (e.g., "response.output_text.delta")
+				// Skip these for metadata extraction as they don't contain usage info
+				return nil, model, requestID, finishReason, thoughtTokens
+			}
 		}
 	}
 

--- a/internal/providers/openai_compat_test.go
+++ b/internal/providers/openai_compat_test.go
@@ -95,7 +95,8 @@ func TestOpenAICompatDetection_DoesNotMisfireOnNativeBodies(t *testing.T) {
 	metadata, err = NewAnthropicProxy().ParseResponseMetadata(strings.NewReader(anthropicNativeStream), true)
 	require.NoError(t, err)
 	assert.Equal(t, "anthropic", metadata.Provider)
-	assert.Equal(t, 16, metadata.TotalTokens)
+	// message_delta usage is cumulative: 10 input + 5 output.
+	assert.Equal(t, 15, metadata.TotalTokens)
 }
 
 // The OpenAI-compatibility endpoints signal streaming via "stream": true in

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -493,6 +493,54 @@ data: [DONE]`
 		assert.True(t, metadata.IsStreaming)
 	})
 
+	t.Run("Streaming Responses API real shape: usage only in response.completed", func(t *testing.T) {
+		// Mirrors the actual API event flow: response.created echoes the
+		// response object with usage null; usage arrives only on the
+		// terminal response.completed event. Regression: the parser used to
+		// look for a nonexistent "response.done" type, discarding
+		// response.completed and recording zero tokens for ALL streaming
+		// Responses API traffic.
+		streamData := `data: {"type":"response.created","response":{"id":"resp_real","model":"gpt-4o-2024-08-06","status":"in_progress","usage":null,"output":[]}}
+data: {"type":"response.output_text.delta","delta":"Hello"}
+data: {"type":"response.output_text.delta","delta":" world"}
+data: {"type":"response.completed","response":{"id":"resp_real","model":"gpt-4o-2024-08-06","status":"completed","usage":{"input_tokens":36,"output_tokens":87,"total_tokens":123,"output_tokens_details":{"reasoning_tokens":10}},"output":[{"id":"msg_real","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello world","annotations":[]}]}]}}
+`
+
+		reader := bytes.NewReader([]byte(streamData))
+		metadata, err := proxy.ParseResponseMetadata(reader, true)
+		require.NoError(t, err)
+		require.NotNil(t, metadata)
+		assert.Equal(t, "gpt-4o-2024-08-06", metadata.Model)
+		assert.Equal(t, 36, metadata.InputTokens)
+		assert.Equal(t, 87, metadata.OutputTokens)
+		assert.Equal(t, 123, metadata.TotalTokens)
+		assert.Equal(t, 10, metadata.ThoughtTokens)
+		assert.Equal(t, "resp_real", metadata.RequestID)
+		assert.True(t, metadata.IsStreaming)
+	})
+
+	t.Run("NonStreaming Responses API gzipped body routes to Responses parser", func(t *testing.T) {
+		// Clients sending their own Accept-Encoding: gzip (stock OpenAI
+		// SDKs) leave raw gzip in the capture buffer. Regression: the
+		// Responses-vs-Chat shape probe used to run on the compressed bytes,
+		// fail to unmarshal, and mis-route the body to the Chat Completions
+		// parser — yielding zero tokens with no error.
+		responseJSON := `{"id":"resp_gz","model":"gpt-4o-2024-08-06","object":"response","status":"completed","output":[{"id":"msg_gz","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hi","annotations":[]}]}],"usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18,"output_tokens_details":{"reasoning_tokens":0}}}`
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, err := gz.Write([]byte(responseJSON))
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+
+		metadata, err := proxy.ParseResponseMetadata(bytes.NewReader(buf.Bytes()), false)
+		require.NoError(t, err)
+		require.NotNil(t, metadata)
+		assert.Equal(t, 11, metadata.InputTokens)
+		assert.Equal(t, 7, metadata.OutputTokens)
+		assert.Equal(t, 18, metadata.TotalTokens)
+		assert.Equal(t, "resp_gz", metadata.RequestID)
+	})
+
 	t.Run("Responses API with Reasoning Tokens", func(t *testing.T) {
 		responseJSON := `{
 			"id": "resp_123",


### PR DESCRIPTION
## Summary
Several response shapes were silently recording zero (or wrong) token counts, which flows straight into cost tracking and rate-limit reconciliation:

- **OpenAI Responses API streams** emit usage on `response.completed` / `incomplete` / `failed`; the parser only matched the non-existent `response.done`, so every Responses stream recorded zero tokens.
- **OpenAI shape detection ran before gzip decompression**, misrouting compressed Responses bodies to the Chat Completions parser (zero tokens again).
- **Anthropic `message_delta` usage is cumulative** per the docs; summing it double-counted output tokens on every stream. All Anthropic-format paths were affected, including Bedrock Mantle.
- **Anthropic non-streaming responses dropped cache read/creation tokens**; Mantle additionally dropped `stop_reason`.
- **Bedrock InvokeModel** (native, non-Converse) bodies use snake_case usage that never matched the Converse parser — both streaming chunk frames and non-streaming bodies now fall back to the native shape, preferring `amazon-bedrock-invocationMetrics` when present.
- Bedrock mid-frame stream truncation now yields partial metadata instead of an error, and debug gzip mode no longer strips a header the client signed into SigV4 (which invalidated the AWS signature).
- **Gemini `streamGenerateContent` without `alt=sse`** returns a JSON array, not SSE; it now parses instead of recording zero tokens.

Each fix has a regression test against a realistic response fixture.

## Test plan
- [x] `go test ./internal/providers/...` passes on this branch in isolation
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed cumulative token accounting for Anthropic streaming usage to avoid double-counting and align totals with cumulative semantics.
  - Improved parsing of token usage and finish reasons across Bedrock and Bedrock Mantle, including cache token metrics.
  - Enhanced handling of additional Gemini streaming payload shapes (non-SSE JSON arrays) to extract model, tokens, and finish reason.
  - Improved OpenAI/Responses metadata extraction for gzipped bodies and terminal events; added resilience to incomplete stream endings.
  - Preserved SigV4-signed headers during Bedrock proxying to avoid signature/encoding issues.
- **Tests**
  - Expanded regression coverage for the above scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->