### PR TITLE
circuit: don't credit caller-shortened timeout budgets to the breaker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,6 +217,11 @@ degraded 503 before its own timeout fires — otherwise it would see a bare
 timeout with no failover signal. A watchdog cancels only the in-flight
 attempt if headers haven't arrived by the deadline; once headers arrive the
 watchdog is disarmed, so a streaming response keeps flowing past the budget.
+A budget the caller shortened does **not** count toward the breaker's failure
+window — one impatient caller must not fast-fail every other caller of a
+provider that is merely slower than its deadline. Only a wait that reached the
+provider's own `response_header_timeout_seconds`, or lasted at least
+`hang_disconnect_failure_seconds`, is credited as provider degradation.
 
 Redis store failures fail open so a dead Redis never takes the proxy down.
 

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -106,6 +106,9 @@ features:
   # would otherwise fire silently. Only takes effect when circuit_breaker is
   # enabled, since the breaker's retry loop is what enforces it; a streaming
   # response that starts before the budget elapses keeps flowing after it.
+  # A shortened budget elapsing is reported to that caller but not credited to
+  # the shared breaker (see circuit_breaker.hang_disconnect_failure_seconds),
+  # so one impatient caller cannot fast-fail everyone else.
   upstream:
     response_header_timeout_seconds: 300
   # ---------------------------------------------------------------------------

--- a/internal/circuit/classifier.go
+++ b/internal/circuit/classifier.go
@@ -536,6 +536,8 @@ const (
 	// FailureClassDegraded (see errTimeoutBudgetExceeded) since the whole
 	// point of the budget is to surface a provider degradation signal
 	// before the caller's own deadline would otherwise fire silently.
+	// A budget the caller shortened is NOT credited to the breaker, though —
+	// see budgetAbortCredits for which waits count as real degradation.
 	KindTimeoutBudgetExceeded FailureKind = "timeout_budget_exceeded"
 
 	// KindClientDisconnectAwaitingHeaders marks a caller disconnect that

--- a/internal/circuit/timeout_budget.go
+++ b/internal/circuit/timeout_budget.go
@@ -83,6 +83,33 @@ func timeoutBudgetFromRequest(req *http.Request, ceiling time.Duration) (budget 
 	return budget, true
 }
 
+// budgetAbortCredits reports whether a RoundTrip we aborted at budget should
+// count toward the breaker's failure window.
+//
+// A caller-shortened budget elapsing says the CALLER gave up early, not that
+// the provider is broken: a router deciding it wants an answer within 15s
+// learns nothing about a provider that reliably answers in 20s. Crediting
+// those would let any one caller with a short budget open the shared breaker
+// and fast-fail every other caller of that provider — including callers whose
+// own budget would have waited happily.
+//
+// Two waits do say something real and stay credited:
+//   - budget >= ceiling: the caller never shortened anything, so this abort is
+//     the provider's own response_header_timeout firing.
+//   - budget >= HangDisconnectFailureSeconds: a pre-headers wait that long is
+//     a hang in its own right, which is the same judgement the
+//     hang_disconnect_failure_seconds carve-out already makes for a caller
+//     that disconnects mid-hang.
+func budgetAbortCredits(budget, ceiling time.Duration, hangDisconnectSeconds int) bool {
+	if ceiling > 0 && budget >= ceiling {
+		return true
+	}
+	if hangDisconnectSeconds <= 0 {
+		return false
+	}
+	return budget >= time.Duration(hangDisconnectSeconds)*time.Second
+}
+
 // hasTimeoutBudgetMarkers returns true if req carries the timeout-budget
 // header or query param, regardless of whether the value is usable —
 // mirrors hasBypassMarkers so an unparsable value still gets stripped
@@ -129,8 +156,10 @@ func stripTimeoutBudgetMarkers(req *http.Request) *http.Request {
 // caller's timeout budget elapsed while still awaiting response headers.
 // Deliberately distinct from context.Canceled (which classifyNetworkError
 // does not credit to the breaker — that carve-out is for an ordinary client
-// disconnect): this IS a provider-degradation signal, so classifyNetworkError
-// falls through to its "unknown transport error => degraded" default for it.
+// disconnect): this caller still needs the tagged degraded 503 to fail over
+// on, so classifyNetworkError falls through to its "unknown transport error
+// => degraded" default for it. Whether it also counts toward the breaker's
+// failure window is a separate question — see budgetAbortCredits.
 var errTimeoutBudgetExceeded = errors.New("circuit: timeout budget exceeded while awaiting response headers")
 
 // roundTripWithBudget runs a single RoundTrip attempt but aborts it if

--- a/internal/circuit/timeout_budget_test.go
+++ b/internal/circuit/timeout_budget_test.go
@@ -278,6 +278,88 @@ func TestHasTimeoutBudgetMarkers_DetectsPresentButEmptyHeader(t *testing.T) {
 	require.True(t, hasTimeoutBudgetMarkers(req))
 }
 
+// newBudgetCreditTestTransport mirrors newTimeoutBudgetTestTransport but exposes
+// the store and lets the test set the two knobs that decide whether a budget
+// abort reaches the breaker: the provider's ceiling and
+// hang_disconnect_failure_seconds.
+func newBudgetCreditTestTransport(inner http.RoundTripper, ceiling time.Duration, hangSeconds int) (*Transport, Store) {
+	cfg := Config{
+		Enabled:                      true,
+		Mode:                         ModeEnforce,
+		FailureThreshold:             2,
+		WindowSeconds:                60,
+		CooldownSeconds:              300,
+		MaxTransientRetries:          2,
+		MaxRateLimitRetries:          1,
+		HangDisconnectFailureSeconds: hangSeconds,
+	}.Defaults()
+	store := NewMemoryStore(cfg)
+	return NewTransport(inner, store, cfg, "openai", nil, WithMaxTimeoutBudget(ceiling)), store
+}
+
+func hangingRoundTripper() http.RoundTripper {
+	return roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})
+}
+
+func TestTransport_TimeoutBudget_ShortBudgetNeverOpensBreaker(t *testing.T) {
+	// A caller that wants an answer in 1s learns nothing about a provider whose
+	// own timeout is 300s — otherwise one impatient caller could open the shared
+	// breaker and fast-fail every other caller of this provider.
+	tr, store := newBudgetCreditTestTransport(hangingRoundTripper(), 300*time.Second, 60)
+
+	for i := 0; i < 3; i++ {
+		resp, err := tr.RoundTrip(budgetRequest("1000"))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		require.Contains(t, string(body), DefaultDegradedSignal, "caller still needs the tagged 503 to fail over")
+	}
+
+	state, err := store.GetState(context.Background(), "openai")
+	require.NoError(t, err)
+	require.Equal(t, StateClosed, state)
+}
+
+func TestTransport_TimeoutBudget_CeilingBudgetStillOpensBreaker(t *testing.T) {
+	// Budget == the provider's ceiling: the caller shortened nothing, so this
+	// abort is the provider's own response-header timeout firing.
+	tr, store := newBudgetCreditTestTransport(hangingRoundTripper(), 1*time.Second, 60)
+
+	for i := 0; i < 2; i++ {
+		resp, err := tr.RoundTrip(budgetRequest("1000"))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	}
+
+	state, err := store.GetState(context.Background(), "openai")
+	require.NoError(t, err)
+	require.Equal(t, StateOpen, state)
+}
+
+func TestBudgetAbortCredits(t *testing.T) {
+	const ceiling = 300 * time.Second
+	for _, tc := range []struct {
+		name           string
+		budget         time.Duration
+		hangSeconds    int
+		expectCredited bool
+	}{
+		{"router-sized budget stays uncredited", 15 * time.Second, 60, false},
+		{"budget past the hang threshold is a real hang", 90 * time.Second, 60, true},
+		{"budget at the hang threshold is a real hang", 60 * time.Second, 60, true},
+		{"budget at the ceiling is the provider's own timeout", ceiling, 60, true},
+		{"hang crediting disabled leaves short budgets uncredited", 90 * time.Second, 0, false},
+		{"hang crediting disabled still credits the ceiling", ceiling, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectCredited, budgetAbortCredits(tc.budget, ceiling, tc.hangSeconds))
+		})
+	}
+}
+
 func TestTransport_TimeoutBudget_NoHeaderBehavesUnchanged(t *testing.T) {
 	// No header/param at all: behaviour must be identical to the feature
 	// not existing, even with a ceiling configured.

--- a/internal/circuit/transport.go
+++ b/internal/circuit/transport.go
@@ -29,6 +29,17 @@ var errRetryBodyTooLarge = errors.New("circuit: request body exceeds MaxRetryabl
 // down to the inner transport (used by the test-mode transport).
 type retryAttemptKey struct{}
 
+// timeoutBudgetKey carries the caller-requested header-wait budget for the
+// in-flight request, so the failure-recording paths can tell a caller-shortened
+// abort from the provider's own timeout without threading the value through
+// every handler signature.
+type timeoutBudgetKey struct{}
+
+func timeoutBudgetFromContext(ctx context.Context) (time.Duration, bool) {
+	budget, ok := ctx.Value(timeoutBudgetKey{}).(time.Duration)
+	return budget, ok
+}
+
 // Transport wraps an inner http.RoundTripper with circuit-breaker logic:
 //
 //   - checks the circuit state before every logical request;
@@ -950,6 +961,9 @@ func (t *Transport) runWithRetries(req *http.Request) (*http.Response, error) {
 	if hasTimeoutBudgetMarkers(req) {
 		req = stripTimeoutBudgetMarkers(req)
 	}
+	if hasBudget {
+		req = req.WithContext(context.WithValue(req.Context(), timeoutBudgetKey{}, budget))
+	}
 
 	ctx := req.Context()
 	startedAt := time.Now()
@@ -1270,6 +1284,20 @@ func (t *Transport) recordHangAbort(req *http.Request, key string, err error, wa
 	t.emit("hang_disconnect_abort", fc)
 }
 
+// creditsBreaker reports whether fc should count toward the breaker's failure
+// window for this request. Everything except a caller-shortened timeout-budget
+// abort does; see budgetAbortCredits for why that one does not.
+func (t *Transport) creditsBreaker(req *http.Request, fc failureContext) bool {
+	if fc.Kind != KindTimeoutBudgetExceeded || req == nil {
+		return true
+	}
+	budget, ok := timeoutBudgetFromContext(req.Context())
+	if !ok {
+		return true
+	}
+	return budgetAbortCredits(budget, t.maxTimeoutBudget, t.cfg.HangDisconnectFailureSeconds)
+}
+
 // retryLoopState is the mutable per-iteration state runWithRetries
 // hands to the per-failure-class handlers below.  It exists so the
 // handlers can update attempt counters and remember the most recent
@@ -1375,15 +1403,15 @@ func (t *Transport) handleDegradedFailure(
 ) (*http.Response, error, bool) {
 	switch t.cfg.RetryContributionMode {
 	case "on":
+		evt := t.enrichedFailureContext(req, resp, err, st.lastUpstreamError)
+		if !t.creditsBreaker(req, evt) {
+			break
+		}
 		t.log.Info("circuit: retried failure contributing to degradation score",
-			append(t.enrichedFailureContext(req, resp, err, st.lastUpstreamError).attrs(),
-				"attempt", st.transientAttempts)...)
+			append(evt.attrs(), "attempt", st.transientAttempts)...)
 		_, openedNow, _ := t.store.RecordTerminalFailure(ctx, key)
 		if openedNow {
-			t.emitOpened(
-				t.enrichedFailureContext(req, resp, err, st.lastUpstreamError),
-				"threshold",
-			)
+			t.emitOpened(evt, "threshold")
 		}
 		t.maybeRecordRollup(ctx, key, openedNow)
 	case "log":
@@ -1665,6 +1693,12 @@ func (t *Transport) recordProbeFailure(ctx context.Context, req *http.Request, r
 // parsed from the response body before drain.
 func (t *Transport) handleTerminalFailure(ctx context.Context, req *http.Request, key string, lastResp *http.Response, lastErr error, upstreamError string) (*http.Response, error) {
 	evt := t.enrichedFailureContext(req, lastResp, lastErr, upstreamError)
+	if !t.creditsBreaker(req, evt) {
+		t.log.Warn(proxylog.UpstreamMsg("circuit: caller's timeout budget elapsed short of a provider timeout; returning degraded signal without crediting the breaker"),
+			append(evt.attrs(), "mode", ModeEnforce)...)
+		t.emit("timeout_budget_uncredited", evt)
+		return t.degradedResponse(req, true), nil
+	}
 	newState, openedNow, err := t.store.RecordTerminalFailure(ctx, key)
 	if err != nil {
 		t.log.Error(proxylog.ProxyMsg("circuit: RecordTerminalFailure error"), "key", key, "error", err)


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

## Summary

Follow-up to #51. A caller-shortened `X-LLM-Proxy-Timeout-Ms` budget elapsing was credited to the circuit breaker as provider degradation. That means any single caller with a short budget can open the shared Redis-backed breaker for a provider and fast-fail every *other* caller of it — including callers whose own budget (or no budget at all) would have waited happily for a provider that is merely slower than one caller's deadline.

This is not hypothetical. While verifying finch's side of the feature (Instawork/finch#2064) against production, five requests carrying a deliberate 1s budget opened the `anthropic` and `gemini` breakers; `llm.circuit.fast_fail` shows roughly 117 Anthropic and 254 Gemini unrelated production requests fast-failed between 15:23 and 15:29 UTC before the cooldown expired and the breakers closed on their own.

The distinction the breaker needs is "did this wait tell us anything about the provider?", so `budgetAbortCredits` credits an abort only when:

- **`budget >= ceiling`** — the caller shortened nothing, so the abort *is* the provider's own `response_header_timeout_seconds` firing; or
- **`budget >= hang_disconnect_failure_seconds`** — a pre-headers wait that long is a hang in its own right, which is exactly the judgement the `KindClientDisconnectAwaitingHeaders` carve-out from #50 already makes for a caller that disconnects mid-hang.

Everything else (a router-sized 15s budget against a 300s provider ceiling) reports to that one caller and stops there.

## Implementation notes

- The caller still receives the tagged `[LLM_PROXY_PROVIDER_DEGRADED]` 503 in every case, so downstream failover behaviour is unchanged — only the `RecordTerminalFailure` store write is skipped.
- Gated at both recording paths: `handleTerminalFailure` and the `retry_contribution_mode: "on"` branch of `handleDegradedFailure`. The half-open probe path needs no change because `runProbe` strips the budget markers and round-trips without a budget, so a probe can never abort this way.
- The budget rides on the request context (`timeoutBudgetKey`, mirroring the existing `retryAttemptKey`) rather than being threaded through five handler signatures.
- Skipped aborts emit a distinct `timeout_budget_uncredited` event plus a warn-level log, so the decision is visible on dashboards instead of silently vanishing from `terminal_failure`.
- No config change required: the rule reuses the ceiling and `hang_disconnect_failure_seconds` that production already sets (300s and 60s).

## Test plan

- [x] New unit tests: a short budget leaves the breaker closed across repeated aborts while still returning the tagged 503; a ceiling-length budget still opens it; table test over `budgetAbortCredits` covering the router-sized budget, the hang threshold boundary, the ceiling, and `hang_disconnect_failure_seconds: 0`.
- [x] `go test ./internal/circuit/` green (40s, full package).
- [x] `go test ./...` green across all packages.
- [x] `go build ./...`, `go vet ./internal/circuit/`, `gofmt` clean.

## Rollback plan

Revert this commit. The breaker returns to crediting every budget abort, which is the behaviour on `main` today — no schema, config, or state-store migration is involved. Note that reverting re-exposes the shared-breaker amplification described above, so prefer rolling forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circuit-breaker accuracy for caller-shortened timeout requests.
  * Prevented shortened request budgets from incorrectly contributing to provider failure tracking.
  * Continued reporting affected requests as degraded while preserving accurate breaker behavior.
  * Provider-level timeouts and configured hang thresholds continue to count toward circuit-breaker activation.

* **Tests**
  * Added coverage for shortened, provider-ceiling, threshold, and disabled timeout-credit scenarios.

* **Documentation**
  * Clarified timeout and circuit-breaker behavior in configuration and technical documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->