### PR TITLE
Allow multiple admin dashboard sign-in domains

### DIFF
--- a/configs/production.yml
+++ b/configs/production.yml
@@ -201,10 +201,11 @@ features:
     requests_per_minute: 120
   admin_dashboard:
     enabled: true
-    # Real sign-in domain is injected at deploy time via the
+    # Real sign-in domain(s) are injected at deploy time via the
     # LLM_PROXY_ADMIN_ALLOWED_DOMAIN env var (it takes precedence over this
-    # value in auth.go). Keep the neutral placeholder here so no private
-    # domain ships in the repo.
+    # value in auth.go). Comma-separate multiple domains, e.g.
+    # "example.com,example.org". Keep the neutral placeholder here so no
+    # private domain ships in the repo.
     allowed_domain: "example.com"
     users:
       dynamodb:

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -476,15 +476,10 @@ func (a *authenticator) requireSession(next http.Handler) http.Handler {
 }
 
 func (a *authenticator) isAllowedUser(email, hd string) bool {
-	domain := a.allowedDomain
 	if hd != "" {
-		return strings.EqualFold(hd, domain)
+		return isAllowedDomain(hd, a.allowedDomain)
 	}
-	at := strings.LastIndex(email, "@")
-	if at < 0 {
-		return false
-	}
-	return strings.EqualFold(email[at+1:], domain)
+	return isAllowedDomainEmail(email, a.allowedDomain)
 }
 
 func randomState() (string, error) {

--- a/internal/admin/auth_oauth_test.go
+++ b/internal/admin/auth_oauth_test.go
@@ -186,12 +186,12 @@ func sessionCookies(t *testing.T, rec *httptest.ResponseRecorder) []*http.Cookie
 }
 
 func TestLoadAuthConfig_EnvOverrides(t *testing.T) {
-	t.Setenv("LLM_PROXY_ADMIN_ALLOWED_DOMAIN", "instawork.com")
+	t.Setenv("LLM_PROXY_ADMIN_ALLOWED_DOMAIN", "override.com")
 	t.Setenv("LLM_PROXY_ADMIN_OAUTH_REDIRECT_URL", "https://llm.example.com/admin/auth/callback")
 
 	cfg, err := loadAuthConfig("example.com", "cid", "csecret", "ssecret")
 	require.NoError(t, err)
-	assert.Equal(t, "instawork.com", cfg.allowedDomain)
+	assert.Equal(t, "override.com", cfg.allowedDomain)
 	assert.Equal(t, "https://llm.example.com/admin/auth/callback", cfg.redirectURL)
 	assert.Equal(t, "cid", cfg.clientID)
 }
@@ -202,14 +202,14 @@ func TestNewAuthenticator_AllowedDomainHonorsEnvOverride(t *testing.T) {
 	// resolved into cfg but auth.allowedDomain kept the YAML value, so every
 	// real-org login was rejected as "forbidden". DevBypassLogin keeps this
 	// network-free (returns before the Google OIDC call).
-	t.Setenv("LLM_PROXY_ADMIN_ALLOWED_DOMAIN", "instawork.com")
+	t.Setenv("LLM_PROXY_ADMIN_ALLOWED_DOMAIN", "override.com")
 	auth, err := newAuthenticator(testLogger(), config.AdminDashboardConfig{
 		DevBypassLogin: true,
 		AllowedDomain:  "example.com",
 	}, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "instawork.com", auth.allowedDomain)
-	assert.True(t, auth.isAllowedUser("alice@instawork.com", "instawork.com"))
+	assert.Equal(t, "override.com", auth.allowedDomain)
+	assert.True(t, auth.isAllowedUser("alice@override.com", "override.com"))
 	assert.False(t, auth.isAllowedUser("alice@example.com", "example.com"))
 }
 
@@ -221,6 +221,14 @@ func TestIsAllowedUser(t *testing.T) {
 	assert.True(t, auth.isAllowedUser("alice@other.com", "example.com"), "hd match wins over email domain")
 	assert.False(t, auth.isAllowedUser("alice@example.com", "other.com"))
 	assert.False(t, auth.isAllowedUser("not-an-email", ""))
+}
+
+func TestIsAllowedUser_MultipleDomains(t *testing.T) {
+	auth := &authenticator{allowedDomain: "example.com,example.org"}
+	assert.True(t, auth.isAllowedUser("adam@example.org", "example.org"))
+	assert.True(t, auth.isAllowedUser("adam@example.org", ""))
+	assert.True(t, auth.isAllowedUser("alice@example.com", "example.com"))
+	assert.False(t, auth.isAllowedUser("alice@other.com", "other.com"))
 }
 
 func TestRandomState_UniqueAndNonEmpty(t *testing.T) {
@@ -236,9 +244,9 @@ func TestRandomState_UniqueAndNonEmpty(t *testing.T) {
 func TestRedirectURL_FromRequest(t *testing.T) {
 	auth := &authenticator{}
 	req := httptest.NewRequest(http.MethodGet, "/admin/auth/login", nil)
-	req.Host = "llm.instawork.com"
+	req.Host = "llm.example.com"
 	req.Header.Set("X-Forwarded-Proto", "https")
-	assert.Equal(t, "https://llm.instawork.com/admin/auth/callback", auth.redirectURL(req))
+	assert.Equal(t, "https://llm.example.com/admin/auth/callback", auth.redirectURL(req))
 }
 
 func TestRedirectURL_EnvWins(t *testing.T) {

--- a/internal/admin/rbac.go
+++ b/internal/admin/rbac.go
@@ -38,17 +38,42 @@ func (a *authenticator) requireRole(min adminusers.Role) func(http.Handler) http
 	}
 }
 
+// allowedDomains splits a comma-separated allowed_domain config value (e.g.
+// "example.com,example.org") into its individual, trimmed domains.
+func allowedDomains(allowedDomain string) []string {
+	parts := strings.Split(allowedDomain, ",")
+	domains := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			domains = append(domains, p)
+		}
+	}
+	return domains
+}
+
+func isAllowedDomain(domain, allowedDomain string) bool {
+	domain = strings.TrimSpace(domain)
+	if domain == "" {
+		return false
+	}
+	for _, d := range allowedDomains(allowedDomain) {
+		if strings.EqualFold(domain, d) {
+			return true
+		}
+	}
+	return false
+}
+
 func isAllowedDomainEmail(email, allowedDomain string) bool {
 	email = strings.TrimSpace(email)
-	allowedDomain = strings.TrimSpace(allowedDomain)
-	if email == "" || allowedDomain == "" {
+	if email == "" {
 		return false
 	}
 	at := strings.LastIndex(email, "@")
 	if at < 0 {
 		return false
 	}
-	return strings.EqualFold(email[at+1:], allowedDomain)
+	return isAllowedDomain(email[at+1:], allowedDomain)
 }
 
 func validateAllowedEmail(email, allowedDomain string) error {

--- a/internal/admin/rbac_test.go
+++ b/internal/admin/rbac_test.go
@@ -23,6 +23,13 @@ func TestIsAllowedDomainEmail(t *testing.T) {
 	assert.False(t, isAllowedDomainEmail("no-at-sign", "example.com"))
 }
 
+func TestIsAllowedDomainEmail_MultipleDomains(t *testing.T) {
+	assert.True(t, isAllowedDomainEmail("a@example.com", "example.com,example.org"))
+	assert.True(t, isAllowedDomainEmail("a@example.org", "example.com,example.org"))
+	assert.True(t, isAllowedDomainEmail("a@example.org", " example.com , example.org "))
+	assert.False(t, isAllowedDomainEmail("a@other.com", "example.com,example.org"))
+}
+
 func TestRequireRoleAllowsAdmin(t *testing.T) {
 	h, _ := testAdminHandler(t)
 	req := authenticatedRequest(t, h, http.MethodGet, "/admin/api/users", nil)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,8 +297,9 @@ type FakeUpstreamConfig struct {
 // AdminDashboardConfig gates the /admin UI and JSON API.
 type AdminDashboardConfig struct {
 	Enabled bool `yaml:"enabled"`
-	// AllowedDomain restricts Google OAuth sign-in to a single hosted domain
-	// (e.g. example.com). Defaults to example.com when unset.
+	// AllowedDomain restricts Google OAuth sign-in and user invites to one or
+	// more hosted domains, given as a comma-separated list (e.g.
+	// "example.com,example.co"). Defaults to example.com when unset.
 	AllowedDomain string `yaml:"allowed_domain"`
 	// DevCORSOrigin allows the Vite dev server to call the admin API.
 	DevCORSOrigin string `yaml:"dev_cors_origin"`


### PR DESCRIPTION
## Summary
- `LLM_PROXY_ADMIN_ALLOWED_DOMAIN` (and `features.admin_dashboard.allowed_domain`) previously matched exactly one hosted domain, so a user with an `instawork.co` address couldn't sign in via Google OAuth, and inviting `person@instawork.com` from the add-user page also failed for the same single-domain check.
- Accept a comma-separated list of domains (e.g. `instawork.com,instawork.co`) and share one matcher (`isAllowedDomain`/`isAllowedDomainEmail`) between OAuth login and the invite-validation path so they can't drift out of sync again.
- Companion infra change (sets the new value): https://github.com/Instawork/infrastructure/pull/new/eric/llm-proxy-allow-instawork-co

## Test plan
- [x] `gofmt -s -l .`, `gofumpt -l .`, `go vet ./...`
- [x] `go run ./cmd/config-validator/`
- [x] `go test -race ./internal/admin/... -short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin sign-in and user invitations now support multiple allowed domains in a comma-separated list.
  * Domain matching ignores extra spaces and letter case.
  * Unrecognized domains continue to be rejected.

* **Documentation**
  * Updated configuration guidance to clarify supported domain lists and where restrictions apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->