### PR TITLE
Reject disabled/expired proxy keys on providers with no-op auth checks

### DIFF
--- a/internal/middleware/apikey_validation.go
+++ b/internal/middleware/apikey_validation.go
@@ -81,7 +81,18 @@ func APIKeyValidationMiddleware(providerManager *providers.ProviderManager, keyS
 
 				proxyKeyAttached := false
 				if lookup, ok := keyStore.(proxyKeyLookup); ok && inboundKey != "" {
-					if record, err := lookup.LookupProxyKey(r.Context(), inboundKey); err == nil && record != nil {
+					record, err := lookup.LookupProxyKey(r.Context(), inboundKey)
+					if err != nil {
+						// Only a prefixed proxy key reaches this branch with an error
+						// (disabled, expired, or unknown); providers like Bedrock whose
+						// ValidateAPIKey is a SigV4-passthrough no-op rely on this lookup
+						// as their only gate, so a swallowed error here would let a
+						// revoked key keep working.
+						proxylog.Proxy("proxy key lookup failed for %s: %v", provider.GetName(), err)
+						proxylog.WriteProxyJSONError(w, http.StatusUnauthorized, fmt.Sprintf("Invalid API key: %s", err.Error()))
+						return
+					}
+					if record != nil {
 						r = r.WithContext(apikeys.WithContext(r.Context(), record))
 						proxyKeyAttached = true
 						if err := apikeys.EnforcePIIOffBedrockProvider(globalPIIEnabled, record); err != nil {

--- a/internal/middleware/apikey_validation_test.go
+++ b/internal/middleware/apikey_validation_test.go
@@ -260,6 +260,54 @@ func (m *mockBanCheckingStore) IsBYOCredentialBanned(_ context.Context, provider
 	return m.banned[provider+":"+hash], nil
 }
 
+// mockRejectingProxyKeyStore simulates a disabled/expired proxy key: the
+// prefix is recognized but the lookup fails, the same as apikeys.Store.GetKey
+// returning an error for a disabled or expired record.
+type mockRejectingProxyKeyStore struct {
+	mockAPIKeyStore
+}
+
+func (m *mockRejectingProxyKeyStore) LookupProxyKey(_ context.Context, bearer string) (*apikeys.APIKey, error) {
+	if bearer == apikeys.KeyPrefix+"disabled" {
+		return nil, errors.New("API key is disabled")
+	}
+	return nil, nil
+}
+
+// TestAPIKeyValidationMiddleware_RejectsDisabledProxyKeyWhenValidateAPIKeyIsNoop
+// covers providers like Bedrock whose ValidateAPIKey is a SigV4-passthrough
+// no-op: the LookupProxyKey error is the only gate for a presented proxy key,
+// so it must reject the request instead of silently letting it through.
+func TestAPIKeyValidationMiddleware_RejectsDisabledProxyKeyWhenValidateAPIKeyIsNoop(t *testing.T) {
+	pm := providers.NewProviderManager()
+	pm.RegisterProvider(providers.NewBedrockProxy())
+
+	store := &mockRejectingProxyKeyStore{}
+	mw := APIKeyValidationMiddleware(pm, store, false, true)
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/bedrock/model/foo/converse", nil)
+	req.Header.Set("Authorization", "Bearer "+apikeys.KeyPrefix+"disabled")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for disabled proxy key on a no-op ValidateAPIKey provider, got %d", rec.Code)
+	}
+
+	// Genuine SigV4-signed Bedrock traffic (no Bearer proxy key) must still
+	// pass through untouched.
+	req = httptest.NewRequest("POST", "/bedrock/model/foo/converse", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=example")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for SigV4 passthrough request, got %d", rec.Code)
+	}
+}
+
 func TestAPIKeyValidationMiddleware_SkipsRedact(t *testing.T) {
 	pm := providers.NewProviderManager()
 	pm.RegisterProvider(providers.NewOpenAIProxy())


### PR DESCRIPTION
# :robot: AI Generated Summary :robot:

## Summary

- `BedrockProxy.ValidateAPIKey` is a SigV4-passthrough no-op by design (clients sign Bedrock requests with their own AWS identity), so the only place a presented `sk-iw-*` proxy key is ever checked against the store is the secondary `LookupProxyKey` call in `APIKeyValidationMiddleware`.
- That call's error was silently swallowed (`err == nil && record != nil` guarded attachment only), so a disabled or expired key kept working against Bedrock instead of being rejected the way it already is for OpenAI/Anthropic/Gemini/Bedrock Mantle.
- Found while manually testing [#57](https://github.com/Instawork/llm-proxy/pull/57)'s key-expiry feature end-to-end; confirmed the same fail-open behavior already existed for `enabled: false` keys, so this is a pre-existing gap, not a regression from that PR.
- Fix: when `LookupProxyKey` returns an error for a presented proxy key, respond `401` immediately instead of silently proceeding without a record. Genuine SigV4-signed traffic (no `Bearer` proxy key) is unaffected since `LookupProxyKey` only returns an error for prefixed keys.

## Test plan

- [x] `go test -race ./internal/middleware/... ./internal/providers/...`
- [x] Added `TestAPIKeyValidationMiddleware_RejectsDisabledProxyKeyWhenValidateAPIKeyIsNoop`, covering both the disabled-key rejection and that genuine SigV4 passthrough traffic still passes.
- [x] `make test` (full race-enabled suite)
- [x] `gofmt -s -l .` / `gofumpt -l .` / `go vet ./...` all clean
- [x] `go run ./cmd/config-validator/`
- [x] `make lint-pii-logs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid, disabled, expired, or unknown proxy keys now receive an HTTP 401 Unauthorized response.
  - Requests with invalid proxy keys are blocked before reaching providers with pass-through API-key validation.
  - Valid signed requests continue to be processed normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->