### PR TITLE
fix(pii): report input length from non-streaming restore writes

### DIFF
--- a/internal/middleware/pii_response.go
+++ b/internal/middleware/pii_response.go
@@ -142,15 +142,27 @@ func (pw *piiRestoreResponseWriter) Write(b []byte) (int, error) {
 	if pw.registry == nil || len(b) == 0 {
 		return pw.ResponseWriter.Write(b)
 	}
+	// On success every branch must report exactly len(b) consumed, even when
+	// restoration (or gzip decompression) changes the byte count.
+	// httputil.ReverseProxy copies the upstream body with io.Copy, which
+	// treats n < len(b) as io.ErrShortWrite and n > len(b) as an invalid
+	// write — either aborts the copy and panics with http.ErrAbortHandler,
+	// surfacing to clients as an ALB 502 with no response body.
 	if !pw.streaming {
 		plain, _, err := decompressPIIResponseIfGzip(b)
 		if err != nil {
 			proxylog.SlogProxy(slog.Default(), slog.LevelWarn, "pii_restore: gzip decompress failed; passing through without placeholder restore",
 				slog.String("error", err.Error()))
-			return pw.writeRestored(b)
+			if _, err := pw.writeRestored(b); err != nil {
+				return 0, err
+			}
+			return len(b), nil
 		}
 		restored := pw.registry.RestoreUserFacing(string(plain))
-		return pw.writeRestored([]byte(restored))
+		if _, err := pw.writeRestored([]byte(restored)); err != nil {
+			return 0, err
+		}
+		return len(b), nil
 	}
 	if pw.streaming {
 		emit, newCarry := pw.registry.RestoreStreamChunk(b, pw.carry)

--- a/internal/middleware/pii_restore_hardening_test.go
+++ b/internal/middleware/pii_restore_hardening_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"compress/gzip"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -230,6 +231,70 @@ func TestPIIResponseRestoreMiddleware_RestoresSquareBracketPIIPlaceholder(t *tes
 	}
 	if got := piiMetricFromResponse(rec, "X-LLM-PII-Leaked"); got != "0" {
 		t.Fatalf("leaked = %q, want 0", got)
+	}
+}
+
+// TestPIIResponseRestoreMiddleware_WriteHonorsIoCopyContract reproduces the
+// production ALB 502s: httputil.ReverseProxy copies the upstream body with
+// io.Copy, which errors (io.ErrShortWrite / invalid write) whenever Write
+// reports n != len(input) — and ReverseProxy then panics with
+// http.ErrAbortHandler, resetting the client connection. Restoring a
+// placeholder changes the byte count, so Write must report the input length,
+// not the restored length.
+func TestPIIResponseRestoreMiddleware_WriteHonorsIoCopyContract(t *testing.T) {
+	reg := redact.NewRegistry()
+	ph := reg.Placeholder("PERSON", "Jane Doe")
+	pm := providers.NewProviderManager()
+
+	body := `{"content":"` + ph + `"}`
+	var copyErr error
+	mw := PIIResponseRestoreMiddleware(pm)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, copyErr = io.Copy(w, strings.NewReader(body))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+	req = req.WithContext(withPIIRegistry(req.Context(), reg))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if copyErr != nil {
+		t.Fatalf("io.Copy failed (ReverseProxy would panic with ErrAbortHandler): %v", copyErr)
+	}
+	want := `{"content":"Jane Doe"}`
+	if rec.Body.String() != want {
+		t.Fatalf("body = %q want %q", rec.Body.String(), want)
+	}
+}
+
+// Gzip variant of the io.Copy contract test: the decompressed+restored body
+// is much longer than the compressed input chunk, so a Write that reports
+// the restored length returns n > len(input), which io.Copy also treats as
+// a fatal error.
+func TestPIIResponseRestoreMiddleware_WriteHonorsIoCopyContractGzip(t *testing.T) {
+	reg := redact.NewRegistry()
+	ph := reg.Placeholder("PERSON", "Jane Doe")
+	pm := providers.NewProviderManager()
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, _ = gz.Write([]byte(`{"content":"` + ph + `","pad":"` + strings.Repeat("a", 2048) + `"}`))
+	_ = gz.Close()
+
+	var copyErr error
+	mw := PIIResponseRestoreMiddleware(pm)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, copyErr = io.Copy(w, bytes.NewReader(compressed.Bytes()))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+	req = req.WithContext(withPIIRegistry(req.Context(), reg))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if copyErr != nil {
+		t.Fatalf("io.Copy failed (ReverseProxy would panic with ErrAbortHandler): %v", copyErr)
+	}
+	if !strings.Contains(rec.Body.String(), "Jane Doe") {
+		t.Fatalf("body = %q, want restored PII", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix the non-streaming PII response writer to report the original input length after successful restoration, preserving the `io.Writer` contract used by `httputil.ReverseProxy`.
- Prevent `io.Copy` errors and `http.ErrAbortHandler` panics that surfaced as ALB 502 responses.
- Add regression coverage for both plain placeholder restoration and gzip decompression/restoration.

## Test plan

- `make test`
- `gofmt -s`
- `gofumpt`
- `go vet`

The new regression tests drive the middleware through `io.Copy`, matching the production reverse-proxy path, and fail against the previous implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed response handling for restored PII data to prevent write-length mismatches.
  * Improved compatibility with proxy and streaming operations for both plain and gzip-compressed responses.
  * Ensured restored response content is delivered correctly without spurious copy errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->