### PR TITLE
Add expiry dates for API keys with background revoke-and-delete sweeper

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/fake"
 	"github.com/Instawork/llm-proxy/internal/history"
 	"github.com/Instawork/llm-proxy/internal/idgatestats"
+	"github.com/Instawork/llm-proxy/internal/keyexpiry"
 	"github.com/Instawork/llm-proxy/internal/middleware"
 	"github.com/Instawork/llm-proxy/internal/modelstatusstats"
 	"github.com/Instawork/llm-proxy/internal/observability"
@@ -151,6 +152,9 @@ var (
 	globalAdminRollupStore *adminrollup.Store
 	globalAdminRollupStop  chan struct{}
 )
+
+// Background sweeper that revokes and deletes keys past their expiry grace period.
+var globalKeyExpiryStop chan struct{}
 
 // Global circuit breaker store instance
 var globalCircuitStore circuit.Store
@@ -803,6 +807,31 @@ func initializeAPIKeyStore(yamlConfig *config.YAMLConfig) providers.APIKeyStore 
 	return store
 }
 
+// startKeyExpirySweeper launches the background job that revokes and deletes
+// keys past their expiry grace period. It is a no-op when the key store
+// isn't a *apikeys.Store (e.g. disabled) or the feature is off in config.
+func startKeyExpirySweeper(yamlConfig *config.YAMLConfig) {
+	expiryCfg := yamlConfig.Features.APIKeyManagement.Expiry
+	if !expiryCfg.Enabled {
+		return
+	}
+	store, ok := globalAPIKeyStore.(*apikeys.Store)
+	if !ok || store == nil {
+		logProxyError("Key expiry sweeper disabled: API key store unavailable")
+		return
+	}
+
+	sweeper := keyexpiry.NewSweeper(store, globalKeyProvisioner, keyexpiry.Config{
+		SweepInterval: time.Duration(expiryCfg.SweepIntervalSeconds) * time.Second,
+		GracePeriod:   time.Duration(expiryCfg.GracePeriodDays) * 24 * time.Hour,
+	}, logger)
+	globalKeyExpiryStop = make(chan struct{})
+	go sweeper.Run(globalKeyExpiryStop)
+	logger.Info("Key expiry sweeper: ENABLED",
+		"sweep_interval_seconds", expiryCfg.SweepIntervalSeconds,
+		"grace_period_days", expiryCfg.GracePeriodDays)
+}
+
 func initializeAdminUserStore(yamlConfig *config.YAMLConfig) *adminusers.Store {
 	if yamlConfig == nil || !yamlConfig.Features.AdminDashboard.Enabled {
 		logger.Info("👤 Admin User Store: admin dashboard disabled")
@@ -1365,6 +1394,8 @@ func runServer(yamlConfig *config.YAMLConfig, disableGzip bool) {
 			logger.Info("Key provisioning: ENABLED")
 		}
 	}
+
+	startKeyExpirySweeper(yamlConfig)
 
 	// Initialize rate limiter if enabled
 	if yamlConfig.Features.RateLimiting.Enabled {
@@ -1976,6 +2007,9 @@ func gracefulShutdown(server *http.Server) {
 	}
 	if globalAdminRollupStop != nil {
 		close(globalAdminRollupStop)
+	}
+	if globalKeyExpiryStop != nil {
+		close(globalKeyExpiryStop)
 	}
 	if globalAdminRollupStore != nil {
 		if err := globalAdminRollupStore.Close(); err != nil {

--- a/configs/production.yml
+++ b/configs/production.yml
@@ -48,6 +48,11 @@ features:
           metered: "${LLM_PROXY_ANTHROPIC_KEY_METERED}"
           elevated: "${LLM_PROXY_ANTHROPIC_KEY_ELEVATED}"
           unrestricted: "${LLM_PROXY_ANTHROPIC_KEY_UNRESTRICTED}"
+    expiry:
+      enabled: true
+      sweep_interval_seconds: 900
+      grace_period_days: 7
+      max_days: 365
   # Circuit breaker: enforce mode.  Retries transient failures (up to
   # max_transient_retries), fast-fails open circuits with a synthetic 503,
   # and counts retry contributions toward the failure window.

--- a/docs/API_KEY_MANAGEMENT.md
+++ b/docs/API_KEY_MANAGEMENT.md
@@ -85,6 +85,29 @@ Dashboard users with the **viewer** role can manage personal proxy keys only:
 
 Legacy keys with an empty `owner_email` are unchanged and remain visible to editors and admins only.
 
+## Key expiry
+
+Any key (org-wide or personal) can have an optional expiry date, set from the admin UI (presets: 1 day, 7 days, 30 days, 90 days, or a custom date) or via the API's `expires_at` field. `expires_at` is stored as an absolute RFC3339 UTC timestamp.
+
+- **Enforcement is immediate**: once `expires_at` is in the past, every request using that key is rejected at the validation path (`Store.GetKey`) with `API key has expired`, the same way a disabled key is rejected. No separate mechanism is needed for this part.
+- **Cleanup runs on a delay**: a background sweeper (`internal/keyexpiry`) periodically finds keys that expired more than `grace_period_days` ago (default 7) and retires them — revoking the upstream provider credential first if the key was provisioned (`internal/provision`), then deleting the DynamoDB record. The grace period keeps an expired key visible (marked "Expired") in the admin UI for a few days before it disappears.
+- **Editing**: expiry can be set, extended, shortened, or cleared at any time via `PATCH /admin/api/keys/{key}` with `expires_at` set to an ISO timestamp (set/extend) or `null` (clear). Viewers may set expiry when creating their own personal key, but cannot edit it afterward — only editors and admins can PATCH `expires_at`.
+- **Bounds**: `expires_at` must be in the future and no more than `max_days` (default 365) out, enforced on both create and update.
+
+Configure the sweeper under `features.api_key_management.expiry` in YAML:
+
+```yaml
+features:
+  api_key_management:
+    expiry:
+      enabled: true
+      sweep_interval_seconds: 900  # how often the sweeper runs (default 900 = 15 min)
+      grace_period_days: 7         # delay between expiry and hard delete (default 7)
+      max_days: 365                # furthest an expiry date can be set (default 365)
+```
+
+Only one ECS task performs cleanup at a time: the sweeper acquires a lease via a conditional put on a fixed DynamoDB record (`lease:key-expiry-sweep`) before scanning for expired keys, so running multiple proxy instances does not cause duplicate revoke calls or delete races.
+
 ## Using the Key Management Tool
 
 ### Building the Tool
@@ -253,7 +276,6 @@ With HTTP status code 401 (Unauthorized).
 
 - **Cost Limiting**: The `daily_cost_limit` field is ready for implementing 24-hour spending limits
 - **Usage Analytics**: Track usage per key for billing and monitoring
-- **Key Expiration**: Automatic key expiration based on `expires_at` field
 - **Rate Limiting**: Per-key rate limiting
 - **Multi-provider Keys**: Single proxy key that works across multiple providers
 

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/apikeys"
 	"github.com/Instawork/llm-proxy/internal/config"
+	"github.com/Instawork/llm-proxy/internal/keyexpiry"
 	"github.com/Instawork/llm-proxy/internal/provision"
 	"github.com/Instawork/llm-proxy/internal/ratelimit"
 	"github.com/gorilla/mux"
@@ -139,6 +140,10 @@ func (h *handler) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider is required"})
 		return
 	}
+	if err := h.validateExpiresAt(req.ExpiresAt); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 
 	user, err := h.auth.currentUser(r)
 	if err != nil {
@@ -202,6 +207,7 @@ func (h *handler) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		meta.ExpiresAt = req.ExpiresAt
 		key, err := h.deps.APIKeyStore.CreatePersonalKey(
 			r.Context(),
 			user.Email,
@@ -336,12 +342,19 @@ func (h *handler) handleUpdateKey(w http.ResponseWriter, r *http.Request) {
 
 	if !permissions.UpdateKeyPolicyFieldsAllowed(role) {
 		if req.Enabled != nil || req.DailyCostLimit != nil || req.MonthlyCostLimit != nil || req.Tags != nil || req.RedactPII.Defined ||
-			req.RateLimitRPM != nil || req.RateLimitTPM != nil || req.RateLimitRPD != nil || req.RateLimitTPD != nil {
+			req.RateLimitRPM != nil || req.RateLimitTPM != nil || req.RateLimitRPD != nil || req.RateLimitTPD != nil || req.ExpiresAt.Defined {
 			writeJSON(w, http.StatusForbidden, map[string]string{"error": "viewers may only update description"})
 			return
 		}
 		if req.Description == nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no fields to update"})
+			return
+		}
+	}
+
+	if req.ExpiresAt.Defined && req.ExpiresAt.Value != nil {
+		if err := h.validateExpiresAt(req.ExpiresAt.Value); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
 	}
@@ -399,6 +412,13 @@ func (h *handler) handleUpdateKey(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.RateLimitTPD != nil {
 		updates["rate_limit_tpd"] = *req.RateLimitTPD
+	}
+	if req.ExpiresAt.Defined {
+		if req.ExpiresAt.Value == nil {
+			updates["expires_at"] = nil
+		} else {
+			updates["expires_at"] = *req.ExpiresAt.Value
+		}
 	}
 
 	if len(updates) == 0 {
@@ -484,24 +504,7 @@ func (h *handler) handleDeleteKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if record.Provisioned && h.deps.KeyProvisioner != nil {
-		if revokeErr := h.deps.KeyProvisioner.Revoke(
-			r.Context(),
-			record.Provider,
-			record.UpstreamKeyID,
-			record.UpstreamKind,
-		); revokeErr != nil {
-			h.deps.Logger.Warn(
-				"admin: upstream revoke failed",
-				"key", keyID,
-				"provider", record.Provider,
-				"upstream_id", record.UpstreamKeyID,
-				"error", revokeErr,
-			)
-		}
-	}
-
-	if err := h.deps.APIKeyStore.DeleteKey(r.Context(), record.PK); err != nil {
+	if err := keyexpiry.RetireKey(r.Context(), h.deps.APIKeyStore, h.deps.KeyProvisioner, record, h.deps.Logger); err != nil {
 		if strings.Contains(err.Error(), "ConditionalCheckFailed") {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "key not found"})
 			return

--- a/internal/admin/key_requests_handlers.go
+++ b/internal/admin/key_requests_handlers.go
@@ -249,6 +249,9 @@ func (h *handler) createOrgKey(r *http.Request, role adminusers.Role, req Create
 	if err := validateProvisionedKeyOnly(role, &req); err != nil {
 		return nil, &orgKeyError{status: http.StatusBadRequest, message: err.Error()}
 	}
+	if err := h.validateExpiresAt(req.ExpiresAt); err != nil {
+		return nil, &orgKeyError{status: http.StatusBadRequest, message: err.Error()}
+	}
 
 	if err := apikeys.ValidatePIIOffBedrockPolicy(
 		h.globalPIIEnabled(),
@@ -309,6 +312,7 @@ func (h *handler) createOrgKey(r *http.Request, role adminusers.Role, req Create
 			return nil, &orgKeyError{status: http.StatusBadRequest, message: "actual_key is required unless auto_provision is true"}
 		}
 	}
+	meta.ExpiresAt = req.ExpiresAt
 
 	key, err := h.deps.APIKeyStore.CreateKeyWithMeta(
 		r.Context(),

--- a/internal/admin/keys_expiry_handlers_test.go
+++ b/internal/admin/keys_expiry_handlers_test.go
@@ -1,0 +1,137 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/adminusers"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleCreateKey_ExpiresAt_RoundTrips(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	expiresAt := time.Now().Add(24 * time.Hour).Truncate(time.Second).UTC()
+
+	body, _ := json.Marshal(CreateKeyRequest{
+		Provider:    "openai",
+		ActualKey:   "sk-real",
+		Description: "expiring key",
+		ExpiresAt:   &expiresAt,
+	})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateKey(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var resp KeyResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.NotNil(t, resp.ExpiresAt)
+	assert.WithinDuration(t, expiresAt, *resp.ExpiresAt, time.Second)
+}
+
+func TestHandleCreateKey_ExpiresAt_RejectsPastDate(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	past := time.Now().Add(-1 * time.Hour)
+
+	body, _ := json.Marshal(CreateKeyRequest{
+		Provider:  "openai",
+		ActualKey: "sk-real",
+		ExpiresAt: &past,
+	})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateKey(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleCreateKey_ExpiresAt_RejectsBeyondMaxDays(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	h.deps.YAMLConfig.Features.APIKeyManagement.Expiry.MaxDays = 30
+	tooFar := time.Now().Add(60 * 24 * time.Hour)
+
+	body, _ := json.Marshal(CreateKeyRequest{
+		Provider:  "openai",
+		ActualKey: "sk-real",
+		ExpiresAt: &tooFar,
+	})
+	req := authenticatedRequest(t, h, http.MethodPost, "/admin/api/keys", body)
+	rec := httptest.NewRecorder()
+	h.handleCreateKey(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleUpdateKey_ExpiresAt_SetAndClear(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+
+	key, err := store.CreateKey(ctx, "openai", "sk", "", 0, nil, nil)
+	require.NoError(t, err)
+
+	future := time.Now().Add(24 * time.Hour).Truncate(time.Second).UTC()
+	setBody, _ := json.Marshal(map[string]interface{}{"expires_at": future})
+	setReq := authenticatedRequest(t, h, http.MethodPatch, "/admin/api/keys/"+key.PK, setBody)
+	setReq = mux.SetURLVars(setReq, map[string]string{"key": key.PK})
+	setRec := httptest.NewRecorder()
+	h.handleUpdateKey(setRec, setReq)
+	require.Equal(t, http.StatusOK, setRec.Code, setRec.Body.String())
+
+	updated, err := store.GetKeyRecord(ctx, key.PK)
+	require.NoError(t, err)
+	require.NotNil(t, updated.ExpiresAt)
+	assert.WithinDuration(t, future, *updated.ExpiresAt, time.Second)
+
+	clearBody := []byte(`{"expires_at": null}`)
+	clearReq := authenticatedRequest(t, h, http.MethodPatch, "/admin/api/keys/"+key.PK, clearBody)
+	clearReq = mux.SetURLVars(clearReq, map[string]string{"key": key.PK})
+	clearRec := httptest.NewRecorder()
+	h.handleUpdateKey(clearRec, clearReq)
+	require.Equal(t, http.StatusOK, clearRec.Code, clearRec.Body.String())
+
+	cleared, err := store.GetKeyRecord(ctx, key.PK)
+	require.NoError(t, err)
+	assert.Nil(t, cleared.ExpiresAt)
+}
+
+func TestHandleUpdateKey_ExpiresAt_RejectsPastDate(t *testing.T) {
+	h, store := testAdminHandler(t)
+	ctx := context.Background()
+
+	key, err := store.CreateKey(ctx, "openai", "sk", "", 0, nil, nil)
+	require.NoError(t, err)
+
+	body := []byte(`{"expires_at": "2000-01-01T00:00:00Z"}`)
+	req := authenticatedRequest(t, h, http.MethodPatch, "/admin/api/keys/"+key.PK, body)
+	req = mux.SetURLVars(req, map[string]string{"key": key.PK})
+	rec := httptest.NewRecorder()
+	h.handleUpdateKey(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleUpdateKey_ExpiresAt_ForbiddenForViewer(t *testing.T) {
+	h, _ := testAdminHandler(t)
+	ctx := context.Background()
+	_, err := h.deps.UserStore.CreateUser(ctx, "viewer@example.com", adminusers.RoleViewer)
+	require.NoError(t, err)
+
+	createBody, _ := json.Marshal(CreateKeyRequest{Provider: "bedrock", Description: "viewer bedrock"})
+	createReq := authenticatedRequestAs(t, h, "viewer@example.com", http.MethodPost, "/admin/api/keys", createBody)
+	createRec := httptest.NewRecorder()
+	h.handleCreateKey(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code, createRec.Body.String())
+	var created KeyResponse
+	require.NoError(t, json.NewDecoder(createRec.Body).Decode(&created))
+
+	future := time.Now().Add(24 * time.Hour)
+	body, _ := json.Marshal(map[string]interface{}{"expires_at": future})
+	req := authenticatedRequestAs(t, h, "viewer@example.com", http.MethodPatch, "/admin/api/keys/"+created.Key, body)
+	req = mux.SetURLVars(req, map[string]string{"key": created.Key})
+	rec := httptest.NewRecorder()
+	h.handleUpdateKey(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/internal/admin/rbac.go
+++ b/internal/admin/rbac.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Instawork/llm-proxy/internal/adminusers"
 	"github.com/Instawork/llm-proxy/internal/config"
 )
+
+const defaultKeyExpiryMaxDays = 365
 
 func (a *authenticator) userRole(r *http.Request) (adminusers.Role, error) {
 	user, err := a.currentUser(r)
@@ -157,6 +160,27 @@ func (h *handler) validateEditorCostLimit(r *http.Request, cents int64) error {
 	max := h.editorMaxDailyCostCents()
 	if max > 0 && cents > max {
 		return fmt.Errorf("daily_cost_limit exceeds editor maximum of %d cents", max)
+	}
+	return nil
+}
+
+// validateExpiresAt rejects expiry dates that are already past or further out
+// than the configured maximum, so a typo can't produce a key that never
+// effectively expires. A nil expiresAt (no expiry requested) always passes.
+func (h *handler) validateExpiresAt(expiresAt *time.Time) error {
+	if expiresAt == nil {
+		return nil
+	}
+	now := time.Now()
+	if !expiresAt.After(now) {
+		return fmt.Errorf("expires_at must be in the future")
+	}
+	maxDays := defaultKeyExpiryMaxDays
+	if h.deps.YAMLConfig != nil && h.deps.YAMLConfig.Features.APIKeyManagement.Expiry.MaxDays > 0 {
+		maxDays = h.deps.YAMLConfig.Features.APIKeyManagement.Expiry.MaxDays
+	}
+	if expiresAt.After(now.AddDate(0, 0, maxDays)) {
+		return fmt.Errorf("expires_at cannot be more than %d days in the future", maxDays)
 	}
 	return nil
 }

--- a/internal/admin/types.go
+++ b/internal/admin/types.go
@@ -141,6 +141,9 @@ type CreateKeyRequest struct {
 	RateLimitTPM     int               `json:"rate_limit_tpm,omitempty"`
 	RateLimitRPD     int               `json:"rate_limit_rpd,omitempty"`
 	RateLimitTPD     int               `json:"rate_limit_tpd,omitempty"`
+	// ExpiresAt optionally sets when the key stops accepting proxy requests
+	// and becomes eligible for the expiry sweeper's cleanup.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
 // UpdateKeyRequest patches mutable key fields.
@@ -155,6 +158,8 @@ type UpdateKeyRequest struct {
 	RateLimitTPM     *int              `json:"rate_limit_tpm,omitempty"`
 	RateLimitRPD     *int              `json:"rate_limit_rpd,omitempty"`
 	RateLimitTPD     *int              `json:"rate_limit_tpd,omitempty"`
+	// ExpiresAt: omitted leaves expiry unchanged, null clears it, a value sets it.
+	ExpiresAt OptionalTime `json:"expires_at,omitempty"`
 }
 
 // OptionalBool distinguishes omitted, null (inherit), and explicit bool values.
@@ -175,6 +180,27 @@ func (o *OptionalBool) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	o.Value = &b
+	return nil
+}
+
+// OptionalTime distinguishes omitted, null (clear), and explicit time values.
+type OptionalTime struct {
+	Defined bool
+	Value   *time.Time
+}
+
+// UnmarshalJSON implements tri-state time decoding for PATCH payloads.
+func (o *OptionalTime) UnmarshalJSON(data []byte) error {
+	o.Defined = true
+	if string(data) == "null" {
+		o.Value = nil
+		return nil
+	}
+	var t time.Time
+	if err := json.Unmarshal(data, &t); err != nil {
+		return err
+	}
+	o.Value = &t
 	return nil
 }
 

--- a/internal/apikeys/store.go
+++ b/internal/apikeys/store.go
@@ -513,6 +513,18 @@ type KeyCreateMeta struct {
 	Provisioned   bool
 	UpstreamKeyID string
 	UpstreamKind  string
+	// ExpiresAt optionally sets the key's expiry at creation time.
+	ExpiresAt *time.Time
+}
+
+// normalizeExpiresAt converts an optional expiry to UTC so stored values sort
+// lexicographically, which ListExpiredKeys relies on for its scan filter.
+func normalizeExpiresAt(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	utc := t.UTC()
+	return &utc
 }
 
 // GenerateKey generates a new API key using the current generation prefix
@@ -553,6 +565,7 @@ func (s *Store) CreateKeyWithMeta(ctx context.Context, provider, actualKey, desc
 		Description:      description,
 		CreatedAt:        now,
 		UpdatedAt:        now,
+		ExpiresAt:        normalizeExpiresAt(meta.ExpiresAt),
 		Enabled:          true,
 		Tags:             tags,
 		RedactPII:        redactPII,
@@ -642,6 +655,7 @@ func (s *Store) CreatePersonalKey(ctx context.Context, ownerEmail, provider, act
 		Description:      description,
 		CreatedAt:        now,
 		UpdatedAt:        now,
+		ExpiresAt:        normalizeExpiresAt(meta.ExpiresAt),
 		Enabled:          true,
 		Tags:             map[string]string{"personal": "true"},
 		Provisioned:      meta.Provisioned,
@@ -796,9 +810,15 @@ func (s *Store) UpdateKey(ctx context.Context, key string, updates map[string]in
 			updateExpr.WriteString(", enabled = :enabled")
 			exprAttrValues[":enabled"] = &types.AttributeValueMemberBOOL{Value: value.(bool)}
 		case "expires_at":
-			updateExpr.WriteString(", expires_at = :expires_at")
-			if t, ok := value.(time.Time); ok {
-				exprAttrValues[":expires_at"] = &types.AttributeValueMemberS{Value: t.Format(time.RFC3339)}
+			if value == nil {
+				removeParts = append(removeParts, "expires_at")
+			} else {
+				t, ok := value.(time.Time)
+				if !ok {
+					return fmt.Errorf("expires_at update must be a time.Time or nil, got %T", value)
+				}
+				updateExpr.WriteString(", expires_at = :expires_at")
+				exprAttrValues[":expires_at"] = &types.AttributeValueMemberS{Value: t.UTC().Format(time.RFC3339)}
 			}
 		case "tags":
 			updateExpr.WriteString(", tags = :tags")
@@ -1010,6 +1030,82 @@ func (s *Store) GetOwnerKeyByProvider(ctx context.Context, ownerEmail, provider 
 		return nil, nil
 	}
 	return keys[0], nil
+}
+
+// ListExpiredKeys returns proxy keys whose expiry is at or before the given
+// cutoff. The DynamoDB filter is a lexicographic narrowing only (expires_at
+// is stored as an RFC3339 UTC string), so callers must not depend on it for
+// correctness; ExpiresAt is re-checked against cutoff after unmarshalling.
+func (s *Store) ListExpiredKeys(ctx context.Context, cutoff time.Time) ([]*APIKey, error) {
+	cutoff = cutoff.UTC()
+	scanInput := &dynamodb.ScanInput{
+		TableName: aws.String(s.tableName),
+		FilterExpression: aws.String(
+			"(begins_with(pk, :skPfx) OR begins_with(pk, :legacyPfx)) AND attribute_exists(expires_at) AND expires_at <= :cutoff",
+		),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":skPfx":     &types.AttributeValueMemberS{Value: generationKeyPrefix(keyPrefixBase)},
+			":legacyPfx": &types.AttributeValueMemberS{Value: keyPrefixBase},
+			":cutoff":    &types.AttributeValueMemberS{Value: cutoff.Format(time.RFC3339)},
+		},
+	}
+
+	var keys []*APIKey
+	for {
+		result, err := s.client.Scan(ctx, scanInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan expired API keys: %w", err)
+		}
+		for _, item := range result.Items {
+			var apiKey APIKey
+			if err := attributevalue.UnmarshalMap(item, &apiKey); err != nil {
+				s.logger.Warn("Failed to unmarshal API key", "error", err)
+				continue
+			}
+			if apiKey.ExpiresAt == nil || apiKey.ExpiresAt.After(cutoff) {
+				continue
+			}
+			keys = append(keys, &apiKey)
+		}
+		if len(result.LastEvaluatedKey) == 0 {
+			break
+		}
+		scanInput.ExclusiveStartKey = result.LastEvaluatedKey
+	}
+	return keys, nil
+}
+
+// sweepLeasePK is the fixed sentinel record used to elect a single sweeper
+// across ECS tasks. It shares the keys table so cleanup has no dependency
+// beyond DynamoDB, which must already be up for keys to exist at all.
+const sweepLeasePK = "lease:key-expiry-sweep"
+
+// TryAcquireSweepLease attempts to become the sole owner of the expiry sweep
+// for the given ttl. Returns true if the caller now holds the lease.
+func (s *Store) TryAcquireSweepLease(ctx context.Context, holder string, ttl time.Duration) (bool, error) {
+	now := time.Now().UTC()
+	expiresAt := now.Add(ttl).Format(time.RFC3339)
+
+	_, err := s.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":               &types.AttributeValueMemberS{Value: sweepLeasePK},
+			"holder":           &types.AttributeValueMemberS{Value: holder},
+			"lease_expires_at": &types.AttributeValueMemberS{Value: expiresAt},
+		},
+		ConditionExpression: aws.String("attribute_not_exists(pk) OR lease_expires_at < :now"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":now": &types.AttributeValueMemberS{Value: now.Format(time.RFC3339)},
+		},
+	})
+	if err != nil {
+		var ccfe *types.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to acquire sweep lease: %w", err)
+	}
+	return true, nil
 }
 
 // LookupProxyKey returns the DynamoDB record for a proxy bearer token

--- a/internal/apikeys/store_test.go
+++ b/internal/apikeys/store_test.go
@@ -192,6 +192,111 @@ func TestStore_UpdateKey_AllFields(t *testing.T) {
 	// code paths in Store.UpdateKey, which is its primary value.
 }
 
+// ----------------------------------------------------------------------------
+// Expiry: set at creation, update (set + clear), and ListExpiredKeys
+// ----------------------------------------------------------------------------
+
+func TestStore_CreateKeyWithMeta_SetsExpiresAt(t *testing.T) {
+	store, _ := newFakeStore(t)
+	expiresAt := time.Now().Add(24 * time.Hour)
+
+	created, err := store.CreateKeyWithMeta(
+		context.Background(), "openai", "real-sk", "expiring", 100, 0, nil, nil,
+		KeyCreateMeta{ExpiresAt: &expiresAt},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, created.ExpiresAt)
+	assert.WithinDuration(t, expiresAt, *created.ExpiresAt, time.Second)
+	assert.Equal(t, time.UTC, created.ExpiresAt.Location())
+}
+
+func TestStore_UpdateKey_SetsExpiresAt(t *testing.T) {
+	store, _ := newFakeStore(t)
+	created, err := store.CreateKey(context.Background(), "openai", "real-sk", "", 100, nil, nil)
+	require.NoError(t, err)
+
+	future := time.Now().Add(48 * time.Hour).Truncate(time.Second)
+	require.NoError(t, store.UpdateKey(context.Background(), created.PK, map[string]interface{}{
+		"expires_at": future,
+	}))
+
+	record, err := store.GetKeyRecord(context.Background(), created.PK)
+	require.NoError(t, err)
+	require.NotNil(t, record.ExpiresAt)
+	assert.WithinDuration(t, future, *record.ExpiresAt, time.Second)
+}
+
+func TestStore_UpdateKey_ClearsExpiresAt(t *testing.T) {
+	store, _ := newFakeStore(t)
+	future := time.Now().Add(1 * time.Hour)
+	created, err := store.CreateKeyWithMeta(
+		context.Background(), "openai", "real-sk", "", 100, 0, nil, nil,
+		KeyCreateMeta{ExpiresAt: &future},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, created.ExpiresAt)
+
+	require.NoError(t, store.UpdateKey(context.Background(), created.PK, map[string]interface{}{
+		"expires_at": nil,
+	}))
+
+	record, err := store.GetKeyRecord(context.Background(), created.PK)
+	require.NoError(t, err)
+	assert.Nil(t, record.ExpiresAt)
+}
+
+func TestStore_UpdateKey_ExpiresAtWrongTypeErrors(t *testing.T) {
+	store, _ := newFakeStore(t)
+	created, err := store.CreateKey(context.Background(), "openai", "real-sk", "", 100, nil, nil)
+	require.NoError(t, err)
+
+	err = store.UpdateKey(context.Background(), created.PK, map[string]interface{}{
+		"expires_at": "not-a-time",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expires_at update must be a time.Time")
+}
+
+func TestStore_ListExpiredKeys(t *testing.T) {
+	store, _ := newFakeStore(t)
+	ctx := context.Background()
+	cutoff := time.Now()
+
+	past := cutoff.Add(-2 * time.Hour)
+	expired, err := store.CreateKeyWithMeta(ctx, "openai", "real-1", "expired", 100, 0, nil, nil, KeyCreateMeta{ExpiresAt: &past})
+	require.NoError(t, err)
+
+	future := cutoff.Add(2 * time.Hour)
+	_, err = store.CreateKeyWithMeta(ctx, "openai", "real-2", "not-yet", 100, 0, nil, nil, KeyCreateMeta{ExpiresAt: &future})
+	require.NoError(t, err)
+
+	_, err = store.CreateKey(ctx, "openai", "real-3", "never-expires", 100, nil, nil)
+	require.NoError(t, err)
+
+	results, err := store.ListExpiredKeys(ctx, cutoff)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, expired.PK, results[0].PK)
+}
+
+// TestStore_TryAcquireSweepLease covers the first-acquire and contended
+// branches. Re-acquisition after TTL expiry relies on DynamoDB evaluating
+// the "lease_expires_at < :now" half of the ConditionExpression, which the
+// shared dynamodbfake (only "attribute_not_exists" aware) doesn't model; that
+// path is exercised by the integration tests against real DynamoDB.
+func TestStore_TryAcquireSweepLease(t *testing.T) {
+	store, _ := newFakeStore(t)
+	ctx := context.Background()
+
+	acquired, err := store.TryAcquireSweepLease(ctx, "host-a", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, acquired, "first acquisition should succeed (no existing lease)")
+
+	acquired, err = store.TryAcquireSweepLease(ctx, "host-b", time.Minute)
+	require.NoError(t, err)
+	assert.False(t, acquired, "host-a's lease is still live, so host-b must not acquire it")
+}
+
 func TestStore_LookupProxyKey(t *testing.T) {
 	store, _ := newFakeStore(t)
 	ctx := context.Background()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -599,6 +599,26 @@ type APIKeyManagementConfig struct {
 	KeyPrefix string `yaml:"key_prefix"`
 	// Provisioning configures automatic upstream key minting for the admin UI.
 	Provisioning KeyProvisioningConfig `yaml:"provisioning,omitempty"`
+	// Expiry controls optional per-key expiry dates and cleanup of expired keys.
+	Expiry KeyExpiryConfig `yaml:"expiry,omitempty"`
+}
+
+// KeyExpiryConfig controls the background sweeper that revokes and deletes
+// keys past their expiry date. Rejection of expired keys on the validation
+// path happens unconditionally in apikeys.Store.GetKey; this only gates
+// cleanup.
+type KeyExpiryConfig struct {
+	Enabled bool `yaml:"enabled"`
+	// SweepIntervalSeconds is how often the sweeper checks for expired keys.
+	// Defaults to 900 (15 minutes) when unset.
+	SweepIntervalSeconds int `yaml:"sweep_interval_seconds,omitempty"`
+	// GracePeriodDays delays deletion after expiry so the admin UI can show
+	// an "Expired" key before it disappears. Defaults to 7 when unset.
+	GracePeriodDays int `yaml:"grace_period_days,omitempty"`
+	// MaxDays bounds how far in the future an expiry date may be set, so a
+	// typo can't produce a key that effectively never expires. Defaults to
+	// 365 when unset.
+	MaxDays int `yaml:"max_days,omitempty"`
 }
 
 // KeyProvisioningConfig controls server-side upstream API key creation.

--- a/internal/keyexpiry/retire.go
+++ b/internal/keyexpiry/retire.go
@@ -1,0 +1,42 @@
+// Package keyexpiry retires proxy API keys: it best-effort revokes the
+// upstream provider credential (when the key was provisioned) and then
+// deletes the DynamoDB record. The admin delete handler and the expiry
+// sweeper share this single path so both stay in sync.
+package keyexpiry
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+)
+
+// deleter is the subset of apikeys.Store used to retire a key.
+type deleter interface {
+	DeleteKey(ctx context.Context, key string) error
+}
+
+// revoker is the subset of provision.Manager used to revoke an upstream
+// credential. Manager.Revoke already no-ops for providers it doesn't manage.
+type revoker interface {
+	Revoke(ctx context.Context, provider, upstreamID, upstreamKind string) error
+}
+
+// RetireKey revokes the upstream provider credential for a provisioned key
+// (logging but not failing on revoke errors, since a key that can't be
+// revoked upstream should still stop accepting proxy traffic), then deletes
+// the proxy key record.
+func RetireKey(ctx context.Context, store deleter, rev revoker, record *apikeys.APIKey, logger *slog.Logger) error {
+	if record.Provisioned && rev != nil {
+		if revokeErr := rev.Revoke(ctx, record.Provider, record.UpstreamKeyID, record.UpstreamKind); revokeErr != nil {
+			logger.Warn(
+				"keyexpiry: upstream revoke failed",
+				"key", apikeys.RedactKey(record.PK),
+				"provider", record.Provider,
+				"upstream_id", record.UpstreamKeyID,
+				"error", revokeErr,
+			)
+		}
+	}
+	return store.DeleteKey(ctx, record.PK)
+}

--- a/internal/keyexpiry/retire_test.go
+++ b/internal/keyexpiry/retire_test.go
@@ -1,0 +1,47 @@
+package keyexpiry
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetireKey_NonProvisioned_SkipsRevoke(t *testing.T) {
+	store := &fakeStore{}
+	rev := &fakeRevoker{}
+
+	err := RetireKey(context.Background(), store, rev, key("k1", false), slog.Default())
+	require.NoError(t, err)
+	assert.Empty(t, rev.revoked)
+	assert.Equal(t, []string{"k1"}, store.deleted)
+}
+
+func TestRetireKey_Provisioned_RevokesThenDeletes(t *testing.T) {
+	store := &fakeStore{}
+	rev := &fakeRevoker{}
+
+	err := RetireKey(context.Background(), store, rev, key("k2", true), slog.Default())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"openai:upstream-k2"}, rev.revoked)
+	assert.Equal(t, []string{"k2"}, store.deleted)
+}
+
+func TestRetireKey_RevokeErrorDoesNotBlockDelete(t *testing.T) {
+	store := &fakeStore{}
+	rev := &fakeRevoker{err: errors.New("upstream down")}
+
+	err := RetireKey(context.Background(), store, rev, key("k3", true), slog.Default())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"k3"}, store.deleted)
+}
+
+func TestRetireKey_DeleteErrorPropagates(t *testing.T) {
+	store := &fakeStore{deleteErr: map[string]error{"k4": errors.New("not found")}}
+
+	err := RetireKey(context.Background(), store, nil, key("k4", false), slog.Default())
+	require.Error(t, err)
+}

--- a/internal/keyexpiry/sweeper.go
+++ b/internal/keyexpiry/sweeper.go
@@ -109,7 +109,10 @@ func (s *Sweeper) SweepOnce(ctx context.Context) (int, error) {
 
 	deleted := 0
 	for _, record := range expired {
-		keyCtx, cancel := context.WithTimeout(ctx, perKeyTimeout)
+		// Independent of ctx's deadline: lease acquisition or listing may have
+		// already consumed most of the sweep budget, and each retirement still
+		// needs its own full timeout rather than whatever is left over.
+		keyCtx, cancel := context.WithTimeout(context.Background(), perKeyTimeout)
 		err := RetireKey(keyCtx, s.store, s.rev, record, s.logger)
 		cancel()
 		if err != nil {

--- a/internal/keyexpiry/sweeper.go
+++ b/internal/keyexpiry/sweeper.go
@@ -1,0 +1,129 @@
+package keyexpiry
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+)
+
+const (
+	defaultSweepInterval = 15 * time.Minute
+	defaultGracePeriod   = 7 * 24 * time.Hour
+	sweepOpTimeout       = 10 * time.Second
+	perKeyTimeout        = 10 * time.Second
+	leaseTTL             = 5 * time.Minute
+)
+
+// Config controls the expiry sweeper's cadence.
+type Config struct {
+	SweepInterval time.Duration
+	GracePeriod   time.Duration
+}
+
+func (c Config) sweepInterval() time.Duration {
+	if c.SweepInterval > 0 {
+		return c.SweepInterval
+	}
+	return defaultSweepInterval
+}
+
+func (c Config) gracePeriod() time.Duration {
+	if c.GracePeriod > 0 {
+		return c.GracePeriod
+	}
+	return defaultGracePeriod
+}
+
+// sweeperStore is the subset of apikeys.Store the sweeper needs.
+type sweeperStore interface {
+	deleter
+	ListExpiredKeys(ctx context.Context, cutoff time.Time) ([]*apikeys.APIKey, error)
+	TryAcquireSweepLease(ctx context.Context, holder string, ttl time.Duration) (bool, error)
+}
+
+// Sweeper periodically retires keys that expired more than the configured
+// grace period ago. A DynamoDB lease ensures only one ECS task sweeps at a
+// time; losing the race is a normal no-op, not an error.
+type Sweeper struct {
+	store  sweeperStore
+	rev    revoker
+	cfg    Config
+	logger *slog.Logger
+	holder string
+}
+
+// NewSweeper constructs a Sweeper. rev may be nil when upstream provisioning
+// is disabled; retirement then just deletes the proxy key record.
+func NewSweeper(store sweeperStore, rev revoker, cfg Config, logger *slog.Logger) *Sweeper {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Sweeper{
+		store:  store,
+		rev:    rev,
+		cfg:    cfg,
+		logger: logger,
+		holder: sweeperHolderID(),
+	}
+}
+
+// Run ticks at the configured interval until stop is closed, sweeping
+// expired keys on each tick.
+func (s *Sweeper) Run(stop <-chan struct{}) {
+	ticker := time.NewTicker(s.cfg.sweepInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), sweepOpTimeout)
+			if _, err := s.SweepOnce(ctx); err != nil {
+				s.logger.Error("keyexpiry: sweep failed", "error", err)
+			}
+			cancel()
+		}
+	}
+}
+
+// SweepOnce retires every key whose expiry is older than the grace period,
+// provided this instance wins the sweep lease. Returns the number retired.
+func (s *Sweeper) SweepOnce(ctx context.Context) (int, error) {
+	acquired, err := s.store.TryAcquireSweepLease(ctx, s.holder, leaseTTL)
+	if err != nil {
+		return 0, err
+	}
+	if !acquired {
+		return 0, nil
+	}
+
+	cutoff := time.Now().Add(-s.cfg.gracePeriod())
+	expired, err := s.store.ListExpiredKeys(ctx, cutoff)
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, record := range expired {
+		keyCtx, cancel := context.WithTimeout(ctx, perKeyTimeout)
+		err := RetireKey(keyCtx, s.store, s.rev, record, s.logger)
+		cancel()
+		if err != nil {
+			s.logger.Error("keyexpiry: retire failed", "key", apikeys.RedactKey(record.PK), "error", err)
+			continue
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+func sweeperHolderID() string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return "llm-proxy"
+}

--- a/internal/keyexpiry/sweeper_test.go
+++ b/internal/keyexpiry/sweeper_test.go
@@ -1,0 +1,134 @@
+package keyexpiry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Instawork/llm-proxy/internal/apikeys"
+)
+
+type fakeStore struct {
+	expired      []*apikeys.APIKey
+	listErr      error
+	deleteErr    map[string]error
+	deleted      []string
+	leaseGranted bool
+	leaseErr     error
+}
+
+func (f *fakeStore) ListExpiredKeys(ctx context.Context, cutoff time.Time) ([]*apikeys.APIKey, error) {
+	return f.expired, f.listErr
+}
+
+func (f *fakeStore) DeleteKey(ctx context.Context, key string) error {
+	f.deleted = append(f.deleted, key)
+	return f.deleteErr[key]
+}
+
+func (f *fakeStore) TryAcquireSweepLease(ctx context.Context, holder string, ttl time.Duration) (bool, error) {
+	return f.leaseGranted, f.leaseErr
+}
+
+type fakeRevoker struct {
+	revoked []string
+	err     error
+}
+
+func (f *fakeRevoker) Revoke(ctx context.Context, provider, upstreamID, upstreamKind string) error {
+	f.revoked = append(f.revoked, provider+":"+upstreamID)
+	return f.err
+}
+
+func key(pk string, provisioned bool) *apikeys.APIKey {
+	return &apikeys.APIKey{
+		PK:            pk,
+		Provider:      "openai",
+		Provisioned:   provisioned,
+		UpstreamKeyID: "upstream-" + pk,
+	}
+}
+
+func TestSweeper_SweepOnce_NoLease_NoWork(t *testing.T) {
+	store := &fakeStore{leaseGranted: false, expired: []*apikeys.APIKey{key("a", true)}}
+	rev := &fakeRevoker{}
+	s := NewSweeper(store, rev, Config{}, nil)
+
+	deleted, err := s.SweepOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+	assert.Empty(t, store.deleted, "losing the lease must not touch any keys")
+	assert.Empty(t, rev.revoked)
+}
+
+func TestSweeper_SweepOnce_RevokesProvisionedOnly(t *testing.T) {
+	store := &fakeStore{
+		leaseGranted: true,
+		expired:      []*apikeys.APIKey{key("provisioned", true), key("byo", false)},
+	}
+	rev := &fakeRevoker{}
+	s := NewSweeper(store, rev, Config{}, nil)
+
+	deleted, err := s.SweepOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, deleted)
+	assert.ElementsMatch(t, []string{"provisioned", "byo"}, store.deleted)
+	assert.Equal(t, []string{"openai:upstream-provisioned"}, rev.revoked, "only the provisioned key should trigger a revoke")
+}
+
+func TestSweeper_SweepOnce_DeletesEvenWhenRevokeFails(t *testing.T) {
+	store := &fakeStore{leaseGranted: true, expired: []*apikeys.APIKey{key("a", true)}}
+	rev := &fakeRevoker{err: errors.New("vendor unavailable")}
+	s := NewSweeper(store, rev, Config{}, nil)
+
+	deleted, err := s.SweepOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted, "a best-effort revoke failure must not block deletion")
+	assert.Equal(t, []string{"a"}, store.deleted)
+}
+
+func TestSweeper_SweepOnce_ContinuesAfterOneDeleteFails(t *testing.T) {
+	store := &fakeStore{
+		leaseGranted: true,
+		expired:      []*apikeys.APIKey{key("bad", false), key("good", false)},
+		deleteErr:    map[string]error{"bad": errors.New("conditional check failed")},
+	}
+	rev := &fakeRevoker{}
+	s := NewSweeper(store, rev, Config{}, nil)
+
+	deleted, err := s.SweepOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted, "one failed delete should not stop the rest of the sweep")
+	assert.ElementsMatch(t, []string{"bad", "good"}, store.deleted)
+}
+
+func TestSweeper_SweepOnce_ListErrorPropagates(t *testing.T) {
+	store := &fakeStore{leaseGranted: true, listErr: errors.New("scan failed")}
+	s := NewSweeper(store, &fakeRevoker{}, Config{}, nil)
+
+	_, err := s.SweepOnce(context.Background())
+	require.Error(t, err)
+}
+
+func TestSweeper_SweepOnce_NilRevokerSkipsRevoke(t *testing.T) {
+	store := &fakeStore{leaseGranted: true, expired: []*apikeys.APIKey{key("a", true)}}
+	s := NewSweeper(store, nil, Config{}, nil)
+
+	deleted, err := s.SweepOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+}
+
+func TestConfig_Defaults(t *testing.T) {
+	var cfg Config
+	assert.Equal(t, defaultSweepInterval, cfg.sweepInterval())
+	assert.Equal(t, defaultGracePeriod, cfg.gracePeriod())
+
+	cfg = Config{SweepInterval: 5 * time.Minute, GracePeriod: 3 * 24 * time.Hour}
+	assert.Equal(t, 5*time.Minute, cfg.sweepInterval())
+	assert.Equal(t, 3*24*time.Hour, cfg.gracePeriod())
+}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -10,8 +10,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <script type="module" crossorigin src="/admin/assets/index-CAoytYYf.js"></script>
-  <link rel="stylesheet" crossorigin href="/admin/assets/index-B5oGKBg6.css">
+  <script type="module" crossorigin src="/admin/assets/index-qpOp2Hng.js"></script>
+  <link rel="stylesheet" crossorigin href="/admin/assets/index-DjPurxRV.css">
 </head>
 
 <body>

--- a/web/src/components/keys/api-keys-modal.tsx
+++ b/web/src/components/keys/api-keys-modal.tsx
@@ -274,6 +274,48 @@ export default function ApiKeysModal({
                 />
               </label>
 
+              {!editingKey || canManagePolicy ? (
+                <div className="form-control w-full">
+                  <span className="label-text mb-1.5">Expires</span>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <select
+                      className="select select-bordered w-full sm:w-48"
+                      value={form.expiry_preset}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          expiry_preset: event.target.value as KeyFormState["expiry_preset"],
+                        }))
+                      }
+                    >
+                      <option value="never">Never</option>
+                      <option value="1d">1 day</option>
+                      <option value="7d">7 days</option>
+                      <option value="30d">30 days</option>
+                      <option value="90d">90 days</option>
+                      <option value="custom">Custom date</option>
+                    </select>
+                    {form.expiry_preset === "custom" ? (
+                      <input
+                        type="date"
+                        className="input input-bordered flex-1"
+                        min={new Date().toISOString().slice(0, 10)}
+                        value={form.expiry_custom}
+                        onChange={(event) =>
+                          setForm((current) => ({
+                            ...current,
+                            expiry_custom: event.target.value,
+                          }))
+                        }
+                      />
+                    ) : null}
+                  </div>
+                  <span className="label-text-alt mt-1.5 block text-base-content/60">
+                    After expiry the key stops accepting requests and is deleted a few days later.
+                  </span>
+                </div>
+              ) : null}
+
               {treatAsPersonal && !editingKey ? (
                 <div className="rounded-lg border border-base-300/70 bg-base-200/40 px-3 py-2 text-sm text-base-content/80">
                   Monthly spend limit: <span className="font-medium">{viewerMonthlyLimitLabel}</span>{" "}

--- a/web/src/components/keys/api-keys-modal.tsx
+++ b/web/src/components/keys/api-keys-modal.tsx
@@ -5,6 +5,7 @@ import {
   type KeyFormState,
   type KeyFormTab,
   providerNeedsUpstreamKey,
+  tomorrowDateString,
 } from "../../lib/key-form";
 import type { APIKey, Provider } from "../../types";
 import { ProviderLabel, ProviderSelect } from "../ui/page-header";
@@ -299,7 +300,7 @@ export default function ApiKeysModal({
                       <input
                         type="date"
                         className="input input-bordered flex-1"
-                        min={new Date().toISOString().slice(0, 10)}
+                        min={tomorrowDateString()}
                         value={form.expiry_custom}
                         onChange={(event) =>
                           setForm((current) => ({

--- a/web/src/components/keys/keys-table.tsx
+++ b/web/src/components/keys/keys-table.tsx
@@ -23,6 +23,19 @@ function formatCreatedAt(value?: string): string {
   return d.toLocaleString();
 }
 
+function isExpired(expiresAt?: string | null): boolean {
+  if (!expiresAt) return false;
+  const d = new Date(expiresAt);
+  return !Number.isNaN(d.getTime()) && d.getTime() <= Date.now();
+}
+
+function formatExpiresAt(expiresAt?: string | null): string {
+  if (!expiresAt) return "Never";
+  const d = new Date(expiresAt);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString();
+}
+
 interface KeysTableProps {
   keys: APIKey[];
   onShare: (record: APIKey) => void;
@@ -74,8 +87,28 @@ export default function KeysTable({
         id: "status",
         accessorKey: "enabled",
         header: "Status",
-        cell: ({ getValue }) => (
-          <StatusBadge active={getValue<boolean>()} activeLabel="Enabled" inactiveLabel="Disabled" />
+        cell: ({ row }) => {
+          if (!row.original.enabled) {
+            return <StatusBadge active={false} inactiveLabel="Disabled" />;
+          }
+          if (isExpired(row.original.expires_at)) {
+            return <span className="badge badge-sm badge-warning badge-outline">Expired</span>;
+          }
+          return <StatusBadge active activeLabel="Enabled" />;
+        },
+      },
+      {
+        id: "expires_at",
+        accessorKey: "expires_at",
+        header: "Expires",
+        cell: ({ row }) => (
+          <span
+            className={`whitespace-nowrap text-xs ${
+              isExpired(row.original.expires_at) ? "text-warning" : "text-base-content/70"
+            }`}
+          >
+            {formatExpiresAt(row.original.expires_at)}
+          </span>
         ),
       },
       {

--- a/web/src/lib/key-form.ts
+++ b/web/src/lib/key-form.ts
@@ -61,6 +61,15 @@ export const defaultKeyForm: KeyFormState = {
   expiry_custom: "",
 };
 
+// tomorrowDateString returns tomorrow's local calendar date as YYYY-MM-DD,
+// for use as the <input type="date"> min: today would convert to a past
+// expires_at as soon as local midnight passes, and the API rejects it.
+export function tomorrowDateString(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 // expiresAtFromForm converts a preset or custom date into an absolute ISO
 // timestamp for the wire, or null when the key should never expire.
 export function expiresAtFromForm(form: KeyFormState): string | null {

--- a/web/src/lib/key-form.ts
+++ b/web/src/lib/key-form.ts
@@ -17,6 +17,15 @@ export function providerLabel(provider: Provider): string {
 
 export type PiiFormValue = "inherit" | "on" | "off";
 
+export type ExpiryPreset = "never" | "1d" | "7d" | "30d" | "90d" | "custom";
+
+const EXPIRY_PRESET_DAYS: Partial<Record<ExpiryPreset, number>> = {
+  "1d": 1,
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
 export type KeyFormState = {
   provider: Provider;
   actual_key: string;
@@ -30,6 +39,9 @@ export type KeyFormState = {
   rate_limit_rpd: string;
   rate_limit_tpd: string;
   anthropic_tier: string;
+  expiry_preset: ExpiryPreset;
+  // ISO date (YYYY-MM-DD) from a <input type="date">, used when expiry_preset is "custom".
+  expiry_custom: string;
 };
 
 export const defaultKeyForm: KeyFormState = {
@@ -45,7 +57,33 @@ export const defaultKeyForm: KeyFormState = {
   rate_limit_rpd: "",
   rate_limit_tpd: "",
   anthropic_tier: "metered",
+  expiry_preset: "never",
+  expiry_custom: "",
 };
+
+// expiresAtFromForm converts a preset or custom date into an absolute ISO
+// timestamp for the wire, or null when the key should never expire.
+export function expiresAtFromForm(form: KeyFormState): string | null {
+  if (form.expiry_preset === "custom") {
+    if (!form.expiry_custom) return null;
+    const d = new Date(`${form.expiry_custom}T00:00:00`);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  const days = EXPIRY_PRESET_DAYS[form.expiry_preset];
+  if (!days) return null;
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+}
+
+export function expiryFormFromRecord(
+  record: APIKey,
+): Pick<KeyFormState, "expiry_preset" | "expiry_custom"> {
+  if (!record.expires_at) {
+    return { expiry_preset: "never", expiry_custom: "" };
+  }
+  return { expiry_preset: "custom", expiry_custom: record.expires_at.slice(0, 10) };
+}
 
 export function piiToFormValue(value?: PiiRedactSetting): PiiFormValue {
   if (value === true) return "on";
@@ -119,6 +157,7 @@ export function keyFormFromRecord(
     rate_limit_rpd: record.rate_limit_rpd ? String(record.rate_limit_rpd) : "",
     rate_limit_tpd: record.rate_limit_tpd ? String(record.rate_limit_tpd) : "",
     anthropic_tier: record.tags?.tier ?? anthropicDefaultTier,
+    ...expiryFormFromRecord(record),
   };
 }
 

--- a/web/src/pages/keys/index.tsx
+++ b/web/src/pages/keys/index.tsx
@@ -30,6 +30,7 @@ import { formatShareExpiry } from "../../lib/share-expiry";
 import {
   costLimitsFromForm,
   defaultKeyForm,
+  expiresAtFromForm,
   formPiiOffRequiresBedrock,
   formatRateLimits,
   keyFormFromRecord,
@@ -454,6 +455,7 @@ export default function KeysPage() {
               monthly_cost_limit: monthlyCostLimit,
               enabled: form.enabled,
               redact_pii: redactPii,
+              expires_at: expiresAtFromForm(form),
               ...rateLimitsFromForm(form),
             },
           });
@@ -470,6 +472,7 @@ export default function KeysPage() {
         const body: CreateAPIKeyRequest = {
           provider: form.provider,
           description: form.description,
+          expires_at: expiresAtFromForm(form),
         };
         if (useAutoProvision) {
           body.auto_provision = true;
@@ -500,6 +503,7 @@ export default function KeysPage() {
           monthly_cost_limit: monthlyCostLimit,
           enabled: form.enabled,
           redact_pii: redactPii,
+          expires_at: expiresAtFromForm(form),
           ...rateLimitsFromForm(form),
         };
         if (useAutoProvision) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -122,6 +122,7 @@ export interface CreateAPIKeyRequest {
   rate_limit_rpd?: number;
   rate_limit_tpd?: number;
   tags?: Record<string, string>;
+  expires_at?: string | null;
 }
 
 export interface UpdateAPIKeyRequest {
@@ -135,6 +136,7 @@ export interface UpdateAPIKeyRequest {
   rate_limit_rpd?: number;
   rate_limit_tpd?: number;
   tags?: Record<string, string>;
+  expires_at?: string | null;
 }
 
 export interface FeatureToggle {


### PR DESCRIPTION
## Summary

- Admins can set an expiry preset (1/7/30/90 days) or a custom date on any proxy API key (org or personal), from the admin UI or via `expires_at` on the create/update API.
- Enforcement was already in place (`Store.GetKey` rejects expired keys); this fills in every way to *set* `expires_at` and adds cleanup: a background sweeper in the new `internal/keyexpiry` package revokes the upstream provider credential and deletes the DynamoDB record once a key has been expired for longer than a configurable grace period (default 7 days).
- The sweeper elects a single active instance across ECS tasks via a DynamoDB conditional-put lease, so it has no dependency on Redis and runs even when `admin_dashboard.rollups` is disabled.
- `handleDeleteKey`'s revoke-then-delete logic is now shared with the sweeper through `keyexpiry.RetireKey`, so both paths behave identically.
- Config: new `features.api_key_management.expiry` block (`enabled`, `sweep_interval_seconds`, `grace_period_days`, `max_days`), enabled in `configs/production.yml`.
- Admin API: `expires_at` on `CreateKeyRequest`, tri-state `OptionalTime` `expires_at` on `UpdateKeyRequest` (omit = unchanged, `null` = clear, value = set), bounds validation (future date, within `max_days`), and viewers are blocked from editing expiry via PATCH (they can still set it on their own key at creation).
- Web UI: expiry preset/custom date picker in the create/edit key modal, an "Expired" status badge, and an "Expires" column in the keys table.

Pre-existing gap noted but out of scope: `cmd/llm-proxy-keys`'s `-delete` flag still skips upstream revoke.

## Test plan

- [x] `make ci` (fmt-check, vet, lint-pii-logs, validate-config, race-enabled unit tests) — all green
- [x] `gofmt -s -l .` and `gofumpt -l .` — both empty
- [x] `cd web && npm run build` — typechecks and builds cleanly
- [x] New unit tests: `internal/apikeys` (create/update/clear expiry, `ListExpiredKeys`, `TryAcquireSweepLease`), `internal/keyexpiry` (`RetireKey`, `Sweeper.SweepOnce` with fakes), `internal/admin` (create/update validation bounds, viewer permission guard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API key expiration settings with presets or custom dates when creating and editing keys.
  * Added expiration dates and status indicators to the API key list.
  * Expired keys are rejected automatically and cleaned up after a configurable grace period.
  * Provisioned credentials are revoked during key cleanup.

* **Documentation**
  * Added guidance on expiration rules, configuration, validation, and cleanup behavior.

* **Configuration**
  * Enabled production expiry cleanup with a 15-minute sweep interval, 7-day grace period, and 365-day maximum lifetime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->