### PR TITLE
Log the panic stack on ErrAbortHandler aborts

### DIFF
--- a/internal/middleware/abort_logging.go
+++ b/internal/middleware/abort_logging.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/Instawork/llm-proxy/internal/proxylog"
@@ -61,6 +62,12 @@ func AbortLoggingMiddleware() func(http.Handler) http.Handler {
 						slog.Duration("duration", time.Since(start)),
 						slog.String("ctx_err", errText(ctx.Err())),
 						slog.String("ctx_cause", errText(context.Cause(ctx))),
+						// The deferred recover runs while the panic frames are
+						// still on this goroutine's stack, so this pinpoints the
+						// exact panic(http.ErrAbortHandler) site — production
+						// aborts have shown "no read error, no write, live
+						// context" shapes that only a stack can disambiguate.
+						slog.String("stack", string(debug.Stack())),
 					)
 				}
 				panic(rec)

--- a/internal/middleware/abort_logging_test.go
+++ b/internal/middleware/abort_logging_test.go
@@ -48,6 +48,11 @@ func TestAbortLoggingMiddleware_LogsErrAbortHandler(t *testing.T) {
 	if !strings.Contains(logOutput, "headers_sent=true") {
 		t.Errorf("expected headers_sent=true in abort log, got: %s", logOutput)
 	}
+	// The stack must include the panic origin so production aborts can be
+	// traced to the exact panic(http.ErrAbortHandler) site.
+	if !strings.Contains(logOutput, "TestAbortLoggingMiddleware_LogsErrAbortHandler") {
+		t.Errorf("expected panic-site stack frames in abort log, got: %s", logOutput)
+	}
 }
 
 // TestAbortLoggingMiddleware_AbortBeforeHeaders covers the observed


### PR DESCRIPTION
## Summary

Third and hopefully final instrumentation step for the recurring ALB 502s (follows #38 and #39).

Production data since #39 deployed rules out both external causes: all 141 aborts show `ctx_err=""` (the inbound ALB/client connection is alive — net/http has not canceled the request context) and there are zero `response body read error` lines (the upstream body never fails). Nothing is ever written to the outermost writer either (`headers_sent=false`, `bytes_written=0`). That combination doesn't match the ReverseProxy copy-failure shapes we expected, so the `panic(http.ErrAbortHandler)` is coming from somewhere we haven't identified inside the handler chain.

This adds `debug.Stack()` to the abort log line. The deferred recover runs while the panic frames are still on the goroutine's stack, so the captured stack includes the exact panic site (same mechanism chi's Recoverer uses to print stacks).

Cost: one string attribute (~2–4 KB) on an error line that fires a few dozen times per hour at worst. No behavior change — the panic is still re-raised unchanged.

## Test plan

- [x] Extended the existing abort test to assert the stack includes the panicking function's frame.
- [x] `make ci` passes locally.
- [ ] After deploy: read the stack on the next abort to identify the panic site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging when a response is aborted by including a stack trace.
  * Preserved existing abort handling and error propagation behavior.

* **Tests**
  * Added verification that abort logs contain relevant stack trace information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->