### PR TITLE
fix(pii): chunk large text fields before Presidio /analyze to stop fail_closed 503s

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -1558,6 +1558,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			Language:           piiCfg.Language,
 			AllowTestEmails:    piiCfg.AllowTestEmails,
 			AnalyzeConcurrency: piiCfg.AnalyzeConcurrency,
+			ChunkChars:         piiCfg.AnalyzeChunkChars,
 		}
 		cacheCfg := redact.AnalyzeCacheConfigFromYAML(piiCfg.AnalyzeCache)
 		fingerprint := redact.AnalyzeCacheFingerprint(redactCfg)
@@ -1667,6 +1668,7 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			"timeout_ms_per_100kb", piiCfg.TimeoutMsPer100KB,
 			"timeout_ms_max", piiCfg.TimeoutMsMax,
 			"analyze_concurrency", piiCfg.AnalyzeConcurrency,
+			"analyze_chunk_chars", piiCfg.AnalyzeChunkChars,
 		)
 	}
 

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -146,6 +146,13 @@ features:
     timeout_ms_per_100kb: 2000
     timeout_ms_max: 30000
     analyze_concurrency: 4
+    # Presidio's spaCy NER is single-threaded per /analyze call, so one large
+    # field (e.g. a big tool-result string) pins a single sidecar worker for
+    # its whole call no matter how many workers are running — the root cause
+    # of the Aug 2026 fail_mode "closed" 503 incident on large bodies. Fields
+    # above 64 KiB are split into overlapping chunks and analyzed in
+    # parallel (bounded by analyze_concurrency) instead of one long call.
+    analyze_chunk_chars: 65536
     # Without this, max_body_bytes falls back to the 1 MiB default. With
     # fail_mode "closed" any body over the limit 503s instead of skipping
     # redaction, and a caller that retries an oversized payload keeps

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1339,6 +1339,13 @@ func (c *YAMLConfig) validatePIIRedactConfig() error {
 	if r.AnalyzeChunkChars < 0 {
 		return fmt.Errorf("analyze_chunk_chars cannot be negative")
 	}
+	// 200 mirrors redact.analyzeChunkOverlapChars (can't import redact here
+	// without a cycle). A chunk size at or below the overlap collapses the
+	// overlap window to zero, so a PII value straddling a chunk boundary
+	// would go undetected.
+	if r.AnalyzeChunkChars > 0 && r.AnalyzeChunkChars <= 200 {
+		return fmt.Errorf("analyze_chunk_chars must be 0 (disabled) or greater than 200 (the chunk overlap window), got %d", r.AnalyzeChunkChars)
+	}
 	if r.ScoreThreshold < 0 || r.ScoreThreshold > 1 {
 		return fmt.Errorf("score_threshold must be in [0, 1] (got %v)", r.ScoreThreshold)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,6 +150,16 @@ type PIIRedactConfig struct {
 	// Zero defaults to 4. Tune down if the sidecar shows queue latency.
 	AnalyzeConcurrency int `yaml:"analyze_concurrency,omitempty"`
 
+	// AnalyzeChunkChars splits a single text field larger than this many
+	// characters into overlapping segments analyzed in parallel (bounded by
+	// AnalyzeConcurrency) instead of one /analyze call covering the whole
+	// field. Presidio's spaCy NER is CPU-bound and effectively
+	// single-threaded per request, so a single large field (e.g. a big tool
+	// result) otherwise takes latency proportional to its own size no
+	// matter how many sidecar workers are running — the root cause of the
+	// August 2026 fail_mode "closed" 503 incident. Zero disables chunking.
+	AnalyzeChunkChars int `yaml:"analyze_chunk_chars,omitempty"`
+
 	// ScoreThreshold is the minimum Presidio confidence score for a
 	// span to be redacted. Default: 0.5.
 	ScoreThreshold float64 `yaml:"score_threshold"`
@@ -1325,6 +1335,9 @@ func (c *YAMLConfig) validatePIIRedactConfig() error {
 	}
 	if r.AnalyzeConcurrency < 0 {
 		return fmt.Errorf("analyze_concurrency cannot be negative")
+	}
+	if r.AnalyzeChunkChars < 0 {
+		return fmt.Errorf("analyze_chunk_chars cannot be negative")
 	}
 	if r.ScoreThreshold < 0 || r.ScoreThreshold > 1 {
 		return fmt.Errorf("score_threshold must be in [0, 1] (got %v)", r.ScoreThreshold)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1339,12 +1339,16 @@ func (c *YAMLConfig) validatePIIRedactConfig() error {
 	if r.AnalyzeChunkChars < 0 {
 		return fmt.Errorf("analyze_chunk_chars cannot be negative")
 	}
-	// 200 mirrors redact.analyzeChunkOverlapChars (can't import redact here
-	// without a cycle). A chunk size at or below the overlap collapses the
-	// overlap window to zero, so a PII value straddling a chunk boundary
-	// would go undetected.
-	if r.AnalyzeChunkChars > 0 && r.AnalyzeChunkChars <= 200 {
-		return fmt.Errorf("analyze_chunk_chars must be 0 (disabled) or greater than 200 (the chunk overlap window), got %d", r.AnalyzeChunkChars)
+	// minAnalyzeChunkChars keeps chunkRunes' worst-case forward progress per
+	// chunk meaningfully positive. redact.chunkRunes backs its boundary off
+	// by up to a 200-rune whitespace lookback, then by the 200-rune overlap
+	// (redact.analyzeChunkOverlapChars; duplicated here since config can't
+	// import redact without a cycle) — together up to 400 runes. Below this
+	// floor a chunk can advance by only a handful of runes, turning one
+	// multi-MB field into millions of chunks.
+	const minAnalyzeChunkChars = 1024
+	if r.AnalyzeChunkChars > 0 && r.AnalyzeChunkChars < minAnalyzeChunkChars {
+		return fmt.Errorf("analyze_chunk_chars must be 0 (disabled) or at least %d, got %d", minAnalyzeChunkChars, r.AnalyzeChunkChars)
 	}
 	if r.ScoreThreshold < 0 || r.ScoreThreshold > 1 {
 		return fmt.Errorf("score_threshold must be in [0, 1] (got %v)", r.ScoreThreshold)

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -194,6 +194,11 @@ func TestValidatePIIRedact_AllBranches(t *testing.T) {
 		{"max_body_bytes zero is fine (uses default)", func(c *PIIRedactConfig) { c.MaxBodyBytes = 0 }, true},
 		{"max_body_bytes positive ok", func(c *PIIRedactConfig) { c.MaxBodyBytes = 1024 * 1024 }, true},
 		{"max_body_bytes negative", func(c *PIIRedactConfig) { c.MaxBodyBytes = -1 }, false},
+		{"analyze_chunk_chars zero disables chunking", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 0 }, true},
+		{"analyze_chunk_chars above overlap window ok", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 65536 }, true},
+		{"analyze_chunk_chars negative", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = -1 }, false},
+		{"analyze_chunk_chars within overlap window rejected", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 200 }, false},
+		{"analyze_chunk_chars just above overlap window ok", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 201 }, true},
 		{"analyze_cache ttl negative", func(c *PIIRedactConfig) {
 			c.AnalyzeCache.Enabled = true
 			c.AnalyzeCache.TTLSeconds = -1

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -195,10 +195,12 @@ func TestValidatePIIRedact_AllBranches(t *testing.T) {
 		{"max_body_bytes positive ok", func(c *PIIRedactConfig) { c.MaxBodyBytes = 1024 * 1024 }, true},
 		{"max_body_bytes negative", func(c *PIIRedactConfig) { c.MaxBodyBytes = -1 }, false},
 		{"analyze_chunk_chars zero disables chunking", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 0 }, true},
-		{"analyze_chunk_chars above overlap window ok", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 65536 }, true},
+		{"analyze_chunk_chars well above minimum ok", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 65536 }, true},
 		{"analyze_chunk_chars negative", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = -1 }, false},
 		{"analyze_chunk_chars within overlap window rejected", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 200 }, false},
-		{"analyze_chunk_chars just above overlap window ok", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 201 }, true},
+		{"analyze_chunk_chars causes near-zero chunk progress rejected", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 201 }, false},
+		{"analyze_chunk_chars below minimum rejected", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 1023 }, false},
+		{"analyze_chunk_chars at minimum ok", func(c *PIIRedactConfig) { c.AnalyzeChunkChars = 1024 }, true},
 		{"analyze_cache ttl negative", func(c *PIIRedactConfig) {
 			c.AnalyzeCache.Enabled = true
 			c.AnalyzeCache.TTLSeconds = -1

--- a/internal/observability/dogstatsd.go
+++ b/internal/observability/dogstatsd.go
@@ -67,5 +67,12 @@ func NewMetricsSink(cfg *configPkg.DatadogTransportConfig, logger *slog.Logger, 
 		"namespace", namespace,
 		"tags", cfg.Tags,
 	)
+	// A one-time heartbeat so "is this sink actually emitting" is answerable
+	// from Datadog without waiting on real feature traffic — llm-proxy
+	// container logs aren't forwarded to Datadog, so the log line above is
+	// otherwise the only signal a broken client construction ever produced.
+	if err := client.Incr("metrics_sink.up", []string{"feature:" + feature}, 1.0); err != nil {
+		logger.Warn("dogstatsd metrics_sink.up heartbeat failed", "feature", feature, "error", err)
+	}
 	return client
 }

--- a/internal/redact/analyze_chunk.go
+++ b/internal/redact/analyze_chunk.go
@@ -1,0 +1,203 @@
+package redact
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// analyzeChunkOverlapChars is the rune overlap between adjacent chunks so an
+// entity that would otherwise straddle a chunk boundary (e.g. a name split
+// across two chunks) is still captured whole by at least one of the two
+// overlapping views. dedupeOverlapSpans then collapses the resulting
+// duplicate detections in the overlap window.
+const analyzeChunkOverlapChars = 200
+
+// analyzeChunked calls /analyze on text, splitting it into parallel chunks
+// first when it exceeds Config.ChunkChars runes. Chunking is transparent to
+// callers: the merged span list uses the same offsets as a single
+// whole-text /analyze call would have returned.
+//
+// Presidio's spaCy NER is CPU-bound and effectively single-threaded per
+// request, so one large field pins a single sidecar worker for the whole
+// call regardless of how many workers the sidecar runs. Splitting the field
+// lets the existing AnalyzeConcurrency fan-out (see json_scrub.go) bound the
+// wall-clock time by parallelism instead of by the field's total size. See
+// the August 2026 fail_mode "closed" 503 incident on large tool-result
+// bodies.
+func (r *Redactor) analyzeChunked(ctx context.Context, text string) ([]Span, error) {
+	if r.cfg.ChunkChars <= 0 {
+		return r.analyze(ctx, text, nil, r.cfg.ScoreThreshold)
+	}
+
+	runes := []rune(text)
+	if len(runes) <= r.cfg.ChunkChars {
+		return r.analyze(ctx, text, nil, r.cfg.ScoreThreshold)
+	}
+
+	chunks := chunkRunes(runes, r.cfg.ChunkChars, analyzeChunkOverlapChars)
+	if len(chunks) <= 1 {
+		return r.analyze(ctx, text, nil, r.cfg.ScoreThreshold)
+	}
+
+	// AnalyzeTimeoutFromContext holds the deadline the middleware computed
+	// for this whole request (scaled by total body size). Binding it to an
+	// absolute deadline once, here, means every chunk's analyze() call —
+	// which independently calls AnalyzeTimeoutFromContext again — shares
+	// that one deadline instead of each restarting a fresh full-length
+	// timeout from its own start time. Without this, N sequential waves of
+	// chunks could take up to N times the intended budget.
+	overallTimeout := AnalyzeTimeoutFromContext(ctx, r.cfg.Timeout)
+	limit := r.analyzeConcurrency()
+	ctx, cancel := context.WithTimeout(ctx, overallTimeout)
+	defer cancel()
+
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+	perChunkSpans := make([][]Span, len(chunks))
+
+	for i := range chunks {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = ctx.Err()
+				}
+				mu.Unlock()
+				return
+			}
+
+			spans, err := r.analyze(ctx, chunks[i].text, nil, r.cfg.ScoreThreshold)
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+					cancel()
+				}
+				mu.Unlock()
+				return
+			}
+			offset := chunks[i].offset
+			rebased := make([]Span, len(spans))
+			for j, s := range spans {
+				s.Start += offset
+				s.End += offset
+				rebased[j] = s
+			}
+			perChunkSpans[i] = rebased
+		}(i)
+	}
+
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	var merged []Span
+	for _, spans := range perChunkSpans {
+		merged = append(merged, spans...)
+	}
+	return dedupeOverlapSpans(merged), nil
+}
+
+// textChunk is a rune-offset view into the text passed to analyzeChunked.
+type textChunk struct {
+	text   string
+	offset int // rune offset into the original text
+}
+
+// chunkRunes splits runes into overlapping segments no longer than maxChars,
+// preferring to break at whitespace near the boundary so word-level
+// entities (PERSON, EMAIL_ADDRESS) aren't sliced in half. Each chunk after
+// the first begins overlapChars runes before its nominal boundary.
+func chunkRunes(runes []rune, maxChars, overlapChars int) []textChunk {
+	if len(runes) == 0 || maxChars <= 0 {
+		return nil
+	}
+	if overlapChars < 0 || overlapChars >= maxChars {
+		overlapChars = 0
+	}
+
+	var chunks []textChunk
+	start := 0
+	for start < len(runes) {
+		end := start + maxChars
+		if end >= len(runes) {
+			end = len(runes)
+		} else {
+			end = whitespaceSplitPoint(runes, start, end)
+		}
+		chunks = append(chunks, textChunk{text: string(runes[start:end]), offset: start})
+		if end >= len(runes) {
+			break
+		}
+		next := end - overlapChars
+		if next <= start {
+			next = end
+		}
+		start = next
+	}
+	return chunks
+}
+
+// whitespaceSplitPoint looks backward from end (bounded to a small lookback
+// window within [start, end]) for the nearest whitespace rune, so a chunk
+// boundary doesn't land mid-word. Falls back to end when none is found.
+func whitespaceSplitPoint(runes []rune, start, end int) int {
+	const maxLookback = 200
+	floor := end - maxLookback
+	if floor < start {
+		floor = start
+	}
+	for i := end; i > floor; i-- {
+		if isJSONWhitespace(runes[i-1]) {
+			return i
+		}
+	}
+	return end
+}
+
+// dedupeOverlapSpans drops duplicate detections in the overlap window
+// between adjacent chunks: spans of the same entity type with overlapping
+// [Start,End) ranges collapse to the single highest-scoring detection.
+func dedupeOverlapSpans(spans []Span) []Span {
+	if len(spans) < 2 {
+		return spans
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].Start != spans[j].Start {
+			return spans[i].Start < spans[j].Start
+		}
+		return spans[i].End < spans[j].End
+	})
+	out := make([]Span, 0, len(spans))
+	for _, s := range spans {
+		if i := indexOfOverlappingSameType(out, s); i >= 0 {
+			if s.Score > out[i].Score {
+				out[i] = s
+			}
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func indexOfOverlappingSameType(spans []Span, s Span) int {
+	for i, existing := range spans {
+		if existing.EntityType != s.EntityType {
+			continue
+		}
+		if s.Start < existing.End && existing.Start < s.End {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/redact/analyze_chunk.go
+++ b/internal/redact/analyze_chunk.go
@@ -52,48 +52,63 @@ func (r *Redactor) analyzeChunked(ctx context.Context, text string) ([]Span, err
 	ctx, cancel := context.WithTimeout(ctx, overallTimeout)
 	defer cancel()
 
-	sem := make(chan struct{}, limit)
+	// A fixed pool of workers pulls chunk indexes off jobs, capping goroutine
+	// count at AnalyzeConcurrency. A goroutine-per-chunk design would let a
+	// pathologically small analyze_chunk_chars (e.g. 1) turn a multi-MB field
+	// into millions of goroutines blocked on a semaphore, exhausting memory
+	// before the shared deadline even expires.
+	workers := limit
+	if workers > len(chunks) {
+		workers = len(chunks)
+	}
+
+	jobs := make(chan int)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var firstErr error
 	perChunkSpans := make([][]Span, len(chunks))
 
-	for i := range chunks {
-		wg.Add(1)
-		go func(i int) {
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
 			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-ctx.Done():
-				mu.Lock()
-				if firstErr == nil {
-					firstErr = ctx.Err()
+			for i := range jobs {
+				spans, err := r.analyze(ctx, chunks[i].text, nil, r.cfg.ScoreThreshold)
+				if err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+						cancel()
+					}
+					mu.Unlock()
+					continue
 				}
-				mu.Unlock()
-				return
-			}
-
-			spans, err := r.analyze(ctx, chunks[i].text, nil, r.cfg.ScoreThreshold)
-			if err != nil {
-				mu.Lock()
-				if firstErr == nil {
-					firstErr = err
-					cancel()
+				offset := chunks[i].offset
+				rebased := make([]Span, len(spans))
+				for j, s := range spans {
+					s.Start += offset
+					s.End += offset
+					rebased[j] = s
 				}
-				mu.Unlock()
-				return
+				perChunkSpans[i] = rebased
 			}
-			offset := chunks[i].offset
-			rebased := make([]Span, len(spans))
-			for j, s := range spans {
-				s.Start += offset
-				s.End += offset
-				rebased[j] = s
-			}
-			perChunkSpans[i] = rebased
-		}(i)
+		}()
 	}
+
+feed:
+	for i := range chunks {
+		select {
+		case jobs <- i:
+		case <-ctx.Done():
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			mu.Unlock()
+			break feed
+		}
+	}
+	close(jobs)
 
 	wg.Wait()
 	if firstErr != nil {
@@ -164,9 +179,13 @@ func whitespaceSplitPoint(runes []rune, start, end int) int {
 	return end
 }
 
-// dedupeOverlapSpans drops duplicate detections in the overlap window
+// dedupeOverlapSpans merges duplicate detections in the overlap window
 // between adjacent chunks: spans of the same entity type with overlapping
-// [Start,End) ranges collapse to the single highest-scoring detection.
+// [Start,End) ranges collapse to their union range, keeping the highest
+// score. Adjacent chunks can disagree on an entity's exact boundaries (e.g.
+// [10,20) at 0.6 from one chunk's view vs [15,25) at 0.9 from the
+// overlapping view); taking only the higher-scored span's range would drop
+// the [10,15) prefix from redaction, so the merged span must cover both.
 func dedupeOverlapSpans(spans []Span) []Span {
 	if len(spans) < 2 {
 		return spans
@@ -180,8 +199,14 @@ func dedupeOverlapSpans(spans []Span) []Span {
 	out := make([]Span, 0, len(spans))
 	for _, s := range spans {
 		if i := indexOfOverlappingSameType(out, s); i >= 0 {
+			if s.Start < out[i].Start {
+				out[i].Start = s.Start
+			}
+			if s.End > out[i].End {
+				out[i].End = s.End
+			}
 			if s.Score > out[i].Score {
-				out[i] = s
+				out[i].Score = s.Score
 			}
 			continue
 		}

--- a/internal/redact/analyze_chunk_characterization_test.go
+++ b/internal/redact/analyze_chunk_characterization_test.go
@@ -1,0 +1,90 @@
+package redact
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These tests pin the behavior behind the August 2026 production incident:
+// Presidio's spaCy NER is CPU-bound and effectively single-threaded per
+// /analyze call, so one large text field (a ~700 KiB tool-result body was
+// the real trigger) takes latency proportional to its full size in a single
+// request. Under fail_mode "closed" that timeout became a 503 to callers.
+//
+// The stub analyzer's per-byte latency and the request deadline are both
+// scaled down from real Presidio/production numbers by the same factor, so
+// the tests run in milliseconds while preserving the ratio that makes an
+// un-chunked 700 KiB field blow the budget.
+const (
+	characterizationBodyBytes  = 717_000 // ~700 KiB, matches the documented incident payload size
+	characterizationPerByte    = time.Microsecond
+	characterizationDeadline   = 200 * time.Millisecond
+	characterizationChunkChars = 100_000
+)
+
+// TestScrub_LargeSingleFieldTimesOutWithoutChunking pins today's default
+// (chunking disabled, ChunkChars: 0) behavior: a single ~700 KiB field is
+// sent to Presidio in one /analyze call, and that call cannot finish inside
+// a deadline sized for a much smaller body.
+func TestScrub_LargeSingleFieldTimesOutWithoutChunking(t *testing.T) {
+	text := strings.Repeat("a", characterizationBodyBytes)
+
+	srv := fakeAnalyzer(t, func(w http.ResponseWriter, req *http.Request) {
+		var payload struct {
+			Text string `json:"text"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		time.Sleep(time.Duration(len(payload.Text)) * characterizationPerByte)
+		_ = json.NewEncoder(w).Encode([]Span{})
+	})
+
+	r, err := New(Config{AnalyzerURL: srv.URL, Timeout: characterizationDeadline})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := WithAnalyzeTimeout(context.Background(), characterizationDeadline)
+	if _, err := r.Scrub(ctx, text, NewRegistry()); err == nil {
+		t.Fatal("expected a timeout analyzing a 700KB field in one un-chunked /analyze call, got nil error")
+	}
+}
+
+// TestScrub_LargeSingleFieldSucceedsWithChunking is the flip side: with
+// ChunkChars configured, the same field and the same per-byte-latency stub
+// complete inside the same deadline because the chunks run in parallel
+// instead of one call bearing the full-body latency.
+func TestScrub_LargeSingleFieldSucceedsWithChunking(t *testing.T) {
+	text := strings.Repeat("a", characterizationBodyBytes)
+
+	srv := fakeAnalyzer(t, func(w http.ResponseWriter, req *http.Request) {
+		var payload struct {
+			Text string `json:"text"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		time.Sleep(time.Duration(len(payload.Text)) * characterizationPerByte)
+		_ = json.NewEncoder(w).Encode([]Span{})
+	})
+
+	r, err := New(Config{
+		AnalyzerURL:        srv.URL,
+		Timeout:            characterizationDeadline,
+		ChunkChars:         characterizationChunkChars,
+		AnalyzeConcurrency: 8,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := WithAnalyzeTimeout(context.Background(), characterizationDeadline)
+	if _, err := r.Scrub(ctx, text, NewRegistry()); err != nil {
+		t.Fatalf("Scrub with chunking enabled: %v", err)
+	}
+}

--- a/internal/redact/analyze_chunk_test.go
+++ b/internal/redact/analyze_chunk_test.go
@@ -106,8 +106,11 @@ func TestDedupeOverlapSpans_CollapsesOverlappingSameType(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 merged span, got %d (%+v)", len(got), got)
 	}
+	if got[0].Start != 10 || got[0].End != 25 {
+		t.Fatalf("expected the merged span to cover the union range [10,25), got %+v", got[0])
+	}
 	if got[0].Score != 0.9 {
-		t.Fatalf("expected the higher-scoring span to survive, got %+v", got[0])
+		t.Fatalf("expected the higher score to survive, got %+v", got[0])
 	}
 }
 

--- a/internal/redact/analyze_chunk_test.go
+++ b/internal/redact/analyze_chunk_test.go
@@ -1,0 +1,124 @@
+package redact
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAnalyzeChunked_SharesOneOverallDeadlineAcrossChunks guards against a
+// regression where each chunk's analyze() call gets its own fresh copy of
+// the request's timeout budget instead of all chunks sharing one absolute
+// deadline. With AnalyzeConcurrency=1 forcing five 80ms chunk calls to run
+// strictly sequentially, a per-chunk-reset bug would let the whole call run
+// close to 5*80ms=400ms; sharing one deadline must cut it off near the
+// 150ms budget instead.
+func TestAnalyzeChunked_SharesOneOverallDeadlineAcrossChunks(t *testing.T) {
+	const perChunkLatency = 80 * time.Millisecond
+	srv := fakeAnalyzer(t, func(w http.ResponseWriter, req *http.Request) {
+		time.Sleep(perChunkLatency)
+		_ = json.NewEncoder(w).Encode([]Span{})
+	})
+	r, err := New(Config{
+		AnalyzerURL:        srv.URL,
+		Timeout:            perChunkLatency,
+		ChunkChars:         10,
+		AnalyzeConcurrency: 1,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	text := strings.Repeat("a", 50) // 5 chunks of 10 chars, no whitespace to split on
+	ctx := WithAnalyzeTimeout(context.Background(), 150*time.Millisecond)
+
+	start := time.Now()
+	_, err = r.Scrub(ctx, text, NewRegistry())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected the shared deadline to expire before all chunks finished, got success in %v", elapsed)
+	}
+	if elapsed > 300*time.Millisecond {
+		t.Fatalf("took %v; a per-chunk-reset timeout bug would let this run close to 400ms instead of stopping near the 150ms shared deadline", elapsed)
+	}
+}
+
+func TestChunkRunes_SingleChunkWhenUnderLimit(t *testing.T) {
+	chunks := chunkRunes([]rune("hello world"), 100, 10)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].offset != 0 || chunks[0].text != "hello world" {
+		t.Fatalf("unexpected chunk: %+v", chunks[0])
+	}
+}
+
+func TestChunkRunes_SplitsAtWhitespaceNearBoundary(t *testing.T) {
+	text := "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd"
+	chunks := chunkRunes([]rune(text), 15, 0)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for _, c := range chunks {
+		if len(c.text) == 0 {
+			t.Fatalf("empty chunk at offset %d", c.offset)
+		}
+		if len(c.text) > 0 && (c.text[0] != ' ' && len(c.text) < len(text)) {
+			// Boundaries should land on whitespace, not mid-word, except
+			// for the final chunk which just takes whatever remains.
+			last := c.text[len(c.text)-1]
+			if last != ' ' && c.offset+len(c.text) != len(text) {
+				t.Fatalf("chunk %q does not end on a whitespace boundary", c.text)
+			}
+		}
+	}
+}
+
+func TestChunkRunes_OverlapCarriesBoundaryText(t *testing.T) {
+	text := "0123456789" + "0123456789" + "0123456789" // 30 chars, no whitespace
+	chunks := chunkRunes([]rune(text), 12, 4)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i := 1; i < len(chunks); i++ {
+		if chunks[i].offset >= chunks[i-1].offset+12 {
+			t.Fatalf("chunk %d offset %d does not overlap with previous chunk", i, chunks[i].offset)
+		}
+	}
+}
+
+func TestChunkRunes_EmptyInput(t *testing.T) {
+	if chunks := chunkRunes(nil, 10, 2); chunks != nil {
+		t.Fatalf("expected nil chunks for empty input, got %v", chunks)
+	}
+}
+
+func TestDedupeOverlapSpans_CollapsesOverlappingSameType(t *testing.T) {
+	spans := []Span{
+		{Start: 10, End: 20, EntityType: "PERSON", Score: 0.6},
+		{Start: 15, End: 25, EntityType: "PERSON", Score: 0.9},
+	}
+	got := dedupeOverlapSpans(spans)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 merged span, got %d (%+v)", len(got), got)
+	}
+	if got[0].Score != 0.9 {
+		t.Fatalf("expected the higher-scoring span to survive, got %+v", got[0])
+	}
+}
+
+func TestDedupeOverlapSpans_KeepsNonOverlappingAndDifferentTypes(t *testing.T) {
+	spans := []Span{
+		{Start: 0, End: 5, EntityType: "PERSON", Score: 0.8},
+		{Start: 5, End: 10, EntityType: "EMAIL_ADDRESS", Score: 0.7},
+		{Start: 100, End: 110, EntityType: "PERSON", Score: 0.5},
+	}
+	got := dedupeOverlapSpans(spans)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 spans preserved, got %d (%+v)", len(got), got)
+	}
+}

--- a/internal/redact/redactor.go
+++ b/internal/redact/redactor.go
@@ -349,7 +349,7 @@ func (r *Redactor) analyzeSpans(ctx context.Context, analysisText string) ([]Spa
 // entity scope and returns raw spans without redacting the input. The
 // redactor's ScoreThreshold is applied server-side.
 func (r *Redactor) Analyze(ctx context.Context, text string) ([]Span, error) {
-	return r.analyze(ctx, text, nil, r.cfg.ScoreThreshold)
+	return r.analyzeChunked(ctx, text)
 }
 
 // AnalyzeEntities posts text to Presidio /analyze scoped to entityTypes

--- a/internal/redact/redactor.go
+++ b/internal/redact/redactor.go
@@ -192,6 +192,15 @@ type Config struct {
 	// with multiple user-content strings. Zero defaults to 4.
 	AnalyzeConcurrency int
 
+	// ChunkChars splits a single text field larger than this many runes
+	// into overlapping segments analyzed in parallel (bounded by
+	// AnalyzeConcurrency) instead of one /analyze call covering the whole
+	// field. Presidio's spaCy NER is CPU-bound and effectively
+	// single-threaded per request, so one large field otherwise takes
+	// latency proportional to its full size no matter how many sidecar
+	// workers are running. Zero (default) disables chunking.
+	ChunkChars int
+
 	// AnalyzeCache optionally caches Presidio span lists per content block.
 	AnalyzeCache AnalyzeCache
 }
@@ -326,7 +335,7 @@ func (r *Redactor) analyzeSpans(ctx context.Context, analysisText string) ([]Spa
 			return spans, nil
 		}
 	}
-	spans, err := r.analyze(ctx, analysisText, nil, r.cfg.ScoreThreshold)
+	spans, err := r.analyzeChunked(ctx, analysisText)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Root-causes and fixes the ongoing `llm.instawork.com` 503 storm (Aug 24-27
2026, ~3,142 ALB 503s and counting): Presidio's spaCy NER is CPU-bound and
effectively single-threaded per `/analyze` call, so a single large text
field (a ~700 KiB tool-result body was the real trigger) takes latency
proportional to its own size no matter how many sidecar workers are
running. Under `fail_mode: "closed"` that timeout became a 503 to callers.

- Adds `analyze_chunk_chars` (`internal/redact`, wired through `configs/*.yml`):
  fields above the threshold are split into overlapping segments,
  analyzed in parallel through the existing `AnalyzeConcurrency` fan-out,
  and merged back with spans rebased to the original offsets and
  overlap-window duplicates deduped. Zero (default) disables chunking —
  fully backward compatible.
- Fixes a real bug found during a local Presidio replay: each chunk's
  `analyze()` call was getting its own fresh copy of the request's timeout
  budget instead of sharing one absolute deadline, so N sequential waves
  of chunks could take up to N times the intended budget. Now the
  deadline is bound once, up front, for the whole chunked operation.
- Adds a characterization test pinning today's (chunking-disabled) timeout
  behavior on a ~700 KiB field, and a companion test proving chunking
  fixes it — both against an in-process fake analyzer with per-byte
  latency scaled down for test speed.
- Adds a one-time `metrics_sink.up` dogstatsd heartbeat on every feature's
  metrics sink construction. Static review of `recordPII` /
  `emitPIIRedactionMetrics` found no code bug — it uses the identical
  `NewMetricsSink` path as the circuit breaker, which demonstrably emits
  `llm.circuit.*` today — but `llm.pii.*` is absent from Datadog over the
  last 30 days despite the incident's fail_closed volume. This closes the
  observability gap so a broken sink is visible next time without waiting
  on real PII traffic or forwarded logs.
- Sets `analyze_chunk_chars: 65536` in `configs/production.yml`.

Companion infrastructure PR (Presidio sidecar scale-up + Datadog log
forwarding + ALB 503 monitor) to follow separately.

## Test plan

- [x] `make ci` (gofmt -s, gofumpt, vet, PII log lint, config-validator,
      race-enabled unit tests)
- [x] Local replay against a real Presidio container (`make test-pii-up`,
      `WORKERS=6`) with a ~711 KB payload: un-chunked config times out at
      the scaled 20s deadline; chunked config (65536 chars, concurrency 4)
      completes in ~19.5s within the same shared deadline
- [ ] Staging deploy + large-payload replay (blocked on this PR + the
      infra PR merging)
- [ ] Production deploy; confirm ALB 503 rate drops to zero and
      `llm.pii.*` / `metrics_sink.up` metrics appear in Datadog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large text fields can now be analyzed in overlapping chunks, improving PII detection for content over 64 KiB.
  * Chunk analysis supports configurable sizing, concurrency, timeouts, and deduplication of overlapping results.
  * Production configuration enables chunked analysis for large fields.

* **Observability**
  * Metrics startup now reports a heartbeat after successful initialization.

* **Bug Fixes**
  * Invalid chunk-size settings are rejected.
  * Large-field analysis is less likely to time out or miss detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->