### PR TITLE
fix(circuit,pii): gunzip upstream_error peeks and bake Presidio recognizers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,34 @@ jobs:
               --dockerignore "" \
               --skip-aws-setup
 
+  build-and-push-presidio:
+    docker:
+      - image: cimg/base:stable
+    working_directory: ~/llm-proxy
+    # Target the Presidio sidecar repo for ensure-repo + the build script.
+    environment:
+      AWS_ECR_REPOSITORY_NAME: llm-proxy-presidio
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - setup_aws_and_docker
+      - run:
+          name: Build and push Presidio sidecar image
+          command: |
+            export GIT_SHA=$(git rev-parse --short HEAD)
+            echo "Building Presidio image with SHA: ${GIT_SHA}"
+            # Bake recognizers.yaml into the stock Presidio image so ECS tasks
+            # get DATE_OF_BIRTH / US_STREET_ADDRESS without a bind mount.
+            # Context is the repo root so COPY recognizers.yaml works; skip the
+            # prod dockerignore (it excludes build/) and use an empty one.
+            ./scripts/build_for_ecr.sh -s ${GIT_SHA} \
+              --repo llm-proxy-presidio \
+              --dockerfile build/Dockerfile.presidio \
+              --context . \
+              --dockerignore "" \
+              --skip-aws-setup
+
   deploy-prod:
     docker:
       - image: cimg/python:3.11.8
@@ -339,6 +367,21 @@ workflows:
             - AWS
 
       - build-and-push-ocr:
+          requires:
+            - lint
+            - unit-tests
+            - integration-tests
+            - fuzz-tests
+          filters:
+            branches:
+              only:
+                - main
+            tags:
+              ignore: /.*/
+          context:
+            - AWS
+
+      - build-and-push-presidio:
           requires:
             - lint
             - unit-tests

--- a/build/Dockerfile.presidio
+++ b/build/Dockerfile.presidio
@@ -1,0 +1,13 @@
+# Presidio analyzer sidecar for llm-proxy with custom recognizers baked in.
+#
+# Stock mcr.microsoft.com/presidio-analyzer does not ship DATE_OF_BIRTH /
+# US_STREET_ADDRESS (and loads UK_NHS / MAC_ADDRESS / etc.). Production ECS
+# cannot bind-mount recognizers.yaml the way docker-compose does, so we
+# overwrite the default registry config at the path Presidio actually reads:
+#   /app/presidio_analyzer/conf/default_recognizers.yaml
+#
+# Keep recognizers.yaml in lockstep with the compose mount and any other
+# consumers (see the header comment in that file).
+FROM mcr.microsoft.com/presidio-analyzer:2.2.362
+
+COPY recognizers.yaml /app/presidio_analyzer/conf/default_recognizers.yaml

--- a/internal/circuit/classifier.go
+++ b/internal/circuit/classifier.go
@@ -2,6 +2,7 @@ package circuit
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -121,6 +122,12 @@ func classifyOpenAI(status int, resp *http.Response) FailureClass {
 // multi-megabyte error page into memory on the hot path.
 const responseBodyPeekBytes = 512
 
+// responseBodyGzipPeekBytes is the compressed-byte budget when the upstream
+// error response is Content-Encoding: gzip.  Error envelopes are tiny JSON,
+// but the gzip wrapper + a truncated peek of only 512 compressed bytes often
+// fails to decompress; 4 KiB is still small and covers real provider errors.
+const responseBodyGzipPeekBytes = 4096
+
 type geminiErrorEnvelope struct {
 	Error struct {
 		Status  string `json:"status"`
@@ -210,12 +217,20 @@ func gemini429IsQuota(resp *http.Response) bool {
 // peekResponseBodyPrefix reads up to responseBodyPeekBytes from resp.Body
 // and restores the stream so callers can still forward or drain the full
 // body afterward.  Returns nil when resp / Body is nil.
+//
+// When Content-Encoding includes gzip, the restored body stays byte-identical
+// to the upstream (compressed) stream — only the returned peek is gunzipped
+// so JSON classification / upstream_error logging can parse the envelope.
 func peekResponseBodyPrefix(resp *http.Response) []byte {
 	if resp == nil || resp.Body == nil {
 		return nil
 	}
 	orig := resp.Body
-	buf, _ := io.ReadAll(io.LimitReader(orig, responseBodyPeekBytes))
+	limit := int64(responseBodyPeekBytes)
+	if contentEncodingHasGzip(resp) {
+		limit = responseBodyGzipPeekBytes
+	}
+	buf, _ := io.ReadAll(io.LimitReader(orig, limit))
 	// Preserve the original Closer so closing resp.Body still releases the
 	// upstream connection (io.NopCloser would swallow Close and leak it).
 	resp.Body = struct {
@@ -225,7 +240,39 @@ func peekResponseBodyPrefix(resp *http.Response) []byte {
 		Reader: io.MultiReader(bytes.NewReader(buf), orig),
 		Closer: orig,
 	}
-	return buf
+	return maybeGunzipPeek(resp, buf)
+}
+
+func contentEncodingHasGzip(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	ce := strings.ToLower(resp.Header.Get("Content-Encoding"))
+	return strings.Contains(ce, "gzip")
+}
+
+// maybeGunzipPeek returns a decompressed copy of buf when the response is
+// gzip-encoded.  On any gunzip failure it returns the raw buf so callers fall
+// through to their existing parse / generic-detail paths.
+func maybeGunzipPeek(resp *http.Response, buf []byte) []byte {
+	if len(buf) == 0 || !contentEncodingHasGzip(resp) {
+		return buf
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(buf))
+	if err != nil {
+		return buf
+	}
+	defer zr.Close() //nolint:errcheck
+	out, err := io.ReadAll(io.LimitReader(zr, responseBodyPeekBytes))
+	if len(out) == 0 {
+		return buf
+	}
+	// Truncated compressed peeks yield UnexpectedEOF after some bytes; prefer
+	// whatever decompressed payload we got so JSON envelopes still parse.
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return buf
+	}
+	return out
 }
 
 // peekUpstreamErrorDetail extracts a compact, provider-aware summary from

--- a/internal/circuit/classifier_test.go
+++ b/internal/circuit/classifier_test.go
@@ -1,6 +1,8 @@
 package circuit
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"io"
@@ -222,6 +224,58 @@ func TestPeekUpstreamErrorDetail_Gemini_UNAVAILABLE(t *testing.T) {
 	}
 	if string(rest) != body {
 		t.Fatalf("restored body = %q, want %q", string(rest), body)
+	}
+}
+
+func TestPeekUpstreamErrorDetail_Gemini_GzipEncoded(t *testing.T) {
+	plain := `{"error":{"code":503,"message":"The model is overloaded. Please try again later.","status":"UNAVAILABLE"}}`
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write([]byte(plain)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	raw := compressed.Bytes()
+
+	r := &http.Response{
+		StatusCode: 503,
+		Header:     http.Header{"Content-Encoding": []string{"gzip"}},
+		Body:       io.NopCloser(bytes.NewReader(raw)),
+	}
+	got := peekUpstreamErrorDetail("gemini", r)
+	want := "UNAVAILABLE: The model is overloaded. Please try again later."
+	if got != want {
+		t.Fatalf("peekUpstreamErrorDetail(gzip gemini) = %q, want %q", got, want)
+	}
+	// Restored body must remain the compressed bytes (client sees upstream as-is).
+	rest, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if !bytes.Equal(rest, raw) {
+		t.Fatalf("restored body must stay gzip-encoded; got %d bytes want %d", len(rest), len(raw))
+	}
+}
+
+func TestPeekOpenAIErrorCode_GzipEncoded(t *testing.T) {
+	plain := `{"error":{"message":"You exceeded your current quota","type":"insufficient_quota","code":"insufficient_quota"}}`
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write([]byte(plain)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	r := &http.Response{
+		StatusCode: 429,
+		Header:     http.Header{"Content-Encoding": []string{"gzip"}},
+		Body:       io.NopCloser(bytes.NewReader(compressed.Bytes())),
+	}
+	if got := peekOpenAIErrorCode(r); got != "insufficient_quota" {
+		t.Fatalf("peekOpenAIErrorCode(gzip) = %q, want insufficient_quota", got)
 	}
 }
 

--- a/internal/circuit/observability_test.go
+++ b/internal/circuit/observability_test.go
@@ -2,6 +2,7 @@ package circuit
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -490,6 +491,65 @@ func TestEnforce_HandleTerminalFailure_LogsGeminiUpstreamError(t *testing.T) {
 	}
 	if gotKind, _ := terminalEntry["failure_kind"].(string); gotKind != string(KindGeminiUnavailable) {
 		t.Fatalf("terminal failure failure_kind = %q, want %q", gotKind, KindGeminiUnavailable)
+	}
+}
+
+func TestEnforce_HandleTerminalFailure_LogsGeminiGzipUpstreamError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := captureLogs(buf)
+
+	plain := `{"error":{"code":503,"message":"The model is overloaded. Please try again later.","status":"UNAVAILABLE"}}`
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write([]byte(plain)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	inner := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		h := make(http.Header)
+		h.Set("Content-Encoding", "gzip")
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     http.StatusText(http.StatusServiceUnavailable),
+			Header:     h,
+			Body:       io.NopCloser(bytes.NewReader(compressed.Bytes())),
+		}, nil
+	})
+	cfg := Config{
+		Enabled:             true,
+		Mode:                ModeEnforce,
+		FailureThreshold:    1,
+		WindowSeconds:       60,
+		CooldownSeconds:     300,
+		MaxTransientRetries: 1,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	tr := NewTransport(
+		inner, store, cfg, "gemini", log,
+		WithModelExtractor(fakeModelFn("gemini-2.5-flash-lite")),
+	)
+
+	resp, err := tr.RoundTrip(dummyOpenAIRequest("gemini-2.5-flash-lite"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+	resp.Body.Close()              //nolint:errcheck
+
+	terminalEntry := findLogLine(t, buf, "terminal failure, returning degraded signal")
+	if terminalEntry == nil {
+		t.Fatalf("expected terminal failure log line; got %s", buf.String())
+	}
+	got, _ := terminalEntry["upstream_error"].(string)
+	want := "UNAVAILABLE: The model is overloaded. Please try again later."
+	if got != want {
+		t.Fatalf("gzip terminal failure upstream_error = %q, want %q", got, want)
+	}
+	if gotKind, _ := terminalEntry["failure_kind"].(string); gotKind != string(KindGeminiUnavailable) {
+		t.Fatalf("gzip terminal failure failure_kind = %q, want %q", gotKind, KindGeminiUnavailable)
 	}
 }
 

--- a/scripts/build_for_ecr.sh
+++ b/scripts/build_for_ecr.sh
@@ -64,6 +64,8 @@ EXAMPLES:
     $0 --skip-aws-setup                  # Skip AWS setup (assume already configured)
     # Build and push the OCR sidecar image to the ocr-gate repo:
     $0 -r ocr-gate -f ocr_sidecar/Dockerfile -c ocr_sidecar --dockerignore ""
+    # Build and push the Presidio sidecar with baked-in recognizers.yaml:
+    $0 -r llm-proxy-presidio -f build/Dockerfile.presidio -c . --dockerignore ""
 
 EOF
 }


### PR DESCRIPTION
## Summary

- Decompress gzip-encoded upstream error bodies in the circuit peek path so `upstream_error` logs and failure-kind refinement work (production was logging binary mojibake for Gemini 503s). The restored response body stays byte-identical for the client.
- Add `build/Dockerfile.presidio` that bakes `recognizers.yaml` into `presidio-analyzer:2.2.362`, plus a `build-and-push-presidio` CircleCI job that publishes to ECR `llm-proxy-presidio`. Production ECS currently runs the stock image with no bind mount, so custom `DATE_OF_BIRTH` / `US_STREET_ADDRESS` recognizers never fire and every request logs recognizer warnings.

Follow-up: infrastructure PR will point the prod `presidio-analyzer` container at `llm-proxy-presidio:latest` once this image exists in ECR (after merge to main).

## Test plan

- [x] `go test ./internal/circuit/ -run 'Gzip|PeekUpstream|HandleTerminalFailure_LogsGemini'`
- [x] `make test` (unit suite)
- [x] Local `docker build -f build/Dockerfile.presidio -t llm-proxy-presidio:local .`
- [x] Smoke: baked image `/analyze` returns `DATE_OF_BIRTH` entity (proves custom yaml loaded)
- [ ] After merge: confirm `build-and-push-presidio` publishes `llm-proxy-presidio` to ECR
- [ ] After infra PR deploy: `/prod/ecs/llm-proxy/log` no longer spam `DATE_OF_BIRTH` / `US_STREET_ADDRESS` recognizer warnings