### PR TITLE
chore(config): add Claude Sonnet 5 and Opus 4.8 to bedrock-mantle

### DIFF
--- a/configs/base.yml
+++ b/configs/base.yml
@@ -1157,6 +1157,17 @@ providers:
         pricing:
           input: 1.00
           output: 5.00
+      # Mantle catalog ID (short form). Same pricing as bedrock us.anthropic.claude-sonnet-5.
+      "anthropic.claude-sonnet-5":
+        enabled: true
+        aliases: ["claude-sonnet-5-bedrock", "claude-sonnet-5-bedrock-thinking"]
+        pricing:
+          - threshold: 200_000
+            input: 3.00
+            output: 15.00
+          - threshold: 0
+            input: 6.00
+            output: 22.50
 
   # ---------------------------------------------------------------------------
   # GOOGLE GEMINI PROVIDER

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -1157,18 +1157,21 @@ providers:
         pricing:
           input: 1.00
           output: 5.00
-      # Mantle catalog ID (short form). Same pricing as bedrock us.anthropic.claude-sonnet-5.
+      # Mantle catalog IDs (short form). Pricing mirrors the matching bedrock SKUs.
       # Aliases omit *-bedrock (owned by the bedrock provider) to keep them globally unique.
       "anthropic.claude-sonnet-5":
         enabled: true
         aliases: ["claude-sonnet-5"]
+        # Flat $3/$15 — Sonnet 5 includes 1M context at standard pricing.
         pricing:
-          - threshold: 200_000
-            input: 3.00
-            output: 15.00
-          - threshold: 0
-            input: 6.00
-            output: 22.50
+          input: 3.00
+          output: 15.00
+      "anthropic.claude-opus-4-8":
+        enabled: true
+        aliases: ["claude-opus-4-8"]
+        pricing:
+          input: 6.00
+          output: 30.00
 
   # ---------------------------------------------------------------------------
   # GOOGLE GEMINI PROVIDER

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -1158,9 +1158,10 @@ providers:
           input: 1.00
           output: 5.00
       # Mantle catalog ID (short form). Same pricing as bedrock us.anthropic.claude-sonnet-5.
+      # Aliases omit *-bedrock (owned by the bedrock provider) to keep them globally unique.
       "anthropic.claude-sonnet-5":
         enabled: true
-        aliases: ["claude-sonnet-5-bedrock", "claude-sonnet-5-bedrock-thinking"]
+        aliases: ["claude-sonnet-5"]
         pricing:
           - threshold: 200_000
             input: 3.00


### PR DESCRIPTION
## Summary
- Adds Mantle catalog IDs `anthropic.claude-sonnet-5` and `anthropic.claude-opus-4-8` under `providers.bedrock-mantle.models` (aliases avoid the `*-bedrock` names already owned by the bedrock provider).
- Sonnet 5 pricing is flat `$3/$15`, matching the native Anthropic and classic Bedrock entries (not the retired long-context tiers).
- Stops Model Status from flagging live Mantle traffic for these slugs as unknown, and enables cost lookup.

## Test plan
- [x] `make validate-config`
- [ ] After deploy, Unknown model calls for `bedrock-mantle` / `anthropic.claude-sonnet-5` and `anthropic.claude-opus-4-8` should clear for new traffic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic Claude Sonnet 5 and Claude Opus 4.8 through the AWS Bedrock Mantle provider.
  * Included model aliases and flat input/output pricing:
    * Claude Sonnet 5: $3/$15
    * Claude Opus 4.8: $6/$30
<!-- end of auto-generated comment: release notes by coderabbit.ai -->