### PR TITLE
fix(cost): correct persisted records, Datadog metrics, and startup bugs

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -213,7 +213,7 @@ func init() {
 				// Format time with consistent RFC3339 format for better log parsing
 				// This is more precise and timezone-aware than the basic AWS format
 				if a.Key == slog.TimeKey && len(groups) == 0 {
-					return slog.String(a.Key, a.Value.Time().Format("2006-01-02 15:04:05,"))
+					return slog.String(a.Key, a.Value.Time().Format("2006-01-02 15:04:05,000"))
 				}
 				return a
 			},
@@ -249,6 +249,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 
 	// Create all configured transports
 	var transports []cost.Transport
+	var transportTypes []string
 	var failedTransports []string
 
 	for i, transportConfig := range transportConfigs {
@@ -317,6 +318,7 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 
 		logger.Info("💰 Cost Tracker: Transport created successfully", "transport_type", transportConfig.Type)
 		transports = append(transports, transport)
+		transportTypes = append(transportTypes, transportConfig.Type)
 	}
 
 	// Check if we have at least one working transport
@@ -332,19 +334,12 @@ func initializeCostTracker(yamlConfig *config.YAMLConfig) *cost.CostTracker {
 		logProxyWarn("💰 Cost Tracker: Falling back to file transport", "fallback_type", "file", "output_file", outputFile)
 		transport := cost.NewFileTransport(outputFile)
 		transports = append(transports, transport)
+		transportTypes = append(transportTypes, "file")
 		logger.Info("💰 Cost Tracker: Initialized with fallback", "actual_transport_type", "file", "output_file", outputFile)
 	}
 
 	// Create cost tracker with all working transports
 	costTracker := cost.NewCostTracker(transports...)
-
-	// Log successful initialization
-	transportTypes := make([]string, len(transports))
-	for i := range transports {
-		if i < len(transportConfigs) {
-			transportTypes[i] = transportConfigs[i].Type
-		}
-	}
 
 	if len(failedTransports) > 0 {
 		logProxyWarn("💰 Cost Tracker: Initialized with some transport failures",
@@ -1904,10 +1899,11 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	}
 
 	// Set up graceful shutdown
+	serverErrChan := make(chan error, 1)
 	go func() {
 		logger.Info("🚀 Starting server", "address", "0.0.0.0:"+port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logProxyError("Server failed to start", "error", err)
+			serverErrChan <- err
 		}
 	}()
 
@@ -1915,9 +1911,18 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
-	sig := <-sigChan
-	logger.Info("🛑 Received shutdown signal", "signal", sig.String())
-	gracefulShutdown(server)
+	select {
+	case err := <-serverErrChan:
+		// e.g. port already in use — flush recorders/sinks, then exit
+		// non-zero so the orchestrator restarts us instead of leaving a
+		// dead proxy blocked on the signal channel.
+		logProxyError("Server failed to start", "error", err)
+		gracefulShutdown(server)
+		os.Exit(1)
+	case sig := <-sigChan:
+		logger.Info("🛑 Received shutdown signal", "signal", sig.String())
+		gracefulShutdown(server)
+	}
 }
 
 // closeGlobalHistorySink flushes buffered row history on shutdown.

--- a/internal/cost/datadog.go
+++ b/internal/cost/datadog.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
 	"net"
 	"strings"
 	"time"
@@ -28,10 +27,11 @@ type DatadogTransportConfig struct {
 
 // DatadogTransport implements Transport interface for Datadog-based cost tracking
 type DatadogTransport struct {
-	client    *statsd.Client
-	namespace string
-	tags      []string
-	logger    *slog.Logger
+	client     *statsd.Client
+	namespace  string
+	tags       []string
+	sampleRate float64
+	logger     *slog.Logger
 }
 
 // NewDatadogTransport creates a new Datadog-based transport
@@ -72,10 +72,11 @@ func NewDatadogTransport(cfg DatadogTransportConfig) (*DatadogTransport, error) 
 	}
 
 	transport := &DatadogTransport{
-		client:    client,
-		namespace: cfg.Namespace,
-		tags:      cfg.Tags,
-		logger:    logger,
+		client:     client,
+		namespace:  cfg.Namespace,
+		tags:       cfg.Tags,
+		sampleRate: cfg.SampleRate,
+		logger:     logger,
 	}
 
 	return transport, nil
@@ -206,37 +207,40 @@ func (dt *DatadogTransport) WriteRecord(record *CostRecord) error {
 	}
 
 	// Send token metrics
-	if err := dt.client.Distribution("tokens.input", float64(record.InputTokens), tags, 1.0); err != nil {
+	if err := dt.client.Distribution("tokens.input", float64(record.InputTokens), tags, dt.sampleRate); err != nil {
 		dt.logger.Warn("💹 Failed to send input tokens metric to Datadog", "error", err)
 	}
 
-	if err := dt.client.Distribution("tokens.output", float64(record.OutputTokens), tags, 1.0); err != nil {
+	if err := dt.client.Distribution("tokens.output", float64(record.OutputTokens), tags, dt.sampleRate); err != nil {
 		dt.logger.Warn("💹 Failed to send output tokens metric to Datadog", "error", err)
 	}
 
-	if err := dt.client.Distribution("tokens.total", float64(record.TotalTokens), tags, 1.0); err != nil {
+	if err := dt.client.Distribution("tokens.total", float64(record.TotalTokens), tags, dt.sampleRate); err != nil {
 		dt.logger.Warn("💹 Failed to send total tokens metric to Datadog", "error", err)
 	}
 
-	// Send cost metrics (convert to cents to avoid floating point precision issues in Datadog)
-	inputCostCents := float64(math.Ceil(record.InputCost * 100))
-	outputCostCents := float64(math.Ceil(record.OutputCost * 100))
-	totalCostCents := float64(math.Ceil(record.TotalCost * 100))
+	// Send cost metrics (convert to cents to avoid floating point precision
+	// issues in Datadog). Keep fractional cents: rounding each record up to a
+	// whole cent overstates aggregate spend by orders of magnitude for
+	// high-volume sub-cent requests (a $0.0001 call would report as 1 cent).
+	inputCostCents := record.InputCost * 100
+	outputCostCents := record.OutputCost * 100
+	totalCostCents := record.TotalCost * 100
 
-	if err := dt.client.Distribution("cost.input_cents", inputCostCents, tags, 1.0); err != nil {
+	if err := dt.client.Distribution("cost.input_cents", inputCostCents, tags, dt.sampleRate); err != nil {
 		dt.logger.Warn("💹 Failed to send input cost metric to Datadog", "error", err)
 	}
 
-	if err := dt.client.Distribution("cost.output_cents", outputCostCents, tags, 1.0); err != nil {
+	if err := dt.client.Distribution("cost.output_cents", outputCostCents, tags, dt.sampleRate); err != nil {
 		dt.logger.Warn("💹 Failed to send output cost metric to Datadog", "error", err)
 	}
 
-	if err := dt.client.Distribution("cost.total_cents", totalCostCents, tags, 1.0); err != nil {
+	if err := dt.client.Distribution("cost.total_cents", totalCostCents, tags, dt.sampleRate); err != nil {
 		dt.logger.Warn("💹 Failed to send total cost metric to Datadog", "error", err)
 	}
 
 	// Send request count metric
-	if err := dt.client.Incr("requests.count", tags, 1.0); err != nil {
+	if err := dt.client.Incr("requests.count", tags, dt.sampleRate); err != nil {
 		dt.logger.Warn("💹 Failed to send request count metric to Datadog", "error", err)
 	}
 

--- a/internal/cost/dynamodb.go
+++ b/internal/cost/dynamodb.go
@@ -55,6 +55,7 @@ type DynamoDBCostRecord struct {
 	Timestamp    int64   `dynamodbav:"timestamp"` // Unix timestamp for easier queries
 	RequestID    string  `dynamodbav:"request_id,omitempty"`
 	UserID       string  `dynamodbav:"user_id,omitempty"`
+	KeyID        string  `dynamodbav:"key_id,omitempty"`
 	IPAddress    string  `dynamodbav:"ip_address,omitempty"`
 	Provider     string  `dynamodbav:"provider"`
 	Model        string  `dynamodbav:"model"`
@@ -288,8 +289,12 @@ func (dt *DynamoDBTransport) WriteRecord(record *CostRecord) error {
 
 // toDynamoDBRecord converts a CostRecord to DynamoDBCostRecord
 func (dt *DynamoDBTransport) toDynamoDBRecord(record *CostRecord) *DynamoDBCostRecord {
-	dateStr := record.Timestamp.Format("2006-01-02")
-	timestampStr := record.Timestamp.Format("2006-01-02T15:04:05.000Z")
+	// Convert to UTC before formatting: the "Z" in the layout is a literal,
+	// so formatting a local-time value would stamp local wall-clock time as
+	// UTC and bucket the partition key by local day instead of UTC day.
+	ts := record.Timestamp.UTC()
+	dateStr := ts.Format("2006-01-02")
+	timestampStr := ts.Format("2006-01-02T15:04:05.000Z")
 
 	return &DynamoDBCostRecord{
 		PK:           fmt.Sprintf("COST#%s", dateStr),
@@ -304,6 +309,7 @@ func (dt *DynamoDBTransport) toDynamoDBRecord(record *CostRecord) *DynamoDBCostR
 		Timestamp:    record.Timestamp.Unix(),
 		RequestID:    record.RequestID,
 		UserID:       record.UserID,
+		KeyID:        record.KeyID,
 		IPAddress:    record.IPAddress,
 		Provider:     record.Provider,
 		Model:        record.Model,

--- a/internal/cost/dynamodb_test.go
+++ b/internal/cost/dynamodb_test.go
@@ -3,10 +3,47 @@ package cost
 import (
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Instawork/llm-proxy/internal/providers"
 )
+
+// TestToDynamoDBRecord_UTCKeysAndKeyID guards two regressions: (1) partition
+// and sort keys must be derived from UTC — the "Z" in the layout is a literal,
+// so formatting a local-time value would stamp local wall-clock time as UTC
+// and bucket records near midnight into the wrong day partition; (2) KeyID
+// must be persisted, not silently dropped.
+func TestToDynamoDBRecord_UTCKeysAndKeyID(t *testing.T) {
+	dt := &DynamoDBTransport{}
+
+	// 20:30 in UTC-7 is 03:30 the NEXT day in UTC.
+	loc := time.FixedZone("UTC-7", -7*3600)
+	record := &CostRecord{
+		Timestamp: time.Date(2026, 7, 24, 20, 30, 0, 0, loc),
+		RequestID: "req-1",
+		UserID:    "user-1",
+		KeyID:     "iw:abcd****wxyz",
+		Provider:  "openai",
+		Model:     "gpt-4o",
+	}
+
+	out := dt.toDynamoDBRecord(record)
+
+	if out.PK != "COST#2026-07-25" {
+		t.Errorf("PK must bucket by UTC day, got %q", out.PK)
+	}
+	if !strings.HasPrefix(out.SK, "TIMESTAMP#2026-07-25T03:30:00.000Z#") {
+		t.Errorf("SK must carry the UTC timestamp, got %q", out.SK)
+	}
+	if out.KeyID != record.KeyID {
+		t.Errorf("KeyID must be persisted, got %q want %q", out.KeyID, record.KeyID)
+	}
+	if out.Timestamp != record.Timestamp.Unix() {
+		t.Errorf("numeric timestamp changed: got %d want %d", out.Timestamp, record.Timestamp.Unix())
+	}
+}
 
 // TestDynamoDBTransportIntegration demonstrates how to use the DynamoDB transport
 // This is an integration test that requires AWS credentials and DynamoDB access.
@@ -69,7 +106,7 @@ func TestDynamoDBTransportIntegration(t *testing.T) {
 	}
 
 	// Track a test request
-	err = tracker.TrackRequest(metadata, "test-user", "192.168.1.1", "/v1/chat/completions", "")
+	err = tracker.TrackRequest(metadata, "test-user", "192.0.2.1", "/v1/chat/completions", "")
 	if err != nil {
 		t.Errorf("Failed to track request: %v", err)
 	}


### PR DESCRIPTION
## Summary
Cost-record and server-startup fixes:

- **DynamoDB PK/SK used local wall-clock time with a literal `Z` suffix**, so date partitions drifted by the host's UTC offset; keys now use the record timestamp in real UTC.
- **`KeyID` was silently dropped** when persisting cost records to DynamoDB.
- **Datadog cost metrics applied `math.Ceil` per record**, overstating spend by up to a cent per request; and the documented `sample_rate` option was parsed and defaulted but never applied to the metric calls.
- Startup logs reported cost transports as `[]` even when transports initialized successfully.
- **A listener bind failure (e.g. port in use) left a zombie process** running with no listener; startup errors now shut the process down cleanly.
- Prod JSON log timestamps rendered a dangling comma with no millisecond digits.

## Test plan
- [x] `go build ./... && go test ./internal/cost/... ./cmd/...` passes on this branch in isolation
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * JSON logs now include millisecond-precision timestamps.
  * Cost metrics honor configured sampling rates and preserve fractional-cent precision.
  * Cost records now include key identifiers and consistent UTC-based timestamps.
* **Bug Fixes**
  * Server startup failures are handled promptly with graceful cleanup and a non-zero exit status.
  * File-based cost tracking is correctly reported when used as a fallback.
  * DynamoDB records now remain consistently partitioned across time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->