### PR TITLE
ratelimit: window-stamp the Redis counter keys

### DIFF
--- a/internal/ratelimit/redis.go
+++ b/internal/ratelimit/redis.go
@@ -184,8 +184,27 @@ func (r *redisLimiter) limitFor(key string, minute bool) rlLimits {
 	return lim
 }
 
-func minuteKey(scopeKey string) string { return "rl:min:" + scopeKey }
-func dayKey(scopeKey string) string    { return "rl:day:" + scopeKey }
+// Counter keys are window-stamped so window identity is explicit. Redis EXPIRE
+// is whole-second granular, so an unstamped key reserved late in a minute
+// outlived its window; the next window's first request inherited the stale
+// count and renewed its TTL, shrinking that window's budget for a full minute.
+func minuteWindow(t time.Time) string {
+	return strconv.FormatInt(t.Unix()/60, 10)
+}
+
+// The Unix epoch starts at UTC midnight, so dividing by a day agrees with
+// secToDayEnd and the memory limiter, both of which truncate on UTC.
+func dayWindow(t time.Time) string {
+	return strconv.FormatInt(t.Unix()/86400, 10)
+}
+
+func minuteKey(scopeKey string, t time.Time) string {
+	return "rl:min:" + minuteWindow(t) + ":" + scopeKey
+}
+
+func dayKey(scopeKey string, t time.Time) string {
+	return "rl:day:" + dayWindow(t) + ":" + scopeKey
+}
 
 func secToMinuteEnd(t time.Time) int {
 	s := int(t.Unix() % 60)
@@ -322,7 +341,7 @@ const snapshotTimeout = 2 * time.Second
 
 // Snapshot implements Snapshotter for the Redis backend so the admin dashboard
 // shows live fleet-wide counters (not just configured limits). It SCANs the
-// rl:min:* and rl:day:* hashes on the rate-limit DB and reports each scope's
+// current window's hashes on the rate-limit DB and reports each scope's
 // current req/tok. Best-effort: on any Redis error it returns the configured
 // limits with empty counters rather than failing the admin request.
 func (r *redisLimiter) Snapshot(now time.Time) LimitsSnapshot {
@@ -346,8 +365,8 @@ func (r *redisLimiter) Snapshot(now time.Time) LimitsSnapshot {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), snapshotTimeout)
 	defer cancel()
-	r.scanCounters(ctx, "rl:min:", snap.Minute.Counters)
-	r.scanCounters(ctx, "rl:day:", snap.Day.Counters)
+	r.scanCounters(ctx, "rl:min:"+minuteWindow(now)+":", snap.Minute.Counters)
+	r.scanCounters(ctx, "rl:day:"+dayWindow(now)+":", snap.Day.Counters)
 	return snap
 }
 
@@ -382,8 +401,8 @@ func (r *redisLimiter) CheckAndReserve(ctx context.Context, id string, scope Sco
 	keys := make([]string, 0, len(scopeKeys)*2)
 	argLimits := make([]interface{}, 0, len(scopeKeys)*4)
 	for _, sk := range scopeKeys {
-		keys = append(keys, minuteKey(sk))
-		keys = append(keys, dayKey(sk))
+		keys = append(keys, minuteKey(sk, now))
+		keys = append(keys, dayKey(sk, now))
 		minLim := r.limitFor(sk, true)
 		dayLim := r.limitFor(sk, false)
 		argLimits = append(argLimits, minLim.reqPerWindow, minLim.tokPerWindow, dayLim.reqPerWindow, dayLim.tokPerWindow)
@@ -422,14 +441,14 @@ func (r *redisLimiter) CheckAndReserve(ctx context.Context, id string, scope Sco
 }
 
 // windowFlags reports which windows are still the ones the reservation was
-// made in. The Redis key names are not window-stamped (identity comes from
-// TTL expiry), so a reconcile that crosses a boundary would otherwise land on
-// the next window's counters and erase other requests' reservations.
+// made in. A window that has rolled over took the reservation with it, so
+// there is nothing left to reconcile — touching its key would only resurrect
+// an expired counter.
 func windowFlags(reservedAt, now time.Time) (applyMin, applyDay int) {
-	if reservedAt.Truncate(time.Minute).Equal(now.Truncate(time.Minute)) {
+	if minuteWindow(reservedAt) == minuteWindow(now) {
 		applyMin = 1
 	}
-	if reservedAt.Truncate(24 * time.Hour).Equal(now.Truncate(24 * time.Hour)) {
+	if dayWindow(reservedAt) == dayWindow(now) {
 		applyDay = 1
 	}
 	return applyMin, applyDay
@@ -447,8 +466,8 @@ func (r *redisLimiter) Adjust(ctx context.Context, id string, scope ScopeKeys, t
 	}
 	keys := make([]string, 0, len(scopeKeys)*2)
 	for _, sk := range scopeKeys {
-		keys = append(keys, minuteKey(sk))
-		keys = append(keys, dayKey(sk))
+		keys = append(keys, minuteKey(sk, reservedAt))
+		keys = append(keys, dayKey(sk, reservedAt))
 	}
 	argv := []interface{}{tokenDelta, secToMinuteEnd(now), secToDayEnd(now), len(scopeKeys), applyMin, applyDay}
 	_, err := luaAdjust.Run(ctx, r.rdb, keys, argv...).Result()
@@ -467,8 +486,8 @@ func (r *redisLimiter) Cancel(ctx context.Context, id string, scope ScopeKeys, e
 	}
 	keys := make([]string, 0, len(scopeKeys)*2)
 	for _, sk := range scopeKeys {
-		keys = append(keys, minuteKey(sk))
-		keys = append(keys, dayKey(sk))
+		keys = append(keys, minuteKey(sk, reservedAt))
+		keys = append(keys, dayKey(sk, reservedAt))
 	}
 	argv := []interface{}{estTokens, secToMinuteEnd(now), secToDayEnd(now), len(scopeKeys), applyMin, applyDay}
 	_, err := luaCancel.Run(ctx, r.rdb, keys, argv...).Result()

--- a/internal/ratelimit/redis_test.go
+++ b/internal/ratelimit/redis_test.go
@@ -88,8 +88,42 @@ func TestRedisLimiterCancelAfterMinuteRotationSkipsNewWindow(t *testing.T) {
 
 	// The day window was still current, so A's day tokens were released:
 	// B's 40 remain (A's 40 + B's 40 - A's cancel).
-	dayTok := mr.HGet("rl:day:user:u-rotate", "tok")
+	dayTok := mr.HGet(dayKey("user:u-rotate", t0), "tok")
 	assert.Equal(t, "40", dayTok, "day window should hold only B's tokens after A's cancel")
+}
+
+// TestRedisLimiterMinuteWindowsDoNotCarryOver pins the window-stamped key
+// layout. EXPIRE has whole-second granularity, so a reservation made late in a
+// minute leaves a key that outlives its window; the next window must neither
+// inherit that count nor extend the stale key's TTL.
+func TestRedisLimiterMinuteWindowsDoNotCarryOver(t *testing.T) {
+	cfg := baseCfg()
+	lim, mr := newRedisLimiterForTest(t, cfg)
+
+	scope := ScopeKeys{UserID: "u-carry"}
+	// Second 59, so the minute key gets a 1s TTL and survives into W2.
+	t0 := time.Date(2026, 7, 24, 12, 0, 59, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	for i := 0; i < 2; i++ {
+		res, err := lim.CheckAndReserve(context.Background(), "w1", scope, 1, t0)
+		require.NoError(t, err)
+		require.True(t, res.Allowed, "W1 reserve %d", i)
+	}
+	over, _ := lim.CheckAndReserve(context.Background(), "w1-over", scope, 1, t0)
+	require.False(t, over.Allowed, "W1's RPM budget should be spent")
+
+	// W1's key is deliberately left unexpired (no FastForward), reproducing the
+	// sub-second overlap at the boundary.
+	for i := 0; i < 2; i++ {
+		res, err := lim.CheckAndReserve(context.Background(), "w2", scope, 1, t1)
+		require.NoError(t, err)
+		require.True(t, res.Allowed, "W2 must start on a full budget, reserve %d", i)
+	}
+
+	w1Key := minuteKey("user:u-carry", t0)
+	assert.Equal(t, "2", mr.HGet(w1Key, "req"), "W2 must not touch W1's counter")
+	assert.Equal(t, time.Second, mr.TTL(w1Key), "W2 must not extend W1's TTL")
 }
 
 func TestRedisLimiterAdjust(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the `fuzz-tests` failure on `main` ([pipeline 310](https://app.circleci.com/pipelines/gh/Instawork/llm-proxy/310)), where the
`ratelimit-cancel-5xx` scenario reported `after 5xx cancel expected 5 ok got 4`.
This turned out to be a real rate-limiter bug, not a flaky assertion.

The Redis limiter stored each scope's counters at a fixed key (`rl:min:<scope>`)
and relied on TTL expiry alone to mark a window as finished. Redis `EXPIRE` is
whole-second granular while `secToMinuteEnd` computes the TTL from
`t.Unix() % 60`, so a reservation made at 12:00:58.7 got a 2s TTL and its key
survived ~700ms into the next minute. The first request of the new window then
read the previous window's count *and* renewed the TTL to the new boundary, so
the leaked usage stuck around for that window's full duration.

Two consequences:

- A caller could silently lose part of its per-minute budget at any minute
  boundary — throttled at 4/5 of its configured RPM for a whole minute in the
  CI case.
- The 5xx refund path added in #40 was doing the right thing and still losing a
  refund: `windowFlags` correctly declines to touch a window that has rolled
  over, but the un-refunded count was visible in the new window anyway because
  both windows shared one key.

The proxy log from the failing job shows this exactly — all five reservations
logged `ratelimit: cancel (upstream 503)`, yet only four of the five recovery
requests were admitted and the fifth got `minute limit exceeded`. The one
reservation whose cancel straddled the 19:07 → 19:08 boundary leaked into
19:08's budget.

### The fix

Stamp the window into the key (`rl:min:<epochMinute>:<scope>`,
`rl:day:<epochDay>:<scope>`) so a reservation, its reconcile, and the admin
snapshot all address one specific window. Second-granularity TTLs then only
decide when a dead key gets collected, not which window a counter belongs to.
This is what the in-memory limiter already does conceptually — it rotates its
counter maps on `now.Truncate(time.Minute)`.

`Adjust`/`Cancel` now address the reservation's window rather than the current
one, and `windowFlags` is rewritten in terms of the same window helpers so the
guard and the key stamping cannot disagree.

### Design alternative considered

Keeping the unstamped keys and storing the window stamp as a field inside each
hash, with the Lua scripts resetting a stale hash on read. That also closes the
hole, but it puts a write on the read path, makes every script branch on
staleness, and leaves the two backends structurally further apart. Stamping the
key needs no reset logic — stale windows collect themselves via TTL.

### Deploy note

This changes the Redis key layout. Old `rl:min:*` keys are orphaned and expire
within a minute; old `rl:day:*` keys are orphaned for up to a day, so daily
counters effectively reset once at deploy. No migration needed.

## Test plan

- [x] `TestRedisLimiterMinuteWindowsDoNotCarryOver` — new regression test:
      fills a window's RPM budget at second 59, then reserves in the next window
      while the old key is deliberately still alive. Verified it fails on the
      pre-fix code with `W2 must start on a full budget, reserve 0` (the same
      symptom CI hit) and passes with the fix. Also asserts the old window's
      counter and TTL are untouched.
- [x] `TestRedisLimiterCancelAfterMinuteRotationSkipsNewWindow` (#40's guard)
      still passes; its hard-coded `rl:day:user:u-rotate` literal now goes
      through `dayKey`.
- [x] `TestRedisLimiter_SnapshotReportsLiveCounters` still passes — the admin
      snapshot now SCANs a narrower, window-scoped prefix.
- [x] `make ci` — gofmt -s, gofumpt, vet, PII log lint, config-validator,
      race-enabled unit tests.
- [ ] `fuzz-tests` in CI on this branch: `ratelimit-cancel-5xx` should now be
      deterministic rather than a coin flip at minute boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed rate-limit counters carrying over between minute and day windows.
  - Ensured new time windows receive fresh budgets while previous counters and expiration periods remain intact.
  - Improved reservation, adjustment, cancellation, and reconciliation behavior across window boundaries.

- **Tests**
  - Added coverage verifying minute-window counters reset correctly at boundary transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->