### PR TITLE
fix(redact): close PII scrub bypasses and stream restore gaps

### DIFF
--- a/internal/history/sink.go
+++ b/internal/history/sink.go
@@ -80,7 +80,12 @@ func (s *Sink) Emit(stream string, event any) {
 	s.mu.Unlock()
 
 	if batch != nil {
-		_ = s.upload(context.Background(), stream, batch)
+		// Bound the inline upload the same way FlushAll does: Emit runs on
+		// caller goroutines (often request paths), and an S3 endpoint that
+		// stops responding must not pin them indefinitely.
+		ctx, cancel := context.WithTimeout(context.Background(), uploadTimeout)
+		defer cancel()
+		_ = s.upload(ctx, stream, batch)
 	}
 }
 

--- a/internal/pii/stats.go
+++ b/internal/pii/stats.go
@@ -218,13 +218,17 @@ func (r *Recorder) RecordRedaction(
 	if len(r.recent) > MaxRecentEvents {
 		r.recent = r.recent[len(r.recent)-MaxRecentEvents:]
 	}
-	r.EmitHistory(entry)
 
 	dayKey := r.dayKey
 	delta := r.piiDeltaLocked()
 	r.advancePIIFlushedLocked()
 	r.mu.Unlock()
 
+	// Emit outside the lock: when the history buffer trips its size
+	// threshold, Emit uploads inline (S3 PUT); doing that under r.mu would
+	// block every concurrent request's PII recording for the upload's
+	// duration.
+	r.EmitHistory(entry)
 	r.QueueDelta(dayKey, delta)
 	if r.RollupBound() {
 		r.AppendRecentEvent(adminrollup.MetricPII, entry, MaxRecentEvents)

--- a/internal/redact/content_adapter_gemini.go
+++ b/internal/redact/content_adapter_gemini.go
@@ -20,5 +20,17 @@ func (geminiContentAdapter) ScrubArrayElement(path []string) bool {
 }
 
 func (geminiContentAdapter) ScrubJSONValue(path []string, key string) bool {
-	return false
+	// Tool traffic lives in contents[].parts[].functionCall.args and
+	// contents[].parts[].functionResponse.response — objects whose leaf keys
+	// are arbitrary (email, query, ...), never "text", so ScrubString cannot
+	// catch them. Gemini's protobuf-JSON accepts both camelCase and
+	// snake_case field names, so match both spellings.
+	switch key {
+	case "args":
+		return hasPathAncestor(path, "functionCall") || hasPathAncestor(path, "function_call")
+	case "response":
+		return hasPathAncestor(path, "functionResponse") || hasPathAncestor(path, "function_response")
+	default:
+		return false
+	}
 }

--- a/internal/redact/content_adapter_openai.go
+++ b/internal/redact/content_adapter_openai.go
@@ -13,7 +13,13 @@ func (openAIContentAdapter) ScrubString(path []string, key string) bool {
 	case "input", "prompt":
 		return len(path) == 0
 	case "arguments", "output":
-		return hasPathAncestor(path, "tool_calls") || hasPathAncestor(path, "function")
+		// tool_calls/function covers Chat Completions; "input" covers the
+		// Responses API, where multi-turn tool use resends function_call /
+		// function_call_output items directly in the input array (array
+		// traversal does not append path segments, so those items are seen
+		// with path=["input"]).
+		return hasPathAncestor(path, "tool_calls") || hasPathAncestor(path, "function") ||
+			hasPathAncestor(path, "input")
 	default:
 		return false
 	}

--- a/internal/redact/content_adapter_test.go
+++ b/internal/redact/content_adapter_test.go
@@ -41,6 +41,53 @@ func TestContentAdapter_OpenAI_ResponsesInputArray(t *testing.T) {
 	}
 }
 
+// TestContentAdapter_OpenAI_ResponsesToolItems guards the Responses API
+// multi-turn tool shape: function_call arguments and function_call_output
+// output resent directly in the input array must be scrubbed, not skipped.
+func TestContentAdapter_OpenAI_ResponsesToolItems(t *testing.T) {
+	body := `{"input":[
+		{"type":"function_call","call_id":"c1","name":"save_user","arguments":"{\"ssn\":\"222-33-4444\"}"},
+		{"type":"function_call_output","call_id":"c1","output":"{\"email\":\"alice.real@gmail.com\"}"}
+	]}`
+	var tasks []jsonScrubTask
+	var root any
+	_ = json.Unmarshal([]byte(body), &root)
+	collectJSONScrubTasks(root, nil, &tasks, openAIContentAdapter{})
+	texts := taskTexts(tasks)
+	if !containsAll(texts, "222-33-4444", "alice.real@gmail.com") {
+		t.Fatalf("Responses tool arguments/output must be scrubbed, tasks = %v", texts)
+	}
+}
+
+// TestContentAdapter_Gemini_ToolCallAndResponse guards Gemini tool traffic:
+// functionCall.args and functionResponse.response hold arbitrary leaf keys
+// (never "text"), so they must be selected as JSON scrub values or the raw
+// PII goes to Google verbatim.
+func TestContentAdapter_Gemini_ToolCallAndResponse(t *testing.T) {
+	body := `{"contents":[{"role":"user","parts":[
+		{"functionCall":{"name":"save_user","args":{"ssn":"222-33-4444"}}},
+		{"functionResponse":{"name":"lookup_user","response":{"email":"alice.real@gmail.com"}}}
+	]}]}`
+	var tasks []jsonScrubTask
+	var root any
+	_ = json.Unmarshal([]byte(body), &root)
+	collectJSONScrubTasks(root, nil, &tasks, geminiContentAdapter{})
+	texts := taskTexts(tasks)
+	if !containsAll(texts, "222-33-4444", "alice.real@gmail.com") {
+		t.Fatalf("gemini tool payloads must be scrubbed, tasks = %v", texts)
+	}
+
+	// snake_case spellings (protobuf-JSON accepts both) are covered too.
+	body = `{"contents":[{"parts":[{"function_response":{"name":"f","response":{"phone":"555-867-5309"}}}]}]}`
+	tasks = nil
+	root = nil
+	_ = json.Unmarshal([]byte(body), &root)
+	collectJSONScrubTasks(root, nil, &tasks, geminiContentAdapter{})
+	if !containsAll(taskTexts(tasks), "555-867-5309") {
+		t.Fatalf("snake_case gemini tool payloads must be scrubbed, tasks = %v", tasks)
+	}
+}
+
 func TestContentAdapter_Anthropic_SystemBlockText(t *testing.T) {
 	body := `{"system":[{"type":"text","text":"You are helpful"}],"messages":[{"role":"user","content":"hi"}]}`
 	var tasks []jsonScrubTask
@@ -66,13 +113,13 @@ func TestContentAdapter_BedrockMantle_UsesUnionForAnthropicShape(t *testing.T) {
 }
 
 func TestContentAdapter_Bedrock_ConverseAndToolResult(t *testing.T) {
-	body := `{"messages":[{"role":"user","content":[{"text":"book shift"}]}],"system":[{"text":"sys prompt"}]}`
+	body := `{"messages":[{"role":"user","content":[{"text":"book appointment"}]}],"system":[{"text":"sys prompt"}]}`
 	var tasks []jsonScrubTask
 	var root any
 	_ = json.Unmarshal([]byte(body), &root)
 	collectJSONScrubTasks(root, nil, &tasks, bedrockContentAdapter{})
 	texts := taskTexts(tasks)
-	if !containsAll(texts, "book shift", "sys prompt") {
+	if !containsAll(texts, "book appointment", "sys prompt") {
 		t.Fatalf("tasks = %v", texts)
 	}
 

--- a/internal/redact/json_analysis_mask_test.go
+++ b/internal/redact/json_analysis_mask_test.go
@@ -86,6 +86,18 @@ func TestIsPrivateOrLoopbackIP(t *testing.T) {
 		{"localhost", true},
 		{"8.8.8.8", false},
 		{"1.1.1.1", false},
+		// host:port forms
+		{net.JoinHostPort(classA, "443"), true},
+		{"8.8.8.8:53", false},
+		{"localhost:8080", true},
+		// IPv6: the old first-colon Cut truncated these to garbage and
+		// misclassified private/loopback addresses as public.
+		{"::1", true},
+		{"fd12:3456::1", true}, // ULA, IsPrivate
+		{"[::1]", true},
+		{"[::1]:8080", true},
+		{"[fd12:3456::1]:443", true},
+		{"2607:f8b0:4004:800::200e", false}, // public (Google)
 	}
 	for _, tc := range cases {
 		if got := isPrivateOrLoopbackIP(tc.value); got != tc.want {

--- a/internal/redact/json_scrub.go
+++ b/internal/redact/json_scrub.go
@@ -21,6 +21,15 @@ func (r *Redactor) scrubJSON(ctx context.Context, text string, reg *Registry, fo
 		return r.scrub(ctx, text, reg, forceRedactMarkers)
 	}
 
+	// Bare JSON scalars (a quoted string, number, bool, null) are valid JSON
+	// but the container walk below produces zero tasks for them, which would
+	// return the text without ever analyzing it. Treat them as plain text.
+	switch root.(type) {
+	case map[string]any, []any:
+	default:
+		return r.scrub(ctx, text, reg, forceRedactMarkers)
+	}
+
 	adapter := AdapterForContext(ctx)
 	var tasks []jsonScrubTask
 	collectJSONScrubTasks(root, nil, &tasks, adapter)
@@ -165,9 +174,11 @@ func (r *Redactor) runJSONScrubTasks(
 				return
 			}
 
-			tasks[i].setText(sub.Text)
-
 			mu.Lock()
+			// setText writes into a shared parent container; sibling string
+			// values in the same map would otherwise race (concurrent map
+			// writes panic the process, unrecoverably).
+			tasks[i].setText(sub.Text)
 			mergeScrubResult(acc, sub)
 			mu.Unlock()
 		}(i)

--- a/internal/redact/json_scrub_parallel_test.go
+++ b/internal/redact/json_scrub_parallel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -60,6 +61,34 @@ func TestScrubJSON_ParallelizesMultipleContentBlocks(t *testing.T) {
 	}
 	if elapsed >= 3*delay {
 		t.Fatalf("parallel scrub took %v, expected well under sequential %v", elapsed, 3*delay)
+	}
+}
+
+// TestScrubJSON_ParallelSiblingStringsInSameMap covers two scrub-eligible
+// strings under the SAME parent map ("system" via the Anthropic adapter and
+// root-level "prompt" via the OpenAI adapter). Their setText callbacks write
+// into one shared map; regression: the parallel path used to apply them
+// outside the mutex, racing on the map (caught by -race; panics with
+// "concurrent map writes" in production).
+func TestScrubJSON_ParallelSiblingStringsInSameMap(t *testing.T) {
+	srv := fakeAnalyzer(t, func(w http.ResponseWriter, req *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode([]Span{})
+	})
+	r, err := New(Config{AnalyzerURL: srv.URL, AnalyzeConcurrency: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	body := `{"system":"block one","prompt":"block two"}`
+	res, err := r.Scrub(context.Background(), body, NewRegistry())
+	if err != nil {
+		t.Fatalf("Scrub: %v", err)
+	}
+	for _, want := range []string{"block one", "block two"} {
+		if !strings.Contains(res.Text, want) {
+			t.Errorf("scrubbed output lost %q: %s", want, res.Text)
+		}
 	}
 }
 

--- a/internal/redact/log_helper.go
+++ b/internal/redact/log_helper.go
@@ -47,9 +47,15 @@ func LogPreview(ctx context.Context, text string, maxLen int) string {
 	if r == nil {
 		return fmt.Sprintf("[len=%d bytes; pii_redact disabled]", len(text))
 	}
+	// Redact a slightly longer excerpt and truncate the REDACTED output:
+	// cutting the raw text at maxLen first can slice an entity in half
+	// (e.g. "222-33-4" from an SSN), and the fragment no longer matches any
+	// recognizer, so it would land in the log verbatim — exactly what this
+	// helper exists to prevent.
+	const entitySlack = 64
 	excerpt := text
-	if len(excerpt) > maxLen {
-		excerpt = excerpt[:maxLen]
+	if len(excerpt) > maxLen+entitySlack {
+		excerpt = excerpt[:maxLen+entitySlack]
 	}
 	// Bound to a tight slice of the redactor timeout so a slow sidecar
 	// can never drag down the calling request — debug previews are
@@ -60,5 +66,9 @@ func LogPreview(ctx context.Context, text string, maxLen int) string {
 	if err != nil {
 		return fmt.Sprintf("[len=%d bytes; pii_redact unavailable: %v]", len(text), err)
 	}
-	return res.Text
+	out := res.Text
+	if len(out) > maxLen {
+		out = out[:maxLen]
+	}
+	return out
 }

--- a/internal/redact/log_helper_test.go
+++ b/internal/redact/log_helper_test.go
@@ -46,8 +46,10 @@ func TestLogPreview_RedactsThroughGlobalRedactor(t *testing.T) {
 }
 
 func TestLogPreview_TruncatesBeforeRedaction(t *testing.T) {
-	// Long input should be capped to maxLen bytes BEFORE being sent to
-	// the analyzer. We assert this by capturing the request payload.
+	// Long input must be capped BEFORE being sent to the analyzer so a
+	// multi-megabyte body can't blow up analyzer cost. The cap includes a
+	// small slack beyond maxLen so an entity straddling the maxLen boundary
+	// is still analyzed whole (the final output is re-truncated to maxLen).
 	var bodySent string
 	srv := fakeAnalyzer(t, func(w http.ResponseWriter, req *http.Request) {
 		var p map[string]any
@@ -60,8 +62,39 @@ func TestLogPreview_TruncatesBeforeRedaction(t *testing.T) {
 	t.Cleanup(func() { SetGlobal(nil) })
 
 	full := strings.Repeat("a", 5000)
-	_ = LogPreview(context.Background(), full, 100)
-	if len(bodySent) != 100 {
-		t.Errorf("LogPreview should send %d bytes to analyzer, sent %d", 100, len(bodySent))
+	out := LogPreview(context.Background(), full, 100)
+	if len(bodySent) != 100+64 {
+		t.Errorf("LogPreview should send maxLen+slack (%d) bytes to analyzer, sent %d", 100+64, len(bodySent))
+	}
+	if len(out) != 100 {
+		t.Errorf("LogPreview output should be capped to maxLen (100), got %d", len(out))
+	}
+}
+
+// TestLogPreview_EntityAtTruncationBoundary guards the truncate-then-redact
+// leak: an SSN straddling the maxLen cut used to be sliced into a fragment
+// that no recognizer matched, so the partial PII landed in the log verbatim.
+func TestLogPreview_EntityAtTruncationBoundary(t *testing.T) {
+	srv := fakeAnalyzer(t, func(w http.ResponseWriter, req *http.Request) {
+		var p map[string]any
+		_ = json.NewDecoder(req.Body).Decode(&p)
+		text, _ := p["text"].(string)
+		if idx := strings.Index(text, "222-33-4444"); idx >= 0 {
+			_ = json.NewEncoder(w).Encode([]Span{
+				{Start: idx, End: idx + 11, EntityType: "US_SSN", Score: 0.95},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]Span{})
+	})
+	r, _ := New(Config{AnalyzerURL: srv.URL})
+	SetGlobal(r)
+	t.Cleanup(func() { SetGlobal(nil) })
+
+	// Place the SSN so a hard cut at maxLen=100 would slice it mid-number.
+	text := strings.Repeat("x", 95) + "222-33-4444 trailing"
+	out := LogPreview(context.Background(), text, 100)
+	if strings.Contains(out, "222-33") {
+		t.Errorf("partial SSN leaked into log preview: %q", out)
 	}
 }

--- a/internal/redact/middleground_helpers.go
+++ b/internal/redact/middleground_helpers.go
@@ -10,10 +10,23 @@ func isPrivateOrLoopbackIP(value string) bool {
 	if trimmed == "localhost" {
 		return true
 	}
-	if host, _, ok := strings.Cut(trimmed, ":"); ok && host != "" {
-		trimmed = host
-	}
 	ip := net.ParseIP(trimmed)
+	if ip == nil && strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		// Bracketed IPv6 without a port, e.g. "[::1]".
+		ip = net.ParseIP(trimmed[1 : len(trimmed)-1])
+	}
+	if ip == nil {
+		// host:port — SplitHostPort handles IPv4, [IPv6]:port, and
+		// hostname:port. Cutting at the first ':' (the old behavior)
+		// truncated bare IPv6 addresses ("fd12:3456::1" became "fd12"),
+		// so private IPv6 was never recognized and got over-masked.
+		if host, _, err := net.SplitHostPort(trimmed); err == nil {
+			if host == "localhost" {
+				return true
+			}
+			ip = net.ParseIP(host)
+		}
+	}
 	if ip == nil {
 		return false
 	}

--- a/internal/redact/redactor_test.go
+++ b/internal/redact/redactor_test.go
@@ -104,6 +104,43 @@ func TestRedact_SingleSpanReplaced(t *testing.T) {
 	}
 }
 
+// TestRedact_BareJSONStringScalarStillAnalyzed covers text that is a valid
+// JSON scalar (here a quoted string). Regression: the JSON scrub path used
+// to collect zero tasks for a scalar root and return the text without ever
+// calling the analyzer — a redaction bypass reachable from POST /redact.
+func TestRedact_BareJSONStringScalarStillAnalyzed(t *testing.T) {
+	text := `"ssn 222-33-4444"`
+	called := false
+	srv := fakeAnalyzer(t, func(w http.ResponseWriter, req *http.Request) {
+		called = true
+		var payload struct {
+			Text string `json:"text"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode analyzer payload: %v", err)
+		}
+		if payload.Text != text {
+			t.Errorf("analyzer received %q, want raw text %q", payload.Text, text)
+		}
+		_ = json.NewEncoder(w).Encode([]Span{
+			{Start: 5, End: 16, EntityType: "US_SSN", Score: 0.95},
+		})
+	})
+	r, _ := New(Config{AnalyzerURL: srv.URL})
+
+	res, err := r.Redact(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("bare JSON scalar text must still be sent to the analyzer")
+	}
+	want := `"ssn [REDACTED:US_SSN]"`
+	if res.Text != want {
+		t.Errorf("got %q, want %q", res.Text, want)
+	}
+}
+
 func TestRedact_MultipleSpansSpliceInReverse(t *testing.T) {
 	// "Bob lives in 222-33-4444 area and email me bob@x.com"
 	//    0   4     12 13         24             45 48

--- a/internal/redact/registry.go
+++ b/internal/redact/registry.go
@@ -28,7 +28,11 @@ var placeholderDelimiterPairs = []struct{ open, close byte }{
 
 // piiPlaceholderTailRE matches a complete PII token at the start of a stream
 // carry suffix, optionally followed by whitespace or a closing delimiter.
-var piiPlaceholderTailRE = regexp.MustCompile(`^PII_[A-Z][A-Z0-9_]*_\d+([\s\]\}>)]|$)`)
+// `\` and `&` count as terminators because the escaped closing delimiters
+// (\u003e, &gt;, &#93;) start with them — without that, a complete escaped
+// token like PII_PERSON_1\u003e was treated as incomplete and split across
+// the emit/carry boundary, so it could never match a wire form on restore.
+var piiPlaceholderTailRE = regexp.MustCompile(`^PII_[A-Z][A-Z0-9_]*_\d+([\s\]\}>)\\&]|$)`)
 
 type registryEntry struct {
 	placeholder string
@@ -296,13 +300,50 @@ func looksLikePIIPlaceholderStart(b []byte) bool {
 		i++
 	}
 	if i >= len(b) {
-		return false
+		// An empty (or all-spaces) suffix after an unclosed open delimiter is
+		// the maximally ambiguous case — the token may start on the very next
+		// chunk — so it must be held, not flushed.
+		return true
 	}
 	prefix := []byte(placeholderTokenPrefix)
 	if len(b[i:]) < len(prefix) {
 		return bytes.HasPrefix(prefix, b[i:])
 	}
 	return bytes.HasPrefix(b[i:], prefix)
+}
+
+// placeholderTextDelimiterPairs are the escaped delimiter spellings that
+// buildPlaceholderWireForms emits (and RestoreUserFacing therefore matches):
+// JSON \u-escapes for every delimiter pair plus the HTML-entity forms.
+// Gemini's JSON encoder escapes angle brackets as \u003c/\u003e in REST/SSE
+// responses, so on those streams the escaped form is the NORMAL case, not an
+// edge case.
+var placeholderTextDelimiterPairs = []struct{ open, close string }{
+	{`\u003c`, `\u003e`},
+	{"&lt;", "&gt;"},
+	{"&#91;", "&#93;"},
+	{`\u005b`, `\u005d`},
+	{`\u007b`, `\u007d`},
+	{`\u0028`, `\u0029`},
+}
+
+// trailingTextDelimPrefixLen reports the length of the longest suffix of b
+// that is a proper prefix of an escaped open-delimiter spelling (e.g. the
+// chunk ends "...\u00" mid-escape). Such a suffix must be held back.
+func trailingTextDelimPrefixLen(b []byte) int {
+	maxLen := 0
+	for _, pair := range placeholderTextDelimiterPairs {
+		open := []byte(pair.open)
+		for l := len(open) - 1; l >= 1; l-- {
+			if l > len(b) || l <= maxLen {
+				continue
+			}
+			if bytes.Equal(b[len(b)-l:], open[:l]) {
+				maxLen = l
+			}
+		}
+	}
+	return maxLen
 }
 
 func streamSafePrefixLen(combined []byte) int {
@@ -324,6 +365,27 @@ func streamSafePrefixLen(combined []byte) int {
 		if looksLikePIIPlaceholderStart(combined[idx+1:]) && idx < safeLen {
 			safeLen = idx
 		}
+	}
+	// Same scan for the escaped delimiter spellings: an unclosed escaped open
+	// followed by a possible token start (or nothing yet) must be held so the
+	// reassembled carry can match a full wire form.
+	for _, pair := range placeholderTextDelimiterPairs {
+		idx := bytes.LastIndex(combined, []byte(pair.open))
+		if idx < 0 {
+			continue
+		}
+		rest := combined[idx+len(pair.open):]
+		if bytes.Contains(rest, []byte(pair.close)) {
+			continue
+		}
+		if looksLikePIIPlaceholderStart(rest) && idx < safeLen {
+			safeLen = idx
+		}
+	}
+	// A chunk can also end mid-escape (e.g. "...\u00"); hold the partial
+	// escape so it can complete on the next chunk.
+	if tail := trailingTextDelimPrefixLen(combined[:safeLen]); tail > 0 && safeLen-tail >= 0 {
+		safeLen -= tail
 	}
 	return safeLen
 }

--- a/internal/redact/registry_test.go
+++ b/internal/redact/registry_test.go
@@ -159,6 +159,62 @@ func TestRegistry_RestoreStreamChunk_SplitPlaceholder(t *testing.T) {
 	}
 }
 
+// streamRestore pushes parts through RestoreStreamChunk + FlushCarry and
+// returns the concatenated client-visible output.
+func streamRestore(reg *Registry, parts []string) string {
+	var carry []byte
+	var got strings.Builder
+	for _, part := range parts {
+		emit, newCarry := reg.RestoreStreamChunk([]byte(part), carry)
+		carry = newCarry
+		got.Write(emit)
+	}
+	if tail := reg.FlushCarry(carry); len(tail) > 0 {
+		got.Write(tail)
+	}
+	return got.String()
+}
+
+// TestRegistry_RestoreStreamChunk_SplitAtDelimiter guards the empty-suffix
+// hold-back: a chunk ending exactly at the opening "<" used to be flushed,
+// after which the reassembled token could never match a wire form and the
+// client saw the mask token instead of the restored value.
+func TestRegistry_RestoreStreamChunk_SplitAtDelimiter(t *testing.T) {
+	reg := NewRegistry()
+	ph := reg.Placeholder("PERSON", "Alice") // "<PII_PERSON_1>"
+	parts := []string{"prefix " + ph[:1], ph[1:] + " suffix"}
+	if got := streamRestore(reg, parts); got != "prefix Alice suffix" {
+		t.Fatalf("stream restore = %q want %q", got, "prefix Alice suffix")
+	}
+}
+
+// TestRegistry_RestoreStreamChunk_EscapedFormSplit guards hold-back for the
+// escaped wire forms: Gemini's JSON encoder emits \u003cPII_..._1\u003e, and a
+// chunk boundary before the closing escape used to flush the token
+// unrestored.
+func TestRegistry_RestoreStreamChunk_EscapedFormSplit(t *testing.T) {
+	reg := NewRegistry()
+	ph := reg.Placeholder("PERSON", "Alice")
+	escaped := jsonEscapedPlaceholder(ph) // \u003cPII_PERSON_1\u003e
+
+	// Split right before the closing escape.
+	cut := strings.LastIndex(escaped, `\u003e`)
+	parts := []string{"x " + escaped[:cut], escaped[cut:] + " y"}
+	if got := streamRestore(reg, parts); got != "x Alice y" {
+		t.Fatalf("escaped-form stream restore = %q want %q", got, "x Alice y")
+	}
+
+	// Split mid-escape (chunk ends "...\u00").
+	reg2 := NewRegistry()
+	ph2 := reg2.Placeholder("PERSON", "Bob")
+	escaped2 := jsonEscapedPlaceholder(ph2)
+	cut2 := strings.LastIndex(escaped2, `\u003e`) + 3 // inside the escape
+	parts2 := []string{"x " + escaped2[:cut2], escaped2[cut2:] + " y"}
+	if got := streamRestore(reg2, parts2); got != "x Bob y" {
+		t.Fatalf("mid-escape stream restore = %q want %q", got, "x Bob y")
+	}
+}
+
 func TestScrub_PolicyAwarePlaceholders(t *testing.T) {
 	spans := []Span{
 		{Start: 0, End: 8, EntityType: "PERSON", Score: 0.9},


### PR DESCRIPTION
## Summary
Redaction coverage and streaming fixes:

- **Tool-call payloads were never scrubbed**: Gemini `functionCall.args` / `functionResponse.response` (camelCase and snake_case) and OpenAI Responses tool `arguments`/`output` in the `input` array passed through to the provider with PII intact.
- **Bare JSON scalar bodies** (e.g. a quoted string) skipped analysis entirely.
- **Data race in parallel JSON scrubbing**: tasks wrote results outside the mutex; reproducible under `-race` with sibling strings in one map.
- **Stream placeholder restore could leak fragments**: an empty suffix after an unclosed delimiter, escaped wire forms (`\u003c`, `&lt;`, ...) split mid-escape, and `PII_` tokens terminated by `\` or `&` all split a placeholder across the emit/carry boundary, sending raw placeholder halves to the client.
- **`LogPreview` truncated before redacting**, so an entity straddling the cutoff leaked its head into logs; it now redacts with slack, then truncates.
- **`isPrivateOrLoopbackIP` mangled bracketed IPv6 and `host:port`**, causing private IPv6 addresses to be classified as public.
- PII stats no longer hold the recorder write lock across the S3 history upload, and history sink uploads get a 30s timeout instead of blocking a worker forever.

Each bypass and restore gap has a regression test.

## Test plan
- [x] `go test -race ./internal/redact/... ./internal/pii/... ./internal/history/...` passes on this branch in isolation
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sensitive-data redaction for OpenAI and Gemini tool calls, including alternate payload formats.
  - Fixed redaction of standalone JSON values and simultaneous fields in the same payload.
  - Improved handling of IPv6 addresses, including private and loopback detection.
  - Prevented sensitive data from leaking when log previews or streamed responses split tokens across boundaries.
  - Added upload time limits and improved history emission reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->