### PR TITLE
Fix PII placeholder JSON corruption, missing cost estimation config, and oversize-body 503s

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -482,21 +482,7 @@ func isFakeModeAllowed(yc *config.YAMLConfig) bool {
 
 func fakeConfigFromYAML(yc *config.YAMLConfig, allowed bool) fake.Config {
 	fu := yc.Features.FakeUpstream
-	est := providers.YAMLConfigEstimationAdapter{
-		MaxSampleBytes:        yc.Features.RateLimiting.Estimation.MaxSampleBytes,
-		BytesPerToken:         yc.Features.RateLimiting.Estimation.BytesPerToken,
-		CharsPerToken:         yc.Features.RateLimiting.Estimation.CharsPerToken,
-		ProviderCharsPerToken: yc.Features.RateLimiting.Estimation.ProviderCharsPerToken,
-	}
-	if est.MaxSampleBytes == 0 {
-		est.MaxSampleBytes = 200000
-	}
-	if est.BytesPerToken == 0 {
-		est.BytesPerToken = 4
-	}
-	if est.CharsPerToken == 0 {
-		est.CharsPerToken = 4
-	}
+	est := providers.NewYAMLConfigEstimationAdapter(yc.Features.RateLimiting.Estimation)
 	return fake.Config{
 		Enabled:          allowed,
 		ChaosFailureRate: fu.ChaosFailureRate,
@@ -1540,12 +1526,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 				}
 				return total
 			}
-			costLimitOpts.Estimation = providers.YAMLConfigEstimationAdapter{
-				MaxSampleBytes:        yamlConfig.Features.RateLimiting.Estimation.MaxSampleBytes,
-				BytesPerToken:         yamlConfig.Features.RateLimiting.Estimation.BytesPerToken,
-				CharsPerToken:         yamlConfig.Features.RateLimiting.Estimation.CharsPerToken,
-				ProviderCharsPerToken: yamlConfig.Features.RateLimiting.Estimation.ProviderCharsPerToken,
-			}
+			costLimitOpts.Estimation = providers.NewYAMLConfigEstimationAdapter(yamlConfig.Features.RateLimiting.Estimation)
 		}
 		r.Use(middleware.CostLimitMiddleware(globalProviderManager, globalCostStatsRecorder, costLimitOpts))
 	}

--- a/cmd/llm-proxy/main_test.go
+++ b/cmd/llm-proxy/main_test.go
@@ -167,6 +167,33 @@ func TestProductionYAML_HasEstimationBlock(t *testing.T) {
 	}
 }
 
+// TestProductionYAML_PIIRedactSetsExplicitMaxBodyBytes guards against the
+// production bug where pii_redact had no max_body_bytes, silently falling
+// back to the 1 MiB middleware default. With fail_mode "closed", any body
+// over that limit 503s instead of skipping redaction, and a caller that
+// retries an oversized payload keeps hitting 503 on every attempt — not
+// just once, and with no attached alert (see the Datadog monitor fix in
+// the paired infrastructure PR).
+func TestProductionYAML_PIIRedactSetsExplicitMaxBodyBytes(t *testing.T) {
+	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
+	if err != nil {
+		t.Fatalf("resolve configs dir: %v", err)
+	}
+	merged, err := config.LoadAndMergeConfigs([]string{
+		filepath.Join(configsDir, "base.yml"),
+		filepath.Join(configsDir, "production.yml"),
+	})
+	if err != nil {
+		t.Fatalf("load prod configs: %v", err)
+	}
+
+	const oneMiB = 1024 * 1024
+	got := merged.Features.PIIRedact.MaxBodyBytes
+	if got <= oneMiB {
+		t.Fatalf("production.yml pii_redact.max_body_bytes must be set above the 1 MiB default, got %d", got)
+	}
+}
+
 // TestSidecarProfile_WritesRollupsWithoutDashboard locks in the sidecar
 // contract: the dashboard HTTP server is OFF, but rollup writing stays ON so
 // sidecars publish usage/cost/etc to the shared Redis the standalone dashboard

--- a/cmd/llm-proxy/main_test.go
+++ b/cmd/llm-proxy/main_test.go
@@ -135,6 +135,38 @@ func TestCircuitConfigFromYAML_ProductionYAMLExpandsEndToEnd(t *testing.T) {
 	}
 }
 
+// TestProductionYAML_HasEstimationBlock guards against the production bug
+// where rate_limiting had no estimation child: every field defaulted to
+// zero, MaxSampleBytes=0 made EstimateRequestTokens treat any non-empty
+// request body as too large to sample, and the model name was never
+// extracted — silently disabling the cluster-wide cost-limit reservation
+// added in #43 for any key with a cost limit configured, in addition to
+// breaking rate-limit token estimation.
+func TestProductionYAML_HasEstimationBlock(t *testing.T) {
+	configsDir, err := filepath.Abs(filepath.Join("..", "..", "configs"))
+	if err != nil {
+		t.Fatalf("resolve configs dir: %v", err)
+	}
+	merged, err := config.LoadAndMergeConfigs([]string{
+		filepath.Join(configsDir, "base.yml"),
+		filepath.Join(configsDir, "production.yml"),
+	})
+	if err != nil {
+		t.Fatalf("load prod configs: %v", err)
+	}
+
+	est := merged.Features.RateLimiting.Estimation
+	if est.MaxSampleBytes <= 0 {
+		t.Fatalf("production.yml rate_limiting.estimation.max_sample_bytes must be > 0, got %d", est.MaxSampleBytes)
+	}
+	if est.BytesPerToken <= 0 {
+		t.Fatalf("production.yml rate_limiting.estimation.bytes_per_token must be > 0, got %d", est.BytesPerToken)
+	}
+	if est.CharsPerToken <= 0 {
+		t.Fatalf("production.yml rate_limiting.estimation.chars_per_token must be > 0, got %d", est.CharsPerToken)
+	}
+}
+
 // TestSidecarProfile_WritesRollupsWithoutDashboard locks in the sidecar
 // contract: the dashboard HTTP server is OFF, but rollup writing stays ON so
 // sidecars publish usage/cost/etc to the shared Redis the standalone dashboard

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -107,6 +107,21 @@ features:
     redis:
       url: "${REDIS_URL}"
       db: 4
+    # Shared by rate limiting, cost-limit reservations, and fake-upstream
+    # sizing (see providers.EstimateRequestTokens) — not only used when
+    # rate_limiting.enabled is true. Without this block every field
+    # defaults to zero, max_sample_bytes=0 makes every non-empty request
+    # body look "too large to parse", and the model name is never
+    # extracted: cost-limit estimation then always prices an empty model,
+    # which fails pricing lookup and silently disables the cluster-wide
+    # cost reservation added in #43 for any key with a cost limit set.
+    estimation:
+      max_sample_bytes: 200000
+      bytes_per_token: 4
+      chars_per_token: 4
+      provider_chars_per_token:
+        openai: 5 # ~185–190 tokens per 1k chars (from scripts/token_estimation.py)
+        anthropic: 3 # ~290–315 tokens per 1k chars (from scripts/token_estimation.py)
     limits:
       requests_per_minute: 0
       tokens_per_minute: 0

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -138,6 +138,13 @@ features:
     timeout_ms_per_100kb: 2000
     timeout_ms_max: 30000
     analyze_concurrency: 4
+    # Without this, max_body_bytes falls back to the 1 MiB default. With
+    # fail_mode "closed" any body over the limit 503s instead of skipping
+    # redaction, and a caller that retries an oversized payload keeps
+    # hitting 503 on every attempt. 2 MiB clears the largest observed
+    # production payload (a 1,092,866-byte Anthropic tool-result body) with
+    # headroom.
+    max_body_bytes: 2097152
     allow_per_key_override: false
     analyze_cache:
       enabled: true

--- a/integration/live/pii_headers.go
+++ b/integration/live/pii_headers.go
@@ -23,3 +23,17 @@ func PIIMaskLeaked(headers, trailer http.Header) (leaked int, ok bool) {
 	}
 	return 0, false
 }
+
+// piiHeaderCount parses an integer X-LLM-PII-* metric from response headers.
+// ok is false when the metric was absent or unparsable.
+func piiHeaderCount(headers http.Header, name string) (n int, ok bool) {
+	if headers == nil {
+		return 0, false
+	}
+	v := headers.Get(name)
+	if v == "" {
+		return 0, false
+	}
+	i, err := strconv.Atoi(v)
+	return i, err == nil
+}

--- a/integration/live/pii_wire.go
+++ b/integration/live/pii_wire.go
@@ -223,3 +223,48 @@ func (p *ProxyClient) GeminiChatRepeatEmail(ctx context.Context, apiKey, email s
 		return p.GeminiChatWithPIIScrub(ctx, apiKey, userMessage, stream)
 	}, geminiAssistantContent)
 }
+
+// repeatNamePromptFor asks the model to echo a PERSON-tagged name inside a
+// JSON object it constructs itself. The upstream model only ever sees the
+// MASK placeholder in place of name — it never sees the quote/newline
+// characters below — so if the client-visible response is invalid JSON, the
+// corruption was introduced by the proxy's placeholder restore step, not by
+// the model.
+const repeatNamePrompt = `My full name is %s. Reply with ONLY this exact JSON object and nothing else (no code fences, no extra text): {"name": "PLACEHOLDER"} where PLACEHOLDER is replaced with my full name as given above.`
+
+func repeatNamePromptFor(name string) string {
+	return fmt.Sprintf(repeatNamePrompt, name)
+}
+
+// quotedMultilineName is a PERSON-shaped value containing characters that
+// require JSON string escaping (a double quote and an embedded newline).
+// Reused verbatim so callers can assert on the exact bytes.
+const quotedMultilineName = "Robert \"Bob\"\nJohnson"
+
+// GeminiChatRepeatQuotedName posts a prompt whose PII original (a nickname
+// containing a double quote and a newline) is expected to come back
+// restored inside a JSON string value. It returns the raw response body
+// unparsed so callers can validate JSON well-formedness directly.
+func (p *ProxyClient) GeminiChatRepeatQuotedName(ctx context.Context, apiKey string, stream bool) (*ProxyResponse, []byte, error) {
+	return p.GeminiChatWithPIIScrub(ctx, apiKey, repeatNamePromptFor(quotedMultilineName), stream)
+}
+
+// firstInvalidSSEDataJSON scans a Gemini SSE stream ("data: {...}\n\n" lines,
+// terminated by "data: [DONE]") and returns the first data payload that does
+// not parse as valid JSON. ok is false when every payload was valid (or no
+// payloads were found).
+func firstInvalidSSEDataJSON(body []byte) (payload string, ok bool) {
+	for _, line := range strings.Split(string(body), "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		jsonData := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+		if jsonData == "" || jsonData == "[DONE]" {
+			continue
+		}
+		if !json.Valid([]byte(jsonData)) {
+			return jsonData, true
+		}
+	}
+	return "", false
+}

--- a/integration/live/runner.go
+++ b/integration/live/runner.go
@@ -781,9 +781,18 @@ func (r *Runner) runPIIWireRestoreGeminiJSONSafety(ctx context.Context) []Result
 	} else if !json.Valid(body) {
 		out = append(out, failResult("pii", "wire-restore-gemini-json-safety",
 			fmt.Sprintf("placeholder restore produced invalid JSON: %s", truncate(string(body), 300))))
-	} else if content, cerr := geminiAssistantContent(body); cerr == nil && !strings.Contains(content, quotedMultilineName) {
+	} else if content, cerr := geminiAssistantContent(body); cerr != nil {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety",
+			"parse Gemini response: "+cerr.Error()))
+	} else if !strings.Contains(content, quotedMultilineName) {
 		out = append(out, failResult("pii", "wire-restore-gemini-json-safety",
 			fmt.Sprintf("expected restored name %q in assistant reply %q", quotedMultilineName, content)))
+	} else if restored, ok := piiHeaderCount(pr.Headers, "X-LLM-PII-Restored"); !ok || restored <= 0 {
+		// Without this the test passes trivially when the name was never
+		// masked and Gemini simply echoed it back.
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety",
+			fmt.Sprintf("name reached client but X-LLM-PII-Restored=%q — MASK restore path did not run",
+				pr.Headers.Get("X-LLM-PII-Restored"))))
 	} else {
 		out = append(out, passResult("pii", "wire-restore-gemini-json-safety",
 			"quote/newline-bearing PERSON restored without corrupting response JSON", elapsed(start)))
@@ -805,6 +814,13 @@ func (r *Runner) runPIIWireRestoreGeminiJSONSafety(ctx context.Context) []Result
 	} else if !strings.Contains(string(streamBody), "Bob") {
 		out = append(out, failResult("pii", "wire-restore-gemini-json-safety-stream",
 			fmt.Sprintf("expected restored name fragments in stream body %q", truncate(string(streamBody), 200))))
+	} else if masked, ok := piiHeaderCount(pr.Headers, "X-LLM-PII-Masked"); !ok || masked <= 0 {
+		// Streaming responses omit X-LLM-PII-Restored, but the early Masked
+		// header proves the upstream saw a MASK placeholder — so name
+		// fragments in the body can only come from the restore path.
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety-stream",
+			fmt.Sprintf("name reached client but X-LLM-PII-Masked=%q — request was never masked",
+				pr.Headers.Get("X-LLM-PII-Masked"))))
 	} else {
 		out = append(out, passResult("pii", "wire-restore-gemini-json-safety-stream",
 			"quote/newline-bearing PERSON restored without corrupting any SSE chunk", elapsed(start)))

--- a/integration/live/runner.go
+++ b/integration/live/runner.go
@@ -499,9 +499,12 @@ func (r *Runner) runPII(ctx context.Context) []Result {
 	}
 	if r.cfg.GeminiKey != "" {
 		out = append(out, r.runPIIWireRestoreGemini(ctx)...)
+		out = append(out, r.runPIIWireRestoreGeminiJSONSafety(ctx)...)
 	} else {
 		out = append(out, skipResult("pii", "wire-restore-gemini", "GEMINI_API_KEY not set"))
 		out = append(out, skipResult("pii", "wire-restore-gemini-stream", "GEMINI_API_KEY not set"))
+		out = append(out, skipResult("pii", "wire-restore-gemini-json-safety", "GEMINI_API_KEY not set"))
+		out = append(out, skipResult("pii", "wire-restore-gemini-json-safety-stream", "GEMINI_API_KEY not set"))
 	}
 	return out
 }
@@ -742,6 +745,69 @@ func (r *Runner) runPIIWireRestoreProvider(ctx context.Context, spec piiWireRest
 	} else {
 		out = append(out, passResult("pii", spec.suitePrefix+"-stream",
 			fmt.Sprintf("MASK email restored in stream (%s)", truncate(streamBody, 80)), elapsed(start)))
+	}
+	return out
+}
+
+// runPIIWireRestoreGeminiJSONSafety reproduces a production bug: when a
+// MASK-tier placeholder's original value contains characters that require
+// JSON string escaping (a quote, a newline), RestoreUserFacing splices the
+// raw text back into the response byte stream verbatim, producing invalid
+// JSON that reaches the client. The upstream model only ever sees the
+// placeholder, so any corruption here was introduced by the proxy.
+func (r *Runner) runPIIWireRestoreGeminiJSONSafety(ctx context.Context) []Result {
+	start := time.Now()
+	redactPII := true
+	key, err := r.admin.CreateKey(ctx, createKeyRequest{
+		Provider:    "gemini",
+		ActualKey:   r.cfg.GeminiKey,
+		Description: "live-pii-wire-gemini-json-safety",
+		RedactPII:   &redactPII,
+	})
+	if err != nil {
+		return []Result{
+			failResult("pii", "wire-restore-gemini-json-safety", "create key: "+err.Error()),
+			failResult("pii", "wire-restore-gemini-json-safety-stream", "create key: "+err.Error()),
+		}
+	}
+	defer func() { _ = r.admin.DeleteKey(ctx, key.Key) }()
+
+	pr, body, err := r.proxy.GeminiChatRepeatQuotedName(ctx, key.Key, false)
+	var out []Result
+	if err != nil {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety", err.Error()))
+	} else if perr := proxyOK(pr); perr != nil {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety", perr.Error()))
+	} else if !json.Valid(body) {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety",
+			fmt.Sprintf("placeholder restore produced invalid JSON: %s", truncate(string(body), 300))))
+	} else if content, cerr := geminiAssistantContent(body); cerr == nil && !strings.Contains(content, quotedMultilineName) {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety",
+			fmt.Sprintf("expected restored name %q in assistant reply %q", quotedMultilineName, content)))
+	} else {
+		out = append(out, passResult("pii", "wire-restore-gemini-json-safety",
+			"quote/newline-bearing PERSON restored without corrupting response JSON", elapsed(start)))
+	}
+
+	start = time.Now()
+	pr, streamBody, err := r.proxy.GeminiChatRepeatQuotedName(ctx, key.Key, true)
+	if err != nil {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety-stream", err.Error()))
+		return out
+	}
+	if perr := proxyOK(pr); perr != nil {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety-stream", perr.Error()))
+		return out
+	}
+	if invalid, found := firstInvalidSSEDataJSON(streamBody); found {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety-stream",
+			fmt.Sprintf("placeholder restore produced invalid JSON in an SSE chunk: %s", truncate(invalid, 300))))
+	} else if !strings.Contains(string(streamBody), "Bob") {
+		out = append(out, failResult("pii", "wire-restore-gemini-json-safety-stream",
+			fmt.Sprintf("expected restored name fragments in stream body %q", truncate(string(streamBody), 200))))
+	} else {
+		out = append(out, passResult("pii", "wire-restore-gemini-json-safety-stream",
+			"quote/newline-bearing PERSON restored without corrupting any SSE chunk", elapsed(start)))
 	}
 	return out
 }

--- a/internal/middleware/pii_response.go
+++ b/internal/middleware/pii_response.go
@@ -71,8 +71,11 @@ func servePIIStreamingRestore(w http.ResponseWriter, r *http.Request, next http.
 	}
 	next.ServeHTTP(restoreWriter, r)
 
+	// flushCarryTail already restored the carry; write it directly so the
+	// stale carry is not prepended and re-held by the streaming path.
 	if tail := restoreWriter.flushCarryTail(); len(tail) > 0 {
-		_, _ = restoreWriter.Write(tail)
+		restoreWriter.carry = nil
+		_, _ = restoreWriter.writeRestored(tail)
 	}
 	finalizePIIRestored(r.Context(), reg)
 	finalizePIILeaked(r.Context(), reg, restoreWriter.emitted.String())

--- a/internal/middleware/pii_response.go
+++ b/internal/middleware/pii_response.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/Instawork/llm-proxy/internal/providers"
 	"github.com/Instawork/llm-proxy/internal/proxylog"
@@ -70,7 +71,7 @@ func servePIIStreamingRestore(w http.ResponseWriter, r *http.Request, next http.
 	}
 	next.ServeHTTP(restoreWriter, r)
 
-	if tail := reg.FlushCarry(restoreWriter.carry); len(tail) > 0 {
+	if tail := restoreWriter.flushCarryTail(); len(tail) > 0 {
 		_, _ = restoreWriter.Write(tail)
 	}
 	finalizePIIRestored(r.Context(), reg)
@@ -114,10 +115,48 @@ func logPIILeakIfNeeded(r *http.Request, streaming bool) {
 
 type piiRestoreResponseWriter struct {
 	http.ResponseWriter
-	registry  *redact.Registry
-	streaming bool
-	carry     []byte
-	emitted   bytes.Buffer
+	registry    *redact.Registry
+	streaming   bool
+	carry       []byte
+	emitted     bytes.Buffer
+	jsonMode    bool
+	jsonModeSet bool
+}
+
+// useJSONRestore decides, once per response, whether restored originals
+// need JSON-string escaping. Every provider response this proxy handles is
+// JSON (or JSON-per-SSE-line); the Content-Type sniff below only exists so
+// a genuinely plain-text response — none exist among current providers,
+// but nothing guarantees that stays true — falls back to the verbatim
+// restore instead of corrupting non-JSON bytes with stray backslashes.
+//
+// Content-Type is safe to read on the first Write: httputil.ReverseProxy
+// copies the upstream response headers onto pw.Header() before it starts
+// copying the body, for both buffered and streamed responses.
+func (pw *piiRestoreResponseWriter) useJSONRestore() bool {
+	if !pw.jsonModeSet {
+		pw.jsonMode = responseLooksLikeJSON(pw.Header().Get("Content-Type"))
+		pw.jsonModeSet = true
+	}
+	return pw.jsonMode
+}
+
+func (pw *piiRestoreResponseWriter) flushCarryTail() []byte {
+	if pw.useJSONRestore() {
+		return pw.registry.FlushCarryJSON(pw.carry)
+	}
+	return pw.registry.FlushCarry(pw.carry)
+}
+
+// responseLooksLikeJSON reports whether a response Content-Type carries a
+// JSON (or JSON-per-SSE-line) body. An empty Content-Type defaults to true
+// since every provider this proxy fronts responds with JSON by default.
+func responseLooksLikeJSON(contentType string) bool {
+	ct := strings.ToLower(contentType)
+	if ct == "" {
+		return true
+	}
+	return strings.Contains(ct, "json") || strings.Contains(ct, "event-stream")
 }
 
 func (pw *piiRestoreResponseWriter) Flush() {
@@ -158,14 +197,24 @@ func (pw *piiRestoreResponseWriter) Write(b []byte) (int, error) {
 			}
 			return len(b), nil
 		}
-		restored := pw.registry.RestoreUserFacing(string(plain))
+		var restored string
+		if pw.useJSONRestore() {
+			restored = pw.registry.RestoreUserFacingJSON(string(plain))
+		} else {
+			restored = pw.registry.RestoreUserFacing(string(plain))
+		}
 		if _, err := pw.writeRestored([]byte(restored)); err != nil {
 			return 0, err
 		}
 		return len(b), nil
 	}
 	if pw.streaming {
-		emit, newCarry := pw.registry.RestoreStreamChunk(b, pw.carry)
+		var emit, newCarry []byte
+		if pw.useJSONRestore() {
+			emit, newCarry = pw.registry.RestoreStreamChunkJSON(b, pw.carry)
+		} else {
+			emit, newCarry = pw.registry.RestoreStreamChunk(b, pw.carry)
+		}
 		pw.carry = newCarry
 		if len(emit) == 0 {
 			return len(b), nil

--- a/internal/middleware/pii_response_test.go
+++ b/internal/middleware/pii_response_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -95,6 +96,106 @@ func TestPIIResponseRestoreMiddleware_RestoresMaskNonStreaming(t *testing.T) {
 	mw.ServeHTTP(rec, req)
 
 	want := `{"content":"Jane Doe"}`
+	if rec.Body.String() != want {
+		t.Fatalf("body = %q want %q", rec.Body.String(), want)
+	}
+}
+
+// TestPIIResponseRestoreMiddleware_QuoteBearingPersonStaysValidJSON is the
+// end-to-end regression test for the production bug: a PERSON original
+// containing a double quote and a newline must not corrupt the JSON
+// response the client receives, even though the upstream handler here only
+// ever emits the placeholder (mirroring how the real upstream LLM only
+// sees a MASK placeholder, never the raw PII).
+func TestPIIResponseRestoreMiddleware_QuoteBearingPersonStaysValidJSON(t *testing.T) {
+	reg := redact.NewRegistry()
+	original := "Robert \"Bob\"\nJohnson"
+	ph := reg.Placeholder("PERSON", original)
+	pm := providers.NewProviderManager()
+	mw := PIIResponseRestoreMiddleware(pm)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"` + ph + `"}`))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/gemini/v1beta/models/gemini-2.5-flash:generateContent", nil)
+	req = req.WithContext(withPIIRegistry(req.Context(), reg))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	body := rec.Body.Bytes()
+	if !json.Valid(body) {
+		t.Fatalf("response is not valid JSON: %q", body)
+	}
+	var parsed struct{ Name string }
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (body %q)", err, body)
+	}
+	if parsed.Name != original {
+		t.Fatalf("Name = %q, want %q", parsed.Name, original)
+	}
+}
+
+// TestPIIResponseRestoreMiddleware_QuoteBearingPersonStaysValidJSONStreaming
+// is the streaming counterpart, using an SSE Content-Type as Gemini's
+// streamGenerateContent endpoint does.
+func TestPIIResponseRestoreMiddleware_QuoteBearingPersonStaysValidJSONStreaming(t *testing.T) {
+	reg := redact.NewRegistry()
+	original := "Robert \"Bob\"\nJohnson"
+	ph := reg.Placeholder("PERSON", original)
+	pm := providers.NewProviderManager()
+	mw := PIIResponseRestoreMiddleware(pm)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"name":"` + ph + `"}` + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/gemini/v1beta/models/gemini-2.5-flash:streamGenerateContent", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	req = req.WithContext(withPIIRegistry(req.Context(), reg))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		jsonData, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			continue
+		}
+		if jsonData == "" || jsonData == "[DONE]" {
+			continue
+		}
+		if !json.Valid([]byte(jsonData)) {
+			t.Fatalf("SSE data line is not valid JSON: %q (full body %q)", jsonData, rec.Body.String())
+		}
+		var parsed struct{ Name string }
+		if err := json.Unmarshal([]byte(jsonData), &parsed); err != nil {
+			t.Fatalf("unmarshal: %v (line %q)", err, jsonData)
+		}
+		if parsed.Name != original {
+			t.Fatalf("Name = %q, want %q", parsed.Name, original)
+		}
+	}
+}
+
+// TestPIIResponseRestoreMiddleware_PlainTextFallsBackToVerbatimRestore
+// checks that a non-JSON Content-Type is not JSON-escaped: a plain-text
+// response should get the original back byte-for-byte, matching
+// RestoreUserFacing rather than RestoreUserFacingJSON.
+func TestPIIResponseRestoreMiddleware_PlainTextFallsBackToVerbatimRestore(t *testing.T) {
+	reg := redact.NewRegistry()
+	original := "Robert \"Bob\" Johnson"
+	ph := reg.Placeholder("PERSON", original)
+	pm := providers.NewProviderManager()
+	mw := PIIResponseRestoreMiddleware(pm)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello " + ph))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+	req = req.WithContext(withPIIRegistry(req.Context(), reg))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	want := "hello " + original
 	if rec.Body.String() != want {
 		t.Fatalf("body = %q want %q", rec.Body.String(), want)
 	}

--- a/internal/middleware/pii_restore_hardening_test.go
+++ b/internal/middleware/pii_restore_hardening_test.go
@@ -141,6 +141,31 @@ func TestPIIResponseRestoreMiddleware_StreamingOmitsRestoredLeakedHeaders(t *tes
 	}
 }
 
+func TestPIIResponseRestoreMiddleware_StreamTailIncompletePlaceholderNotTruncated(t *testing.T) {
+	reg := redact.NewRegistry()
+	_ = reg.Placeholder("PERSON", "Jane Doe")
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(providers.NewOpenAIProxy())
+
+	// Ends mid-escape after a placeholder-like open: the whole suffix is held
+	// in the carry, and the end-of-stream flush must emit it verbatim exactly
+	// once rather than re-feeding it through the streaming Write path.
+	body := `data: {"text":"\u003cPII_PERSON_1\u00`
+	mw := PIIResponseRestoreMiddleware(pm)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	req = req.WithContext(withPIIRegistry(req.Context(), reg))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if rec.Body.String() != body {
+		t.Fatalf("body = %q, want %q", rec.Body.String(), body)
+	}
+}
+
 func TestPIIResponseRestoreMiddleware_NonStreamingRestoredInHeaders(t *testing.T) {
 	reg := redact.NewRegistry()
 	ph := reg.Placeholder("EMAIL_ADDRESS", "header@example.com")

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -25,12 +25,7 @@ func RateLimitingMiddleware(pm *providers.ProviderManager, cfg *config.YAMLConfi
 		return func(next http.Handler) http.Handler { return next }
 	}
 
-	estCfg := providers.YAMLConfigEstimationAdapter{
-		MaxSampleBytes:        cfg.Features.RateLimiting.Estimation.MaxSampleBytes,
-		BytesPerToken:         cfg.Features.RateLimiting.Estimation.BytesPerToken,
-		CharsPerToken:         cfg.Features.RateLimiting.Estimation.CharsPerToken,
-		ProviderCharsPerToken: cfg.Features.RateLimiting.Estimation.ProviderCharsPerToken,
-	}
+	estCfg := providers.NewYAMLConfigEstimationAdapter(cfg.Features.RateLimiting.Estimation)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/estimation_adapter_test.go
+++ b/internal/providers/estimation_adapter_test.go
@@ -1,0 +1,50 @@
+package providers
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewYAMLConfigEstimationAdapter_ZeroValueFillsDefaults(t *testing.T) {
+	a := NewYAMLConfigEstimationAdapter(config.EstimationConfig{})
+	assert.Equal(t, defaultEstimationMaxSampleBytes, a.GetMaxSampleBytes())
+	assert.Equal(t, defaultEstimationBytesPerToken, a.GetBytesPerToken())
+	assert.Equal(t, defaultEstimationCharsPerToken, a.GetCharsPerToken())
+}
+
+func TestNewYAMLConfigEstimationAdapter_PreservesExplicitValues(t *testing.T) {
+	a := NewYAMLConfigEstimationAdapter(config.EstimationConfig{
+		MaxSampleBytes:        1024,
+		BytesPerToken:         3,
+		CharsPerToken:         5,
+		ProviderCharsPerToken: map[string]int{"openai": 5},
+	})
+	assert.Equal(t, 1024, a.GetMaxSampleBytes())
+	assert.Equal(t, 3, a.GetBytesPerToken())
+	assert.Equal(t, 5, a.GetCharsPerToken())
+	assert.Equal(t, 5, a.GetProviderCharsPerToken("openai"))
+}
+
+// TestNewYAMLConfigEstimationAdapter_MissingBlockStillExtractsModel is the
+// regression test for the production bug: a wholly absent
+// rate_limiting.estimation block (config.EstimationConfig{}, its YAML zero
+// value) used to leave MaxSampleBytes at 0, which made
+// EstimateRequestTokens treat every non-empty request body as too large to
+// sample and never extract a model name. Building the adapter through the
+// shared constructor must keep model extraction working even with no
+// estimation config at all.
+func TestNewYAMLConfigEstimationAdapter_MissingBlockStillExtractsModel(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello world"}]}`)
+	req, _ := http.NewRequest("POST", "/openai/v1/chat/completions", bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	adapter := NewYAMLConfigEstimationAdapter(config.EstimationConfig{})
+	n, model := EstimateRequestTokens(req, adapter, NewOpenAIProxy())
+	assert.Equal(t, "gpt-4o", model)
+	assert.Greater(t, n, 0)
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Instawork/llm-proxy/internal/config"
 	"github.com/gorilla/mux"
 )
 
@@ -390,6 +391,43 @@ func (a YAMLConfigEstimationAdapter) GetProviderCharsPerToken(provider string) i
 		return v
 	}
 	return 0
+}
+
+// Fallback defaults applied by NewYAMLConfigEstimationAdapter whenever a
+// field is left at its YAML zero value — i.e. an absent or partially
+// specified rate_limiting.estimation block behaves like the tuned defaults
+// below, not like "estimation disabled".
+const (
+	defaultEstimationMaxSampleBytes = 200000
+	defaultEstimationBytesPerToken  = 4
+	defaultEstimationCharsPerToken  = 4
+)
+
+// NewYAMLConfigEstimationAdapter builds a YAMLConfigEstimationAdapter from
+// config.EstimationConfig, applying the fallback defaults above to any
+// zero-valued field. Every one of Features.RateLimiting.Estimation's three
+// consumers — rate limiting, cost-limit reservations, and fake-upstream
+// request sizing — must build its adapter through this constructor rather
+// than copying fields directly, so a missing YAML block can't silently
+// zero out MaxSampleBytes and disable model-name extraction for
+// EstimateRequestTokens (see provider.go EstimateRequestTokens).
+func NewYAMLConfigEstimationAdapter(cfg config.EstimationConfig) YAMLConfigEstimationAdapter {
+	a := YAMLConfigEstimationAdapter{
+		MaxSampleBytes:        cfg.MaxSampleBytes,
+		BytesPerToken:         cfg.BytesPerToken,
+		CharsPerToken:         cfg.CharsPerToken,
+		ProviderCharsPerToken: cfg.ProviderCharsPerToken,
+	}
+	if a.MaxSampleBytes == 0 {
+		a.MaxSampleBytes = defaultEstimationMaxSampleBytes
+	}
+	if a.BytesPerToken == 0 {
+		a.BytesPerToken = defaultEstimationBytesPerToken
+	}
+	if a.CharsPerToken == 0 {
+		a.CharsPerToken = defaultEstimationCharsPerToken
+	}
+	return a
 }
 
 // EstimateRequestTokens returns (estimatedTokens, model)

--- a/internal/redact/registry.go
+++ b/internal/redact/registry.go
@@ -2,6 +2,7 @@ package redact
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -223,8 +224,31 @@ func countPlaceholderForms(text string, forms []string) int {
 }
 
 // RestoreUserFacing replaces MASK-tier placeholders with their original
-// values. SEAL placeholders and REDACT markers are left unchanged.
+// values, spliced in verbatim with no escaping. SEAL placeholders and
+// REDACT markers are left unchanged.
+//
+// Every provider response this proxy restores (OpenAI, Anthropic, Gemini,
+// Bedrock — streamed or not) is JSON, or JSON-per-SSE-line, on the wire. A
+// MASK original containing a quote, backslash, or control character (a
+// nickname like `Robert "Bob" Johnson`, an address with an embedded
+// newline) spliced in verbatim breaks the enclosing JSON string and
+// produces a response the client cannot parse. Callers restoring inside a
+// JSON (or JSON-per-line) body must use RestoreUserFacingJSON instead; this
+// verbatim form only belongs on genuinely plain-text responses.
 func (r *Registry) RestoreUserFacing(text string) string {
+	return r.restoreUserFacing(text, false)
+}
+
+// RestoreUserFacingJSON is the JSON-safe counterpart to RestoreUserFacing:
+// each restored original is escaped as a JSON string fragment (quotes,
+// backslashes, control characters) before being spliced back in, so the
+// result stays valid JSON even when the original value itself is not
+// JSON-string-safe.
+func (r *Registry) RestoreUserFacingJSON(text string) string {
+	return r.restoreUserFacing(text, true)
+}
+
+func (r *Registry) restoreUserFacing(text string, jsonEscape bool) string {
 	if r == nil || text == "" {
 		return text
 	}
@@ -246,14 +270,41 @@ func (r *Registry) RestoreUserFacing(text string) string {
 		if !ok || entry.policy != PolicyMask {
 			continue
 		}
+		original := entry.original
+		if jsonEscape {
+			original = jsonEscapeString(original)
+		}
 		var delta int
-		out, delta = applyWireFormReplacements(out, entry.wireForms, entry.original)
+		out, delta = applyWireFormReplacements(out, entry.wireForms, original)
 		restoredDelta += delta
 	}
 	if restoredDelta > 0 {
 		r.mu.Lock()
 		r.restoredCount += restoredDelta
 		r.mu.Unlock()
+	}
+	return out
+}
+
+// jsonEscapeString returns s escaped as the interior of a JSON string
+// literal — quotes, backslashes, and control characters (including
+// newlines) — without the surrounding quotes and without Go's default
+// HTML-safe escaping of <, >, and &. Those three are legal unescaped inside
+// a JSON string; skipping that extra escaping keeps a restored original
+// byte-for-byte outside of the characters that actually require it.
+func jsonEscapeString(s string) string {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		// encoding/json only errors on unsupported types, never on strings;
+		// this is unreachable in practice. Fall back to the verbatim value
+		// rather than dropping the restore entirely.
+		return s
+	}
+	out := strings.TrimSuffix(buf.String(), "\n")
+	if len(out) >= 2 && out[0] == '"' && out[len(out)-1] == '"' {
+		return out[1 : len(out)-1]
 	}
 	return out
 }
@@ -392,7 +443,20 @@ func streamSafePrefixLen(combined []byte) int {
 
 // RestoreStreamChunk restores MASK placeholders in a streaming chunk,
 // holding back a suffix that might be an incomplete placeholder token.
+// Restored originals are spliced in verbatim; see RestoreUserFacing for why
+// that is only correct for genuinely plain-text streams.
 func (r *Registry) RestoreStreamChunk(chunk []byte, carry []byte) (emit []byte, newCarry []byte) {
+	return r.restoreStreamChunk(chunk, carry, false)
+}
+
+// RestoreStreamChunkJSON is the JSON-safe counterpart to RestoreStreamChunk;
+// see RestoreUserFacingJSON. Use this for SSE streams, where each "data: "
+// line is itself a JSON payload.
+func (r *Registry) RestoreStreamChunkJSON(chunk []byte, carry []byte) (emit []byte, newCarry []byte) {
+	return r.restoreStreamChunk(chunk, carry, true)
+}
+
+func (r *Registry) restoreStreamChunk(chunk []byte, carry []byte, jsonEscape bool) (emit []byte, newCarry []byte) {
 	combined := append(append([]byte(nil), carry...), chunk...)
 	safeLen := streamSafePrefixLen(combined)
 	toProcess := combined[:safeLen]
@@ -401,16 +465,26 @@ func (r *Registry) RestoreStreamChunk(chunk []byte, carry []byte) (emit []byte, 
 		toProcess = combined
 		newCarry = nil
 	}
-	restored := r.RestoreUserFacing(string(toProcess))
+	restored := r.restoreUserFacing(string(toProcess), jsonEscape)
 	return []byte(restored), newCarry
 }
 
-// FlushCarry restores any bytes held back at the end of a stream.
+// FlushCarry restores any bytes held back at the end of a stream, verbatim;
+// see RestoreUserFacing.
 func (r *Registry) FlushCarry(carry []byte) []byte {
+	return r.flushCarry(carry, false)
+}
+
+// FlushCarryJSON is the JSON-safe counterpart to FlushCarry.
+func (r *Registry) FlushCarryJSON(carry []byte) []byte {
+	return r.flushCarry(carry, true)
+}
+
+func (r *Registry) flushCarry(carry []byte, jsonEscape bool) []byte {
 	if len(carry) == 0 {
 		return nil
 	}
-	return []byte(r.RestoreUserFacing(string(carry)))
+	return []byte(r.restoreUserFacing(string(carry), jsonEscape))
 }
 
 // Len returns the number of registered placeholders (MASK + SEAL).

--- a/internal/redact/registry_test.go
+++ b/internal/redact/registry_test.go
@@ -2,6 +2,7 @@ package redact
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -212,6 +213,121 @@ func TestRegistry_RestoreStreamChunk_EscapedFormSplit(t *testing.T) {
 	parts2 := []string{"x " + escaped2[:cut2], escaped2[cut2:] + " y"}
 	if got := streamRestore(reg2, parts2); got != "x Bob y" {
 		t.Fatalf("mid-escape stream restore = %q want %q", got, "x Bob y")
+	}
+}
+
+// TestRegistry_RestoreUserFacing_QuoteBreaksRawJSON documents the bug: the
+// verbatim restore splices an original containing a JSON-special character
+// straight into the byte stream, so a caller that treats the input as JSON
+// ends up with invalid JSON on the wire. RestoreUserFacing is for plain-text
+// callers only — see RestoreUserFacingJSON for the JSON-safe counterpart
+// used on every provider response.
+func TestRegistry_RestoreUserFacing_QuoteBreaksRawJSON(t *testing.T) {
+	reg := NewRegistry()
+	ph := reg.Placeholder("PERSON", `Robert "Bob" Johnson`)
+	in := `{"name": "` + ph + `"}`
+	out := reg.RestoreUserFacing(in)
+	if json.Valid([]byte(out)) {
+		t.Fatalf("expected verbatim restore to produce invalid JSON, got valid: %q", out)
+	}
+}
+
+// TestRegistry_RestoreUserFacingJSON_EscapesQuotes is the fix: restoring
+// the same PERSON through the JSON-safe path keeps the response valid JSON
+// and still yields the original name once unmarshaled.
+func TestRegistry_RestoreUserFacingJSON_EscapesQuotes(t *testing.T) {
+	reg := NewRegistry()
+	original := `Robert "Bob" Johnson`
+	ph := reg.Placeholder("PERSON", original)
+	in := `{"name": "` + ph + `"}`
+	out := reg.RestoreUserFacingJSON(in)
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("RestoreUserFacingJSON produced invalid JSON: %q", out)
+	}
+	var parsed struct{ Name string }
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (body %q)", err, out)
+	}
+	if parsed.Name != original {
+		t.Fatalf("Name = %q, want %q", parsed.Name, original)
+	}
+}
+
+// TestRegistry_RestoreUserFacingJSON_EscapesNewlineAndBackslash covers the
+// exact production failure mode: "invalid character '\n' in string
+// literal", plus a literal backslash which would otherwise start a bogus
+// escape sequence.
+func TestRegistry_RestoreUserFacingJSON_EscapesNewlineAndBackslash(t *testing.T) {
+	reg := NewRegistry()
+	original := "123 Main St\\nApt 4\nSpringfield"
+	ph := reg.Placeholder("LOCATION", original)
+	in := `{"address": "` + ph + `"}`
+	out := reg.RestoreUserFacingJSON(in)
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("RestoreUserFacingJSON produced invalid JSON: %q", out)
+	}
+	var parsed struct{ Address string }
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (body %q)", err, out)
+	}
+	if parsed.Address != original {
+		t.Fatalf("Address = %q, want %q", parsed.Address, original)
+	}
+}
+
+// TestRegistry_RestoreUserFacingJSON_DoesNotEscapeAngleBrackets checks that
+// the JSON-safe restore does not add Go's default HTML-safe escaping on top
+// of the required JSON escaping — angle brackets and ampersands are legal
+// unescaped inside a JSON string and should come back byte-for-byte.
+func TestRegistry_RestoreUserFacingJSON_DoesNotEscapeAngleBrackets(t *testing.T) {
+	reg := NewRegistry()
+	original := "Bourne & Hollingsworth <legal name>"
+	ph := reg.Placeholder("PERSON", original)
+	in := `{"name": "` + ph + `"}`
+	out := reg.RestoreUserFacingJSON(in)
+	if !strings.Contains(out, original) {
+		t.Fatalf("expected verbatim angle brackets/ampersand in %q", out)
+	}
+	var parsed struct{ Name string }
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (body %q)", err, out)
+	}
+	if parsed.Name != original {
+		t.Fatalf("Name = %q, want %q", parsed.Name, original)
+	}
+}
+
+// TestRegistry_RestoreStreamChunkJSON_QuoteSplitAcrossChunks exercises the
+// streaming path end to end: the placeholder itself is split across chunk
+// boundaries (already covered elsewhere), and once restored the
+// quote-bearing original must not break the JSON accumulated so far.
+func TestRegistry_RestoreStreamChunkJSON_QuoteSplitAcrossChunks(t *testing.T) {
+	reg := NewRegistry()
+	original := `Robert "Bob" Johnson`
+	ph := reg.Placeholder("PERSON", original)
+	parts := []string{`{"name": "` + ph[:4], ph[4:] + `"}`}
+
+	var carry []byte
+	var got strings.Builder
+	for _, part := range parts {
+		emit, newCarry := reg.RestoreStreamChunkJSON([]byte(part), carry)
+		carry = newCarry
+		got.Write(emit)
+	}
+	if tail := reg.FlushCarryJSON(carry); len(tail) > 0 {
+		got.Write(tail)
+	}
+
+	out := got.String()
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("streamed JSON restore produced invalid JSON: %q", out)
+	}
+	var parsed struct{ Name string }
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (body %q)", err, out)
+	}
+	if parsed.Name != original {
+		t.Fatalf("Name = %q, want %q", parsed.Name, original)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three real production bugs found in CloudWatch Insights, all from the same investigation:

1. **PII placeholder restore corrupts JSON responses.** `RestoreUserFacing` spliced MASK-tier PII originals (PERSON, EMAIL, LOCATION, etc.) back into response bytes verbatim. When an original contains a quote, backslash, or newline, the restored response is no longer valid JSON — matching `failed to parse Gemini response: invalid character '\n' in string literal`, seen 342 times in 2 days against 663 Gemini requests with a detected entity. The upstream model never sees the raw PII, only the placeholder, so the corruption is introduced entirely by the proxy's restore step, and it reaches real clients.

   Fix: add `RestoreUserFacingJSON` / `RestoreStreamChunkJSON` / `FlushCarryJSON`, which JSON-escape each restored original before splicing it back in. `pii_response.go` now sniffs the response `Content-Type` once per response and uses the JSON-safe path for JSON/SSE bodies (every provider this proxy fronts), falling back to the verbatim restore only for genuinely non-JSON responses.

2. **Production is missing the `rate_limiting.estimation` config block.** With every estimation field at zero, `EstimateRequestTokens` treats any non-empty request body as too large to sample and never extracts a model name. The cost-limit middleware's reservation path then always prices an empty model, which fails pricing lookup and returns a zero estimate — silently skipping the cluster-wide reservation added in #43 for any key with a cost limit configured, and falling back to the older, racier read-recorded-spend enforcement. Rate-limit token estimation has the same gap wherever rate limiting is enabled.

   Fix: add the missing `estimation` block to `configs/production.yml`, and hoist the zero-value defaults that only lived in `fakeConfigFromYAML` into `providers.NewYAMLConfigEstimationAdapter`, used at all three call sites that read `Features.RateLimiting.Estimation` (fake-upstream sizing, cost-limit reservations, rate limiting).

3. **Oversized PII-redact bodies 503 silently, with no attached alert.** `pii_redact.max_body_bytes` was unset, falling back to the 1 MiB default. With `fail_mode: "closed"`, any body over that limit 503s instead of skipping redaction — on 8/3 a caller retried a 1,092,866-byte Anthropic body 42 times, every attempt 503ing.

   Fix: set `max_body_bytes` to 2 MiB in `configs/production.yml`, clearing the largest observed payload with headroom. The paired Datadog monitor widening (instawork/infrastructure) makes this outcome alertable going forward.

Also adds a live Gemini PII-wire-restore case (`integration/live`) that reproduces the JSON corruption end to end through a running proxy, for use with `make test-live-pii`.

## Test plan

- [x] `make test` (full unit suite, race detector) passes
- [x] New unit coverage in `internal/redact` proves the raw-restore bug and the JSON-safe fix (quotes, newlines, backslashes, angle brackets, streaming across chunk boundaries)
- [x] New unit coverage in `internal/middleware` exercises `PIIResponseRestoreMiddleware` end to end (non-streaming, SSE streaming, and the plain-text Content-Type fallback)
- [x] New unit coverage in `internal/providers` for `NewYAMLConfigEstimationAdapter` (zero-value defaults, explicit overrides, and a regression proving model extraction works with a wholly absent estimation config)
- [x] New regression tests in `cmd/llm-proxy` load the real `configs/production.yml` and assert the `estimation` block and `max_body_bytes` are set
- [ ] `make test-live-pii LIVE_ARGS="-suite pii,gemini -verbose"` against a real Gemini key — not run in this environment (no `GEMINI_API_KEY`/`.env` available); please run this before merging to confirm the new `wire-restore-gemini-json-safety` case passes live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - PII redaction restoration now safely preserves names containing quotes, newlines, and backslashes in JSON and streaming responses.
  - Streaming event data remains valid JSON, including values split across chunks.
  - Incomplete streaming placeholders are preserved without truncation or duplication.
  - Plain-text responses continue to restore content without JSON escaping.

- **Configuration**
  - Improved request token-estimation defaults and production rate-limit settings.
  - Increased the explicitly supported PII-redaction request body size to 2 MiB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->